### PR TITLE
atmega1280: Add remaining common patches

### DIFF
--- a/patch/atmega1280.yaml
+++ b/patch/atmega1280.yaml
@@ -1,2 +1,5 @@
 _include:
   - "common/usart.yaml"
+  - "common/twi.yaml"
+  - "common/ac.yaml"
+  - "common/wdt.yaml"


### PR DESCRIPTION
As far as I can tell the pll does not exist for the atmega1280, but the rest seems to apply.