### PR TITLE
Added missing patches for atmega328p

### DIFF
--- a/patch/atmega328p.yaml
+++ b/patch/atmega328p.yaml
@@ -1,3 +1,6 @@
 _include:
-  - "common/wdt.yaml"
   - "common/ac.yaml"
+  - "common/timer/tc0.yaml"
+  - "common/twi.yaml"
+  - "common/usart.yaml"
+  - "common/wdt.yaml"


### PR DESCRIPTION
Added missing patches for atmega328p by copying the commons from atmega32u4, omitting PLL because the 328p lacks that feature