### PR TITLE
Use sh as an interpreter for gen-intr-lut.sh

### DIFF
--- a/gen-intr-lut.sh
+++ b/gen-intr-lut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Generate a lookup table function for interrupts of all supported chips
 set -e
 


### PR DESCRIPTION
No `/bin/bash` features are in use and it is not guaranteed that bash is always installed in `/bin/bash` (i.e. might be `/usr/bin/bash`)