### PR TITLE
Add patches for ADC peripherals

### DIFF
--- a/patch/atmega1280.yaml
+++ b/patch/atmega1280.yaml
@@ -1,5 +1,6 @@
 _include:
   - "common/ac.yaml"
+  - "common/adc.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega328p.yaml
+++ b/patch/atmega328p.yaml
@@ -1,5 +1,6 @@
 _include:
   - "common/ac.yaml"
+  - "common/adc.yaml"
   - "common/spi.yaml"
   - "common/timer/tc0.yaml"
   - "common/twi.yaml"

--- a/patch/atmega32u4.yaml
+++ b/patch/atmega32u4.yaml
@@ -1,5 +1,6 @@
 _include:
   - "common/ac.yaml"
+  - "common/adc.yaml"
   - "common/pll.yaml"
   - "common/spi.yaml"
   - "common/timer/tc0.yaml"

--- a/patch/atmega64.yaml
+++ b/patch/atmega64.yaml
@@ -1,4 +1,5 @@
 _include:
   - "common/ac.yaml"
+  - "common/adc.yaml"
   - "common/spi.yaml"
   - "common/usart.yaml"

--- a/patch/common/adc.yaml
+++ b/patch/common/adc.yaml
@@ -5,3 +5,19 @@ ADC:
   _modify:
     ADCSRA:
       access: read-write
+  ADCSRA:
+    ADPS:
+      _replace_enum:
+        PRESCALER_2: [1, "Prescaler Value 2"]
+        PRESCALER_4: [2, "Prescaler Value 4"]
+        PRESCALER_8: [3, "Prescaler Value 8"]
+        PRESCALER_16: [4, "Prescaler Value 16"]
+        PRESCALER_32: [5, "Prescaler Value 32"]
+        PRESCALER_64: [6, "Prescaler Value 64"]
+        PRESCALER_128: [7, "Prescaler Value 128"]
+  ADMUX:
+    REFS:
+      _replace_enum:
+        AREF: [0, "Aref Internal Vref turned off"]
+        AVCC: [1, "AVcc with external capacitor at AREF pin"]
+        INTERNAL: [3, "Internal 1.1V Voltage Reference with external capacitor at AREF pin"]

--- a/patch/common/adc.yaml
+++ b/patch/common/adc.yaml
@@ -1,0 +1,7 @@
+# Patches for the Analog Digital Converter
+#
+# - Make the control-register actually writable
+ADC:
+  _modify:
+    ADCSRA:
+      access: read-write


### PR DESCRIPTION
Patch needed for ADC implementation
currently only `atmega328p`

[avr-hal/11](https://github.com/Rahix/avr-hal/issues/11)