### PR TITLE
Add an #[entry] macro

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-quote = "0.6.12"
-proc-macro2 = "0.4.30"
+quote = "1.0.7"
+proc-macro2 = "1.0.19"
 
 [dependencies.syn]
-version = "0.15.39"
+version = "1.0.35"
 features = ["extra-traits", "full"]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,16 +10,16 @@ pub fn interrupt(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     // Adapted from https://github.com/rust-embedded/cortex-m-rt/blob/master/macros/src/lib.rs
-    let f: syn::ItemFn = syn::parse(input).expect("`#[interrupt]` must be applied to a function");
+    let f = syn::parse_macro_input!(input as syn::ItemFn);
     let args: Vec<_> = args.into_iter().collect();
 
     let fspan = f.span();
-    let ident = f.ident;
+    let ident = f.sig.ident;
     let ident_s = ident.to_string();
     let attrs = f.attrs;
     let block = f.block;
     let stmts = block.stmts;
-    let unsafety = f.unsafety;
+    let unsafety = f.sig.unsafety;
 
     let chip = if let Some(tree) = args.get(0) {
         if let proc_macro::TokenTree::Ident(ident) = tree {
@@ -41,14 +41,14 @@ pub fn interrupt(
         .into();
     };
 
-    let valid_signature = f.constness.is_none()
+    let valid_signature = f.sig.constness.is_none()
         && f.vis == syn::Visibility::Inherited
-        && f.abi.is_none()
-        && f.decl.inputs.is_empty()
-        && f.decl.generics.params.is_empty()
-        && f.decl.generics.where_clause.is_none()
-        && f.decl.variadic.is_none()
-        && match f.decl.output {
+        && f.sig.abi.is_none()
+        && f.sig.inputs.is_empty()
+        && f.sig.generics.params.is_empty()
+        && f.sig.generics.where_clause.is_none()
+        && f.sig.variadic.is_none()
+        && match f.sig.output {
             syn::ReturnType::Default => true,
             syn::ReturnType::Type(_, ref ty) => match **ty {
                 syn::Type::Tuple(ref tuple) => tuple.elems.is_empty(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,37 @@ use generic::*;
 #[doc = r"Common register and bit access and modify traits"]
 pub mod generic;
 
+/// Attribute to declare an interrupt service routine
+///
+/// ```
+/// #[avr_device::interrupt(atmega32u4)]
+/// fn INT6() {
+///     // ...
+/// }
+/// ```
+///
+/// # Constraints
+/// - The name of the function must be the name of an interrupt.  Each chip's
+///   module has a `Interrupt` enum defining the available names.
+/// - The attribute needs the chip-name to correctly map the interrupt to its
+///   vector.  This is an unfortunate requirement of the current crate
+///   architecture and might change in the future.
+/// - The function must have a signature of `[unsafe] fn() [-> !]`.
 #[cfg(feature = "rt")]
 pub use avr_device_macros::interrupt;
+
+/// Attribute to declare the entry point of the program
+///
+/// Exactly one entry point must be declared in the entire dependency tree.
+///
+/// ```
+/// #[avr_device::entry]
+/// fn main() -> ! {
+///     // ...
+/// }
+/// ```
+///
+/// The entry function must have a signature of `[unsafe] fn() -> !`.
 #[cfg(feature = "rt")]
 pub use avr_device_macros::entry;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub mod generic;
 
 #[cfg(feature = "rt")]
 pub use avr_device_macros::interrupt;
+#[cfg(feature = "rt")]
+pub use avr_device_macros::entry;
 
 #[allow(non_camel_case_types, unused_attributes, unreachable_patterns)]
 mod devices;


### PR DESCRIPTION
This is the last major thing needed for crates.io release.  Add a `#[entry]` macro which hides the actual entry implementation.  This will allow us to later transparently switch away from the avr-libc runtime to something completely custom.

The macro is similar to the one from [`cortex-m-rt`](https://github.com/rust-embedded/cortex-m-rt/blob/98e4c3c8597f1dfa52d55616c7ce7cf90682d95b/macros/src/lib.rs#L18).  However, the [automagic static mut vodoo](https://docs.rs/cortex-m-rt/0.6.12/cortex_m_rt/attr.entry.html) has not yet been added here.

Fixes #15.