### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RUSTUP_TOOLCHAIN ?= nightly
 PATCHES := $(foreach chip, $(CHIPS), $(wildcard patch/$(chip).yaml))
 DEPS := $(foreach patch, $(PATCHES), $(patsubst patch/%.yaml, .deps/%.d, $(patch)))
 
-.PHONY: chips deps $(CHIPS) vector
+.PHONY: chips deps $(CHIPS) vector all clean
 chips: $(CHIPS)
 deps: $(DEPS)
 vector: macros/src/vector.rs

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ clean:
 	@rm -rf svd/
 	@echo -e "\tCLEAN\t\t./src/devices"
 	@rm -rf src/devices/at*
+	@echo -e "\tCLEAN\t\t./src/generic.rs"
+	@rm -f src/generic.rs
 	@echo -e "\tCLEAN\t\t./.deps/"
 	@rm -rf .deps/
 	@echo -e "\tCLEAN\t\t./macros/src/vector.rs"


### PR DESCRIPTION
Adds a check target to run `cargo check --all-features`, which I've found useful to verify I'm not totally breaking things.

Also adds `all` and `clean` to the `.PHONY` list.