### PR TITLE
Add asm module for assembly instructions

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1,0 +1,19 @@
+//! Assembly instructions
+
+/// No Operation
+#[inline(always)]
+pub fn nop() {
+    unsafe { llvm_asm!("nop") }
+}
+
+/// Sleep / Wait For Interrupt
+#[inline(always)]
+pub fn sleep() {
+    unsafe { llvm_asm!("sleep") }
+}
+
+/// Watchdog Reset
+#[inline(always)]
+pub fn wdr() {
+    unsafe { llvm_asm!("wdr") }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(llvm_asm)]
 
 pub mod interrupt;
+pub mod asm;
 
 #[allow(unused_imports)]
 use generic::*;


### PR DESCRIPTION
Add a new module containing wrapper functions for various assembly instructions.  These functions are marked inline(always) to ensure they will always just generate the single instruction as expected.