### PR TITLE
Make interrupt::enable() unsafe

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -26,12 +26,10 @@ pub fn disable() {
 /// # Safety
 ///
 /// - Do not call this function inside an [crate::interrupt::free] critical section
-pub fn enable() {
-    unsafe {
-        llvm_asm!(
-            "sei" :::: "volatile"
-        );
-    }
+pub unsafe fn enable() {
+    llvm_asm!(
+        "sei" :::: "volatile"
+    );
 }
 
 /// Execute closure `f` in an interrupt-free context.
@@ -61,7 +59,7 @@ where
 
     // Restore interrupt state
     if sreg & 0x80 != 0x00 {
-        enable();
+        unsafe { enable(); }
     }
 
     r


### PR DESCRIPTION
To bring this crate more in line with cortex-m, mark interrupt::enable() as unsafe.  This also fixes a soundness issue: When the function is safe, one could call it inside a critical section in entirely safe rust.  This is problematic because lot's of code in critical sections relies on the fact that interrupts are disabled and it thus can safely perform non-atomic operations without anything interrupting it.