### PR TITLE
Fix interrupt::free() reading wrong address

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -44,7 +44,7 @@ where
     // Store current state
     unsafe {
         llvm_asm!(
-            "in $0,0x35"
+            "in $0,0x3F"
             : "=r"(sreg)
             :
             :


### PR DESCRIPTION
This one is embarrasing (and I have absolutely no clue how it slipped in!): The SREG is at IO address 0x3F, not 0x35.  Fix interrupt::free() to read the correct register to make it work as advertised.