### PR TITLE
Error if the wrong architecture is being used

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -58,7 +58,14 @@ pub fn entry(
     let stmts = block.stmts;
     let unsafety = f.sig.unsafety;
 
-    quote::quote!(
+    quote::quote! (
+        #[cfg(not(any(doc, target_arch = "avr")))]
+        compile_error!(
+            "Ensure that you are using an AVR target! You may need to change \
+       directories or pass a --target flag to cargo. See
+       https://github.com/Rahix/avr-device/pull/41 for more details."
+        );
+
         #(#attrs)*
         #[doc(hidden)]
         #[export_name = "main"]


### PR DESCRIPTION
There [have been](https://github.com/Rahix/avr-hal/issues/29) a [couple times](https://github.com/Rahix/avr-hal/issues/39) where an incorrectly set target file has caused errors that don't immediately point to the problem. Instead, we should show an error immediately telling the user that the wrong architecture has been selected.