### PR TITLE
Only emit inline-assembly when building for AVR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ include = [
     "/README.md",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 atmega1280 = []
 atmega168 = []
@@ -32,11 +35,9 @@ rt = ["avr-device-macros"]
 [dependencies]
 bare-metal = "0.2.5"
 vcell = "0.1.2"
+cfg-if = "0.1.10"
 
 [dependencies.avr-device-macros]
 path = "macros/"
 version = "=0.2.0"
 optional = true
-
-[package.metadata.docs.rs]
-all-features = true

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -3,17 +3,35 @@
 /// No Operation
 #[inline(always)]
 pub fn nop() {
-    unsafe { llvm_asm!("nop") }
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe { llvm_asm!("nop") }
+        } else {
+            unimplemented!()
+        }
+    }
 }
 
 /// Sleep / Wait For Interrupt
 #[inline(always)]
 pub fn sleep() {
-    unsafe { llvm_asm!("sleep") }
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe { llvm_asm!("sleep") }
+        } else {
+            unimplemented!()
+        }
+    }
 }
 
 /// Watchdog Reset
 #[inline(always)]
 pub fn wdr() {
-    unsafe { llvm_asm!("wdr") }
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe { llvm_asm!("wdr") }
+        } else {
+            unimplemented!()
+        }
+    }
 }


### PR DESCRIPTION
Make sure that we'll never emit AVR assembly on non-AVR targets.  Instead of failing the build, fail at runtime, to allow a potential application testsuite to run even if those functions somehow get linked in.

Follow up to #41.