### PR TITLE
make: Properly remove 'extern crate' lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ src/devices/%/mod.rs: src/devices/%/mod.full.rs
 	@mv $(@D)/lib.rs $@
 	@RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustfmt $@
 	@# Remove the `extern crate` lines
-	@sed -i'' -e "1,7d" $@
+	@sed -i'' -e "/^extern crate/d" $@
 	@# Remove DEVICE_PERIPHERALS declaration and replace it with a reference
 	@# to the global version
 	@patch --no-backup-if-mismatch --quiet $@ patch/modrs.patch


### PR DESCRIPTION
The previous sed expression would remove arbitrary lines which can break easily.  Instead, only remove actual extern crate lines.

This will provide a seamless upgrade to the next svd2rust version which contains commit 85615cb0bbc8 ("Use and generate code for Edition 2018 only ") and thus no longer emits 'extern crate' lines.