### PR TITLE
Add shared feature for just the common bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ atmega32u4 = []
 atmega64 = []
 attiny85 = []
 attiny88 = []
+shared = []
 rt = ["avr-device-macros"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Via the feature you can select which chip you want the register specifications f
 * `atmega64`
 * `attiny85`
 * `attiny88`
+* `shared` to only include generic shared code (rarely useful)
 
 ## Build Instructions
 The version on `crates.io` is pre-built.  The following is only necessary when trying to build this crate from source.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,5 +98,6 @@ pub use crate::devices::attiny88;
     feature = "atmega64",
     feature = "attiny85",
     feature = "attiny88",
+    feature = "shared",
 )))]
 compile_error!("You need to select at least one chip as a feature!");


### PR DESCRIPTION
I'm writing some code that could be shared across AVR chips, and I'd like to depend on the common parts of this repo.  The downstream users will be pulling it in anyway, but I'll leave it to them to pick a chip.

This feature allows a dependent crate to opt in to not picking a specific device, keeping the current user-friendly behavior of a compile fail when a device isn't chosen.

Happy to discuss more or bikeshed the feature name.