### PR TITLE
Make the PINx registers writeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `#[entry]` causes a (readable) compile-error when attempting to build
   for non-AVR targets.
+- `PINx` registers are now writeable, which enables efficient toggling
+  of bits in the corresponding `PORTx` register.
 
 ### Fixed
 - inline-assembly is now only emitted when building for AVR targets to

--- a/patch/atmega1280.yaml
+++ b/patch/atmega1280.yaml
@@ -1,6 +1,7 @@
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega168.yaml
+++ b/patch/atmega168.yaml
@@ -1,6 +1,7 @@
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega2560.yaml
+++ b/patch/atmega2560.yaml
@@ -1,6 +1,7 @@
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega328p.yaml
+++ b/patch/atmega328p.yaml
@@ -1,6 +1,7 @@
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega32u4.yaml
+++ b/patch/atmega32u4.yaml
@@ -2,6 +2,7 @@ _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
   - "common/pll.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega64.yaml
+++ b/patch/atmega64.yaml
@@ -1,5 +1,6 @@
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega8.yaml
+++ b/patch/atmega8.yaml
@@ -1,0 +1,2 @@
+_include:
+  - "common/port.yaml"

--- a/patch/attiny85.yaml
+++ b/patch/attiny85.yaml
@@ -1,5 +1,6 @@
 _include:
   - "common/ac.yaml"
+  - "common/port.yaml"
   - "common/wdt.yaml"
 
   - "timer/attiny85.yaml"

--- a/patch/attiny88.yaml
+++ b/patch/attiny88.yaml
@@ -1,5 +1,6 @@
 _include:
   - "common/ac.yaml"
+  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/wdt.yaml"

--- a/patch/common/port.yaml
+++ b/patch/common/port.yaml
@@ -1,0 +1,7 @@
+# Patches for I/O Ports
+#
+# - Make the PINx register writable (toggles the corresponding PORTx bit)
+PORT?:
+  _modify:
+    PIN?:
+      access: read-write


### PR DESCRIPTION
> Writing a logic one to PINxn toggles the value of PORTxn, independent on the value of DDRxn. Note that the SBI instruction can be used to toggle one single bit in a port.