### PR TITLE
fix: attiny84 ADCSRA should be read-write

### DIFF
--- a/patch/attiny84.yaml
+++ b/patch/attiny84.yaml
@@ -28,6 +28,9 @@ AC:
         bitWidth: 1
         access: read-write
 ADC:
+  _modify:
+    ADCSRA:
+      access: read-write
   ADCSRA:
     ADPS:
       _replace_enum:


### PR DESCRIPTION
Haven't found any other variants which are affected by this, but it may be worth pulling all of the access-related patches into common or creating a common/tiny/adc patch.