### PR TITLE
fix: atmegaX8 TIFR should be read-write

### DIFF
--- a/patch/timer/dev/16bit.yaml
+++ b/patch/timer/dev/16bit.yaml
@@ -1,3 +1,7 @@
+_modify:
+  TIFR?:
+    access: read-write
+
 TCCR?A:
   _modify:
     COM??:

--- a/patch/timer/dev/8bit-async.yaml
+++ b/patch/timer/dev/8bit-async.yaml
@@ -1,3 +1,7 @@
+_modify:
+  TIFR?:
+    access: read-write
+
 TCCR?A:
   _modify:
     COM?A:

--- a/patch/timer/dev/8bit.yaml
+++ b/patch/timer/dev/8bit.yaml
@@ -1,3 +1,7 @@
+_modify:
+  TIFR?:
+    access: read-write
+
 TCCR?A:
   _modify:
     COM?A:


### PR DESCRIPTION
Update AtmegaX8 Timers TIFR register to Write-Read (used in event driven code for clear overflow and other events without interrupt handler)