### PR TITLE
Fix svd2rust regressions

### DIFF
--- a/patch/atmega64.yaml
+++ b/patch/atmega64.yaml
@@ -6,3 +6,9 @@ _include:
   - "common/port.yaml"
   - "common/spi.yaml"
   - "common/usart.yaml"
+
+USART?:
+  UCSR?C:
+    _modify:
+      UMSEL?:
+        bitRange: "[7:6]"

--- a/patch/common/spi.yaml
+++ b/patch/common/spi.yaml
@@ -13,3 +13,10 @@ SPI*:
         access: read-only
       SPI2X:
         access: read-write
+  SPCR:
+    SPR:
+      _replace_enum:
+        FOSC_4_2: [0, "Fosc/4 if SPI2X == 0 else Fosc/2"]
+        FOSC_16_8: [1, "Fosc/16 if SPI2X == 0 else Fosc/8"]
+        FOSC_64_32: [2, "Fosc/64 if SPI2X == 0 else Fosc/32"]
+        FOSC_128_64: [3, "Fosc/128 if SPI2X == 0 else Fosc/64"]


### PR DESCRIPTION
Latest `svd2rust` built from git seems to be more strict on the validity of enumerated values (they must fit into the field they are for now).  This will break some of the current chip descriptions.

Fix all those cases so we are prepared for when `svd2rust` releases a new version.  A few of the changes will be breaking, which means the next version bump of `avr-device` after merging this PR must be a major one.