### PR TITLE
Split INT field into 2 bits for atmega328 and atmega328pb

### DIFF
--- a/patch/atmega328p.yaml
+++ b/patch/atmega328p.yaml
@@ -15,3 +15,10 @@ CPU:
   _modify:
     PRR:
       access: read-write
+
+EXINT:
+  EIMSK:
+    _modify:
+      INT:
+        description: External Interrupt Request Enable
+    _split: [INT]

--- a/patch/atmega328pb.yaml
+++ b/patch/atmega328pb.yaml
@@ -58,4 +58,18 @@ _include:
 
   - "timer/atmega328pb.yaml"
 
+CPU:
+  _modify:
+    PRR0:
+      access: read-write
+    PRR1:
+      access: read-write
+
+EXINT:
+  EIMSK:
+    _modify:
+      INT:
+        description: External Interrupt Request Enable
+    _split: [INT]
+
 


### PR DESCRIPTION
The INT0 and INT1 fields in the EIMSK register were incorrectly
combined into a 2 bit field, split into individual bits
Allowed write access to PRR0 and PRR1 in atmega328pb