### PR TITLE
Drop unnecessary access mode patches

### DIFF
--- a/patch/atmega1280.yaml
+++ b/patch/atmega1280.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega1280.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega168.yaml
+++ b/patch/atmega168.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega168.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega2560.yaml
+++ b/patch/atmega2560.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega2560.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega328p.yaml
+++ b/patch/atmega328p.yaml
@@ -3,18 +3,12 @@ _svd: ../svd/atmega328p.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"
   - "common/wdt.yaml"
 
   - "timer/atmega328p.yaml"
-
-CPU:
-  _modify:
-    PRR:
-      access: read-write
 
 EXINT:
   EIMSK:

--- a/patch/atmega328pb.yaml
+++ b/patch/atmega328pb.yaml
@@ -32,9 +32,6 @@ TWI1:
 # messes up the patch when using `common/ac.yaml`, so the
 # ac has to be patched here instead.
 AC:
-  _modify:
-    ACSR:
-      access: read-write
   ACSR:
     _modify:
       ACIS:
@@ -50,20 +47,12 @@ AC:
 
 _include:
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/usart.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/wdt.yaml"
 
   - "timer/atmega328pb.yaml"
-
-CPU:
-  _modify:
-    PRR0:
-      access: read-write
-    PRR1:
-      access: read-write
 
 EXINT:
   EIMSK:

--- a/patch/atmega32u4.yaml
+++ b/patch/atmega32u4.yaml
@@ -4,7 +4,6 @@ _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
   - "common/pll.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega48p.yaml
+++ b/patch/atmega48p.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega48p.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega64.yaml
+++ b/patch/atmega64.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega64.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/usart.yaml"
 

--- a/patch/atmega644.yaml
+++ b/patch/atmega644.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega644.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/usart.yaml"

--- a/patch/atmega8.yaml
+++ b/patch/atmega8.yaml
@@ -1,4 +1,1 @@
 _svd: ../svd/atmega8.svd
-
-_include:
-  - "common/port.yaml"

--- a/patch/atmega8u2.yaml
+++ b/patch/atmega8u2.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/atmega8u2.svd
 _include:
   - "common/ac.yaml"
   - "common/eeprom.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/usart.yaml"
   - "common/wdt.yaml"

--- a/patch/attiny84.yaml
+++ b/patch/attiny84.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/attiny84.svd
 _include:
   - "common/ac.yaml"
   - "common/eeprom.yaml"
-  - "common/port.yaml"
   - "common/wdt.yaml"
 
   - "common/tiny/exint.yaml"
@@ -28,9 +27,6 @@ AC:
         bitWidth: 1
         access: read-write
 ADC:
-  _modify:
-    ADCSRA:
-      access: read-write
   ADCSRA:
     ADPS:
       _replace_enum:
@@ -142,9 +138,6 @@ ADC:
       AREF: [1, "External Voltage Reference at AREF pin, Internal Voltage Reference turned off"]
       INTERNAL: [2, "Internal 1.1V Voltage Reference"]
 CPU:
-  _modify:
-    OSCCAL:
-      access: read-write
   CLKPR:
     CLKPS:
       _replace_enum:
@@ -168,8 +161,4 @@ CPU:
         description: "BOD Sleep Enable (available on some devices)"
         bitOffset: 2
         bitWidth: 1
-        access: read-write
-  OSCCAL:
-    _modify:
-      CAL:
         access: read-write

--- a/patch/attiny841.yaml
+++ b/patch/attiny841.yaml
@@ -2,7 +2,6 @@ _svd: ../svd/attiny841.svd
 
 _include:
   - "common/ac.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/usart.yaml"
   - "common/wdt.yaml"
@@ -10,9 +9,6 @@ _include:
   - "timer/attiny841.yaml"
 
 ADC:
-  _modify:
-    ADCSRA:
-      access: read-write
   ADCSRA:
     ADPS:
       _replace_enum:
@@ -39,9 +35,6 @@ ADC:
 # slave, so it doesn't have many of the fields that the common peripheral
 # does, like TWWC, TWAMR, and TWPS
 TWI*:
-  _modify:
-    TWCR:
-      access: read-write
   TWSCRB:
     TWAA:
       _replace_enum:

--- a/patch/attiny85.yaml
+++ b/patch/attiny85.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/attiny85.svd
 _include:
   - "common/ac.yaml"
   - "common/eeprom.yaml"
-  - "common/port.yaml"
   - "common/wdt.yaml"
 
   - "common/tiny/exint.yaml"
@@ -69,13 +68,6 @@ ADC:
         INTERNAL: [2, "Internal Voltage Reference (1.1V when REFS2 is cleared, 2.56V when REFS2 is set) without external bypass"]
         INTERNAL_BYPASS: [3, "Internal 2.56V Voltage Reference with external bypass capacitor at AREF pin (REFS2 must be set)"]
 CPU:
-  _modify:
-    CLKPR:
-      access: read-write
-    MCUSR:
-      access: read-write
-    OSCCAL:
-      access: read-write
   CLKPR:
     CLKPS:
       _replace_enum:
@@ -101,10 +93,6 @@ CPU:
         description: "BOD Sleep Enable (available on some devices)"
         bitOffset: 2
         bitWidth: 1
-        access: read-write
-  OSCCAL:
-    _modify:
-      CAL:
         access: read-write
   PLLCSR:
     _modify:

--- a/patch/attiny861.yaml
+++ b/patch/attiny861.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/attiny861.svd
 _include:
   - "common/ac.yaml"
   - "common/adc.yaml"
-  - "common/port.yaml"
   - "common/tiny/usi.yaml"
   - "common/wdt.yaml"
 

--- a/patch/attiny88.yaml
+++ b/patch/attiny88.yaml
@@ -3,7 +3,6 @@ _svd: ../svd/attiny88.svd
 _include:
   - "common/ac.yaml"
   - "common/eeprom.yaml"
-  - "common/port.yaml"
   - "common/spi.yaml"
   - "common/twi.yaml"
   - "common/wdt.yaml"
@@ -54,15 +53,6 @@ ADC:
         TC1_OVF: [6, "Timer/Counter1 Overflow"]
         TC1_CE: [7, "Timer/Counter1 Capture Event"]
 CPU:
-  _modify:
-    CLKPR:
-      access: read-write
-    OSCCAL:
-      access: read-write
-    PORTCR:
-      access: read-write
-    PRR:
-      access: read-write
   CLKPR:
     CLKPS:
       _replace_enum:
@@ -92,9 +82,3 @@ EXINT:
   _modify:
     PCICR:
       description: "Pin Change Interrupt Control Register"
-PORTA:
-  _modify:
-    PORTA:
-      access: read-write
-    DDRA:
-      access: read-write

--- a/patch/common/ac.yaml
+++ b/patch/common/ac.yaml
@@ -5,9 +5,6 @@
 # - Make just the Output field of ACSR read-only
 # - Fix the "Interrupt Mode Select" enumerated values
 AC:
-  _modify:
-    ACSR,ACSR?A,ACSRA:
-      access: read-write
   ACSR,ACSR?A,ACSRA:
     _modify:
       ACIS,ACIS?:

--- a/patch/common/adc.yaml
+++ b/patch/common/adc.yaml
@@ -2,9 +2,6 @@
 #
 # - Make the control-register actually writable
 ADC:
-  _modify:
-    ADCSRA:
-      access: read-write
   ADCSRA:
     ADPS:
       _replace_enum:

--- a/patch/common/port.yaml
+++ b/patch/common/port.yaml
@@ -1,7 +1,0 @@
-# Patches for I/O Ports
-#
-# - Make the PINx register writable (toggles the corresponding PORTx bit)
-PORT?:
-  _modify:
-    PIN?:
-      access: read-write

--- a/patch/common/spi.yaml
+++ b/patch/common/spi.yaml
@@ -2,17 +2,12 @@
 #
 # Fix the SP2X status register bit to have write access
 SPI*:
-  _modify:
-    SPSR:
-      access: read-write
   SPSR:
     _modify:
       SPIF:
         access: read-only
       WCOL:
         access: read-only
-      SPI2X:
-        access: read-write
   SPCR:
     SPR:
       _replace_enum:

--- a/patch/common/tiny/exint.yaml
+++ b/patch/common/tiny/exint.yaml
@@ -1,7 +1,4 @@
 EXINT:
-  _modify:
-    GIFR:
-      access: read-write
   MCUCR:
     _delete:
       ISC??:

--- a/patch/common/tiny/usi.yaml
+++ b/patch/common/tiny/usi.yaml
@@ -1,7 +1,4 @@
 USI:
-  _modify:
-    USISR:
-      access: read-write
   USICR:
     _modify:
       USICLK:

--- a/patch/common/twi.yaml
+++ b/patch/common/twi.yaml
@@ -5,9 +5,6 @@
 # - Fix the "Slave Address Mask" description
 # - Fix the Prescaler enumerated values
 TWI*:
-  _modify:
-    TWCR:
-      access: read-write
   TWCR:
     _modify:
       TWWC:

--- a/patch/common/usart.yaml
+++ b/patch/common/usart.yaml
@@ -1,7 +1,4 @@
 USART?:
-  _modify:
-    UCSR?A:
-      access: read-write
   UCSR?A:
     _modify:
       UPE?:

--- a/patch/common/wdt.yaml
+++ b/patch/common/wdt.yaml
@@ -3,14 +3,10 @@
 # The control register has a different name between ATmega and
 # ATtiny (WDTCSR vs WDTCR).
 #
-# - Make the control register read-write
 # - Remove the overlapping WDP (Prescaler) field and replace
 #   it with two separate fields.
 # - TODO: See if svd2rust would support some kind of mask?
 WDT:
-  _modify:
-    WDTCSR,WDTCR:
-      access: read-write
   WDTCSR,WDTCR:
     _delete:
       - WDP

--- a/patch/timer/dev/16bit-tiny861-tc0.yaml
+++ b/patch/timer/dev/16bit-tiny861-tc0.yaml
@@ -1,7 +1,3 @@
-_modify:
-  TIFR?:
-    access: read-write
-
 TCCR?B:
   _modify:
     CS?:

--- a/patch/timer/dev/16bit.yaml
+++ b/patch/timer/dev/16bit.yaml
@@ -1,7 +1,3 @@
-_modify:
-  TIFR?:
-    access: read-write
-
 TCCR?A:
   _modify:
     COM??:

--- a/patch/timer/dev/8bit-async.yaml
+++ b/patch/timer/dev/8bit-async.yaml
@@ -1,7 +1,3 @@
-_modify:
-  TIFR?:
-    access: read-write
-
 TCCR?A:
   _modify:
     COM?A:

--- a/patch/timer/dev/8bit-tiny85-tc1.yaml
+++ b/patch/timer/dev/8bit-tiny85-tc1.yaml
@@ -37,8 +37,6 @@ _modify:
     description: "Output Compare Register B"
   OCR1C:
     description: "Output Compare Register C"
-  TCNT?:
-    access: read-write
 
 GTCCR:
   _modify:

--- a/patch/timer/dev/8bit.yaml
+++ b/patch/timer/dev/8bit.yaml
@@ -1,7 +1,3 @@
-_modify:
-  TIFR?:
-    access: read-write
-
 TCCR?A:
   _modify:
     COM?A:


### PR DESCRIPTION
Due to a [change in `atdf2svd`][1], all these access mode patches are no longer required - they are now translated correctly from the vendor source file.

Drop all patches which no longer change the output (the code before and after this changeset is equivalent when using the new atdf2svd).

[1]: https://github.com/Rahix/atdf2svd/commit/a189276b3540b647fab832946edf0acf39730a0e

---

- [x] This PR is blocked on the release of a new `atdf2svd` version.