### PR TITLE
add at90usb1286 chip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 
 [features]
 device-selected = []
+at90usb1286 = ["device-selected"]
 atmega1280 = ["device-selected"]
 atmega168 = ["device-selected"]
 atmega2560 = ["device-selected"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: deps chips
 
-CHIPS := atmega1280 atmega168 atmega2560 atmega8 atmega8u2 atmega328p atmega328pb atmega32u4 atmega4809 atmega48p atmega64 atmega644 attiny84 attiny85 attiny88 attiny841 attiny861
+CHIPS := at90usb1286 atmega1280 atmega168 atmega2560 atmega8 atmega8u2 atmega328p atmega328pb atmega32u4 atmega4809 atmega48p atmega64 atmega644 attiny84 attiny85 attiny88 attiny841 attiny861
 
 RUSTUP_TOOLCHAIN ?= nightly
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ features = ["atmega32u4"]
 ```
 
 Via the feature you can select which chip you want the register specifications for.  The following list is what is currently supported:
+* `at90usb1286`
 * `atmega1280`
 * `atmega168`
 * `atmega2560`

--- a/patch/at90usb1286.yaml
+++ b/patch/at90usb1286.yaml
@@ -1,0 +1,8 @@
+_svd: ../svd/at90usb1286.svd
+
+_include:
+  - "common/ac.yaml"
+  - "common/adc.yaml"
+  - "common/spi.yaml"
+  - "common/usart.yaml"
+  - "common/twi.yaml"

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -3,6 +3,25 @@
 #[no_mangle]
 pub(crate) static mut DEVICE_PERIPHERALS: bool = false;
 
+/// [AT90USB1286](https://www.microchip.com/wwwproducts/en/AT90USB1286)
+#[cfg(feature = "at90usb1286")]
+pub mod at90usb1286;
+
+#[cfg(feature = "at90usb1286")]
+impl at90usb1286::Peripherals {
+    /// Returns all the peripherals *once*
+    #[inline]
+    pub fn take() -> Option<Self> {
+        crate::interrupt::free(|_| {
+            if unsafe { DEVICE_PERIPHERALS } {
+                None
+            } else {
+                Some(unsafe { at90usb1286::Peripherals::steal() })
+            }
+        })
+    }
+}
+
 /// [ATmega1280](https://www.microchip.com/wwwproducts/en/ATmega1280)
 #[cfg(feature = "atmega1280")]
 pub mod atmega1280;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! This crate contains register definitions for
+#![cfg_attr(feature = "at90usb1286", doc = "**at90usb1286**,")]
 #![cfg_attr(feature = "atmega1280", doc = "**atmega1280**,")]
 #![cfg_attr(feature = "atmega168", doc = "**atmega168**,")]
 #![cfg_attr(feature = "atmega2560", doc = "**atmega2560**,")]
@@ -20,6 +21,7 @@
 //!
 //! Which chips the crate is built for depends on the feature flag used.
 //! The following chips are available (using feature flags of the same name):
+//! * `at90usb1286`
 //! * `atmega1280`
 //! * `atmega168`
 //! * `atmega2560`
@@ -111,6 +113,8 @@ compile_error!(
 #[allow(non_camel_case_types, unused_attributes, unreachable_patterns)]
 mod devices;
 
+#[cfg(feature = "at90usb1286")]
+pub use crate::devices::at90usb1286;
 #[cfg(feature = "atmega1280")]
 pub use crate::devices::atmega1280;
 #[cfg(feature = "atmega168")]

--- a/vendor/at90usb1286.atdf
+++ b/vendor/at90usb1286.atdf
@@ -1,0 +1,1229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<avr-tools-device-file xmlns:xalan="http://xml.apache.org/xalan" xmlns:NumHelper="NumHelper" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schema-version="0.3" xsi:noNamespaceSchemaLocation="../../schema/avr_tools_device_file.xsd">
+  <variants>
+    <variant tempmin="0" tempmax="0" speedmax="0" package="" ordercode="standard" vccmin="2.2" vccmax="5.5"/>
+  </variants>
+  <devices>
+    <device name="AT90USB1286" architecture="AVR8" family="megaAVR">
+      <address-spaces>
+        <address-space endianness="little" name="prog" id="prog" start="0x0000" size="0x20000">
+          <memory-segment start="0x0000" size="0x20000" type="flash" rw="RW" exec="1" name="FLASH" pagesize="0x100"/>
+          <memory-segment start="0x1fc00" size="0x0400" type="flash" rw="RW" exec="1" name="BOOT_SECTION_1" pagesize="0x100"/>
+          <memory-segment start="0x1f800" size="0x0800" type="flash" rw="RW" exec="1" name="BOOT_SECTION_2" pagesize="0x100"/>
+          <memory-segment start="0x1f000" size="0x1000" type="flash" rw="RW" exec="1" name="BOOT_SECTION_3" pagesize="0x100"/>
+          <memory-segment start="0x1e000" size="0x2000" type="flash" rw="RW" exec="1" name="BOOT_SECTION_4" pagesize="0x100"/>
+        </address-space>
+        <address-space endianness="little" name="signatures" id="signatures" start="0" size="3">
+          <memory-segment start="0" size="3" type="signatures" rw="R" exec="0" name="SIGNATURES"/>
+        </address-space>
+        <address-space endianness="little" name="fuses" id="fuses" start="0" size="0x0003">
+          <memory-segment start="0" size="0x0003" type="fuses" rw="RW" exec="0" name="FUSES"/>
+        </address-space>
+        <address-space endianness="little" name="lockbits" id="lockbits" start="0" size="0x0001">
+          <memory-segment start="0" size="0x0001" type="lockbits" rw="RW" exec="0" name="LOCKBITS"/>
+        </address-space>
+        <address-space endianness="little" name="data" id="data" start="0x0000" size="0x10000">
+          <memory-segment external="false" type="regs" size="0x0020" start="0x0000" name="REGISTERS"/>
+          <memory-segment name="MAPPED_IO" start="0x0020" size="0x00e0" type="io" external="false"/>
+          <memory-segment name="IRAM" start="0x0100" size="0x2000" type="ram" external="false"/>
+          <memory-segment name="XRAM" start="0x2200" size="0xde00" type="ram" external="true"/>
+        </address-space>
+        <address-space endianness="little" name="eeprom" id="eeprom" start="0x0000" size="0x1000">
+          <memory-segment start="0x0000" size="0x1000" type="eeprom" rw="RW" exec="0" name="EEPROM" pagesize="0x08"/>
+        </address-space>
+        <address-space size="0x40" start="0x00" endianness="little" name="io" id="io"/>
+        <address-space endianness="little" name="osccal" id="osccal" start="0" size="1">
+          <memory-segment start="0" size="1" type="osccal" rw="R" exec="0" name="OSCCAL"/>
+        </address-space>
+      </address-spaces>
+      <peripherals>
+        <module name="WDT">
+          <instance name="WDT" caption="Watchdog Timer">
+            <register-group name="WDT" name-in-module="WDT" offset="0x00" address-space="data" caption="Watchdog Timer"/>
+          </instance>
+        </module>
+        <module name="PORT">
+          <instance name="PORTA" caption="I/O Port">
+            <register-group name="PORTA" name-in-module="PORTA" offset="0x00" address-space="data" caption="I/O Port"/>
+          </instance>
+          <instance name="PORTB" caption="I/O Port">
+            <register-group name="PORTB" name-in-module="PORTB" offset="0x00" address-space="data" caption="I/O Port"/>
+          </instance>
+          <instance name="PORTC" caption="I/O Port">
+            <register-group name="PORTC" name-in-module="PORTC" offset="0x00" address-space="data" caption="I/O Port"/>
+          </instance>
+          <instance name="PORTD" caption="I/O Port">
+            <register-group name="PORTD" name-in-module="PORTD" offset="0x00" address-space="data" caption="I/O Port"/>
+          </instance>
+          <instance name="PORTE" caption="I/O Port">
+            <register-group name="PORTE" name-in-module="PORTE" offset="0x00" address-space="data" caption="I/O Port"/>
+          </instance>
+          <instance name="PORTF" caption="I/O Port">
+            <register-group name="PORTF" name-in-module="PORTF" offset="0x00" address-space="data" caption="I/O Port"/>
+          </instance>
+        </module>
+        <module name="CPU">
+          <instance name="CPU" caption="CPU Registers">
+            <register-group name="CPU" name-in-module="CPU" offset="0x00" address-space="data" caption="CPU Registers"/>
+            <parameters>
+              <param name="CORE_VERSION" value="V3"/>
+            </parameters>
+          </instance>
+        </module>
+        <module name="TWI">
+          <instance name="TWI" caption="Two Wire Serial Interface">
+            <register-group name="TWI" name-in-module="TWI" offset="0x00" address-space="data" caption="Two Wire Serial Interface"/>
+          </instance>
+        </module>
+        <module name="SPI">
+          <instance name="SPI" caption="Serial Peripheral Interface">
+            <register-group name="SPI" name-in-module="SPI" offset="0x00" address-space="data" caption="Serial Peripheral Interface"/>
+          </instance>
+        </module>
+        <module name="USART">
+          <instance name="USART1" caption="USART">
+            <register-group name="USART1" name-in-module="USART1" offset="0x00" address-space="data" caption="USART"/>
+          </instance>
+        </module>
+        <module name="USB_DEVICE">
+          <instance name="USB_DEVICE" caption="USB Device Registers">
+            <register-group name="USB_DEVICE" name-in-module="USB_DEVICE" offset="0x00" address-space="data" caption="USB Device Registers"/>
+          </instance>
+        </module>
+        <module name="BOOT_LOAD">
+          <instance name="BOOT_LOAD" caption="Bootloader">
+            <register-group name="BOOT_LOAD" name-in-module="BOOT_LOAD" offset="0x00" address-space="data" caption="Bootloader"/>
+          </instance>
+        </module>
+        <module name="EEPROM">
+          <instance name="EEPROM" caption="EEPROM">
+            <register-group name="EEPROM" name-in-module="EEPROM" offset="0x00" address-space="data" caption="EEPROM"/>
+          </instance>
+        </module>
+        <module name="TC8">
+          <instance name="TC0" caption="Timer/Counter, 8-bit">
+            <register-group name="TC0" name-in-module="TC0" offset="0x00" address-space="data" caption="Timer/Counter, 8-bit"/>
+          </instance>
+        </module>
+        <module name="TC8_ASYNC">
+          <instance name="TC2" caption="Timer/Counter, 8-bit Async">
+            <register-group name="TC2" name-in-module="TC2" offset="0x00" address-space="data" caption="Timer/Counter, 8-bit Async"/>
+          </instance>
+        </module>
+        <module name="TC16">
+          <instance name="TC3" caption="Timer/Counter, 16-bit">
+            <register-group name="TC3" name-in-module="TC3" offset="0x00" address-space="data" caption="Timer/Counter, 16-bit"/>
+          </instance>
+          <instance name="TC1" caption="Timer/Counter, 16-bit">
+            <register-group name="TC1" name-in-module="TC1" offset="0x00" address-space="data" caption="Timer/Counter, 16-bit"/>
+          </instance>
+        </module>
+        <module name="JTAG">
+          <instance name="JTAG" caption="JTAG Interface">
+            <register-group name="JTAG" name-in-module="JTAG" offset="0x00" address-space="data" caption="JTAG Interface"/>
+          </instance>
+        </module>
+        <module name="EXINT">
+          <instance name="EXINT" caption="External Interrupts">
+            <register-group name="EXINT" name-in-module="EXINT" offset="0x00" address-space="data" caption="External Interrupts"/>
+          </instance>
+        </module>
+        <module name="ADC">
+          <instance name="ADC" caption="Analog-to-Digital Converter">
+            <register-group name="ADC" name-in-module="ADC" offset="0x00" address-space="data" caption="Analog-to-Digital Converter"/>
+          </instance>
+        </module>
+        <module name="AC">
+          <instance name="AC" caption="Analog Comparator">
+            <register-group name="AC" name-in-module="AC" offset="0x00" address-space="data" caption="Analog Comparator"/>
+          </instance>
+        </module>
+        <module name="PLL">
+          <instance name="PLL" caption="Phase Locked Loop">
+            <register-group name="PLL" name-in-module="PLL" offset="0x00" address-space="data" caption="Phase Locked Loop"/>
+          </instance>
+        </module>
+        <module name="USB_GLOBAL">
+          <instance name="USB_GLOBAL" caption="USB Controller">
+            <register-group name="USB_GLOBAL" name-in-module="USB_GLOBAL" offset="0x00" address-space="data" caption="USB Controller"/>
+          </instance>
+        </module>
+        <module name="FUSE">
+          <instance name="FUSE" caption="Fuses">
+            <register-group name="FUSE" name-in-module="FUSE" offset="0" address-space="fuses" caption="Fuses"/>
+          </instance>
+        </module>
+        <module name="LOCKBIT">
+          <instance name="LOCKBIT" caption="Lockbits">
+            <register-group name="LOCKBIT" name-in-module="LOCKBIT" offset="0" address-space="lockbits" caption="Lockbits"/>
+          </instance>
+        </module>
+      </peripherals>
+      <interrupts>
+        <interrupt index="0" name="RESET" caption="External Pin,Power-on Reset,Brown-out Reset,Watchdog Reset,and JTAG AVR Reset. See Datasheet.     "/>
+        <interrupt index="1" name="INT0" caption="External Interrupt Request 0"/>
+        <interrupt index="2" name="INT1" caption="External Interrupt Request 1"/>
+        <interrupt index="3" name="INT2" caption="External Interrupt Request 2"/>
+        <interrupt index="4" name="INT3" caption="External Interrupt Request 3"/>
+        <interrupt index="5" name="INT4" caption="External Interrupt Request 4"/>
+        <interrupt index="6" name="INT5" caption="External Interrupt Request 5"/>
+        <interrupt index="7" name="INT6" caption="External Interrupt Request 6"/>
+        <interrupt index="8" name="INT7" caption="External Interrupt Request 7"/>
+        <interrupt index="9" name="PCINT0" caption="Pin Change Interrupt Request 0"/>
+        <interrupt index="10" name="USB_GEN" caption="USB General Interrupt Request"/>
+        <interrupt index="11" name="USB_COM" caption="USB Endpoint/Pipe Interrupt Communication Request"/>
+        <interrupt index="12" name="WDT" caption="Watchdog Time-out Interrupt"/>
+        <interrupt index="13" name="TIMER2_COMPA" caption="Timer/Counter2 Compare Match A"/>
+        <interrupt index="14" name="TIMER2_COMPB" caption="Timer/Counter2 Compare Match B"/>
+        <interrupt index="15" name="TIMER2_OVF" caption="Timer/Counter2 Overflow"/>
+        <interrupt index="16" name="TIMER1_CAPT" caption="Timer/Counter1 Capture Event"/>
+        <interrupt index="17" name="TIMER1_COMPA" caption="Timer/Counter1 Compare Match A"/>
+        <interrupt index="18" name="TIMER1_COMPB" caption="Timer/Counter1 Compare Match B"/>
+        <interrupt index="19" name="TIMER1_COMPC" caption="Timer/Counter1 Compare Match C"/>
+        <interrupt index="20" name="TIMER1_OVF" caption="Timer/Counter1 Overflow"/>
+        <interrupt index="21" name="TIMER0_COMPA" caption="Timer/Counter0 Compare Match A"/>
+        <interrupt index="22" name="TIMER0_COMPB" caption="Timer/Counter0 Compare Match B"/>
+        <interrupt index="23" name="TIMER0_OVF" caption="Timer/Counter0 Overflow"/>
+        <interrupt index="24" name="SPI_STC" caption="SPI Serial Transfer Complete"/>
+        <interrupt index="25" name="USART1_RX" caption="USART1, Rx Complete"/>
+        <interrupt index="26" name="USART1_UDRE" caption="USART1 Data register Empty"/>
+        <interrupt index="27" name="USART1_TX" caption="USART1, Tx Complete"/>
+        <interrupt index="28" name="ANALOG_COMP" caption="Analog Comparator"/>
+        <interrupt index="29" name="ADC" caption="ADC Conversion Complete"/>
+        <interrupt index="30" name="EE_READY" caption="EEPROM Ready"/>
+        <interrupt index="31" name="TIMER3_CAPT" caption="Timer/Counter3 Capture Event"/>
+        <interrupt index="32" name="TIMER3_COMPA" caption="Timer/Counter3 Compare Match A"/>
+        <interrupt index="33" name="TIMER3_COMPB" caption="Timer/Counter3 Compare Match B"/>
+        <interrupt index="34" name="TIMER3_COMPC" caption="Timer/Counter3 Compare Match C"/>
+        <interrupt index="35" name="TIMER3_OVF" caption="Timer/Counter3 Overflow"/>
+        <interrupt index="36" name="TWI" caption="2-wire Serial Interface        "/>
+        <interrupt index="37" name="SPM_READY" caption="Store Program Memory Read"/>
+      </interrupts>
+      <interfaces>
+        <interface name="ISP" type="isp"/>
+        <interface name="HVPP" type="hvpp"/>
+        <interface name="JTAG" type="megajtag"/>
+      </interfaces>
+      <property-groups>
+        <property-group name="SIGNATURES">
+          <property name="JTAGID" value="0x0978203F"/>
+          <property name="SIGNATURE0" value="0x1e"/>
+          <property name="SIGNATURE1" value="0x97"/>
+          <property name="SIGNATURE2" value="0x82"/>
+        </property-group>
+        <property-group name="OCD">
+          <property name="OCD_REVISION" value="3"/>
+          <property name="OCD_DATAREG" value="0x31"/>
+          <property name="PROGBASE" value="0x0000"/>
+        </property-group>
+        <property-group name="JTAG_INTERFACE">
+          <property name="ALLOWFULLPAGESTREAM" value="0x00"/>
+        </property-group>
+        <property-group name="ISP_INTERFACE">
+          <property name="IspEnterProgMode_timeout" value="200"/>
+          <property name="IspEnterProgMode_stabDelay" value="100"/>
+          <property name="IspEnterProgMode_cmdexeDelay" value="25"/>
+          <property name="IspEnterProgMode_synchLoops" value="32"/>
+          <property name="IspEnterProgMode_byteDelay" value="0"/>
+          <property name="IspEnterProgMode_pollIndex" value="3"/>
+          <property name="IspEnterProgMode_pollValue" value="0x53"/>
+          <property name="IspLeaveProgMode_preDelay" value="1"/>
+          <property name="IspLeaveProgMode_postDelay" value="1"/>
+          <property name="IspChipErase_eraseDelay" value="55"/>
+          <property name="IspChipErase_pollMethod" value="1"/>
+          <property name="IspProgramFlash_mode" value="0x41"/>
+          <property name="IspProgramFlash_blockSize" value="256"/>
+          <property name="IspProgramFlash_delay" value="6"/>
+          <property name="IspProgramFlash_cmd1" value="0x40"/>
+          <property name="IspProgramFlash_cmd2" value="0x4C"/>
+          <property name="IspProgramFlash_cmd3" value="0x00"/>
+          <property name="IspProgramFlash_pollVal1" value="0x00"/>
+          <property name="IspProgramFlash_pollVal2" value="0x00"/>
+          <property name="IspProgramEeprom_mode" value="0x41"/>
+          <property name="IspProgramEeprom_blockSize" value="8"/>
+          <property name="IspProgramEeprom_delay" value="10"/>
+          <property name="IspProgramEeprom_cmd1" value="0xC1"/>
+          <property name="IspProgramEeprom_cmd2" value="0xC2"/>
+          <property name="IspProgramEeprom_cmd3" value="0x00"/>
+          <property name="IspProgramEeprom_pollVal1" value="0x00"/>
+          <property name="IspProgramEeprom_pollVal2" value="0x00"/>
+          <property name="IspReadFlash_blockSize" value="256"/>
+          <property name="IspReadEeprom_blockSize" value="256"/>
+          <property name="IspReadFuse_pollIndex" value="4"/>
+          <property name="IspReadLock_pollIndex" value="4"/>
+          <property name="IspReadSign_pollIndex" value="4"/>
+          <property name="IspReadOsccal_pollIndex" value="4"/>
+        </property-group>
+        <property-group name="PP_INTERFACE">
+          <property name="PpControlStack" value="0x0E 0x1E 0x0F 0x1F 0x2E 0x3E 0x2F 0x3F 0x4E 0x5E 0x4F 0x5F 0x6E 0x7E 0x6F 0x7F 0x66 0x76 0x67 0x77 0x6A 0x7A 0x6B 0x7B 0xBE 0xFD 0x00 0x01 0x00 0x00 0x00 0x00"/>
+          <property name="PpEnterProgMode_stabDelay" value="100"/>
+          <property name="PpEnterProgMode_progModeDelay" value="0"/>
+          <property name="PpEnterProgMode_latchCycles" value="5"/>
+          <property name="PpEnterProgMode_toggleVtg" value="1"/>
+          <property name="PpEnterProgMode_powerOffDelay" value="15"/>
+          <property name="PpEnterProgMode_resetDelayMs" value="1"/>
+          <property name="PpEnterProgMode_resetDelayUs" value="0"/>
+          <property name="PpLeaveProgMode_stabDelay" value="15"/>
+          <property name="PpLeaveProgMode_resetDelay" value="15"/>
+          <property name="PpChipErase_pulseWidth" value="0"/>
+          <property name="PpChipErase_pollTimeout" value="10"/>
+          <property name="PpProgramFlash_pollTimeout" value="5"/>
+          <property name="PpProgramFlash_mode" value="0x01"/>
+          <property name="PpProgramFlash_blockSize" value="256"/>
+          <property name="PpReadFlash_blockSize" value="256"/>
+          <property name="PpProgramEeprom_pollTimeout" value="5"/>
+          <property name="PpProgramEeprom_mode" value="0x07"/>
+          <property name="PpProgramEeprom_blockSize" value="256"/>
+          <property name="PpReadEeprom_blockSize" value="256"/>
+          <property name="PpProgramFuse_pulseWidth" value="0"/>
+          <property name="PpProgramFuse_pollTimeout" value="5"/>
+          <property name="PpProgramLock_pulseWidth" value="0"/>
+          <property name="PpProgramLock_pollTimeout" value="5"/>
+        </property-group>
+        <property-group name="ISP_INTERFACE_STK600">
+          <property name="IspEnterProgMode_timeout" value="200"/>
+          <property name="IspEnterProgMode_stabDelay" value="100"/>
+          <property name="IspEnterProgMode_cmdexeDelay" value="25"/>
+          <property name="IspEnterProgMode_synchLoops" value="32"/>
+          <property name="IspEnterProgMode_byteDelay" value="0"/>
+          <property name="IspEnterProgMode_pollIndex" value="3"/>
+          <property name="IspEnterProgMode_pollValue" value="0x53"/>
+          <property name="IspLeaveProgMode_preDelay" value="1"/>
+          <property name="IspLeaveProgMode_postDelay" value="1"/>
+          <property name="IspChipErase_eraseDelay" value="55"/>
+          <property name="IspChipErase_pollMethod" value="1"/>
+          <property name="IspProgramFlash_mode" value="0x41"/>
+          <property name="IspProgramFlash_blockSize" value="256"/>
+          <property name="IspProgramFlash_delay" value="6"/>
+          <property name="IspProgramFlash_cmd1" value="0x40"/>
+          <property name="IspProgramFlash_cmd2" value="0x4C"/>
+          <property name="IspProgramFlash_cmd3" value="0x00"/>
+          <property name="IspProgramFlash_pollVal1" value="0x00"/>
+          <property name="IspProgramFlash_pollVal2" value="0x00"/>
+          <property name="IspProgramEeprom_mode" value="0x41"/>
+          <property name="IspProgramEeprom_blockSize" value="4"/>
+          <property name="IspProgramEeprom_delay" value="20"/>
+          <property name="IspProgramEeprom_cmd1" value="0xC1"/>
+          <property name="IspProgramEeprom_cmd2" value="0xC2"/>
+          <property name="IspProgramEeprom_cmd3" value="0x00"/>
+          <property name="IspProgramEeprom_pollVal1" value="0x00"/>
+          <property name="IspProgramEeprom_pollVal2" value="0x00"/>
+          <property name="IspReadFlash_blockSize" value="256"/>
+          <property name="IspReadEeprom_blockSize" value="256"/>
+          <property name="IspReadFuse_pollIndex" value="4"/>
+          <property name="IspReadLock_pollIndex" value="4"/>
+          <property name="IspReadSign_pollIndex" value="4"/>
+          <property name="IspReadOsccal_pollIndex" value="4"/>
+        </property-group>
+        <property-group name="PP_INTERFACE_STK600">
+          <property name="PpControlStack" value="0x0E 0x1E 0x0F 0x1F 0x2E 0x3E 0x2F 0x3F 0x4E 0x5E 0x4F 0x5F 0x6E 0x7E 0x6F 0x7F 0x66 0x76 0x67 0x77 0x6A 0x7A 0x6B 0x7B 0xBE 0xFD 0x00 0x01 0x00 0x00 0x00 0x00"/>
+          <property name="PpEnterProgMode_stabDelay" value="100"/>
+          <property name="PpEnterProgMode_progModeDelay" value="0"/>
+          <property name="PpEnterProgMode_latchCycles" value="6"/>
+          <property name="PpEnterProgMode_toggleVtg" value="0"/>
+          <property name="PpEnterProgMode_powerOffDelay" value="0"/>
+          <property name="PpEnterProgMode_resetDelayMs" value="0"/>
+          <property name="PpEnterProgMode_resetDelayUs" value="0"/>
+          <property name="PpLeaveProgMode_stabDelay" value="15"/>
+          <property name="PpLeaveProgMode_resetDelay" value="15"/>
+          <property name="PpChipErase_pulseWidth" value="0"/>
+          <property name="PpChipErase_pollTimeout" value="10"/>
+          <property name="PpProgramFlash_pollTimeout" value="5"/>
+          <property name="PpProgramFlash_mode" value="0x01"/>
+          <property name="PpProgramFlash_blockSize" value="256"/>
+          <property name="PpReadFlash_blockSize" value="256"/>
+          <property name="PpProgramEeprom_pollTimeout" value="5"/>
+          <property name="PpProgramEeprom_mode" value="0x07"/>
+          <property name="PpProgramEeprom_blockSize" value="256"/>
+          <property name="PpReadEeprom_blockSize" value="256"/>
+          <property name="PpProgramFuse_pulseWidth" value="0"/>
+          <property name="PpProgramFuse_pollTimeout" value="5"/>
+          <property name="PpProgramLock_pulseWidth" value="0"/>
+          <property name="PpProgramLock_pollTimeout" value="5"/>
+        </property-group>
+      </property-groups>
+    </device>
+  </devices>
+  <modules>
+    <module caption="Fuses" name="FUSE">
+      <register-group caption="Fuses" name="FUSE">
+        <register caption="" name="EXTENDED" offset="0x02" size="1" initval="0xF3">
+          <bitfield caption="Brown-out Detector trigger level" mask="0x07" name="BODLEVEL" values="ENUM_BODLEVEL"/>
+          <bitfield caption="Hardware Boot Enable" mask="0x08" name="HWBE"/>
+        </register>
+        <register caption="" name="HIGH" offset="0x01" size="1" initval="0x99">
+          <bitfield caption="On-Chip Debug Enabled" mask="0x80" name="OCDEN"/>
+          <bitfield caption="JTAG Interface Enabled" mask="0x40" name="JTAGEN"/>
+          <bitfield caption="Serial program downloading (SPI) enabled" mask="0x20" name="SPIEN"/>
+          <bitfield caption="Watchdog timer always on" mask="0x10" name="WDTON"/>
+          <bitfield caption="Preserve EEPROM through the Chip Erase cycle" mask="0x08" name="EESAVE"/>
+          <bitfield caption="Select Boot Size" mask="0x06" name="BOOTSZ" values="ENUM_BOOTSZ"/>
+          <bitfield caption="Boot Reset vector Enabled" mask="0x01" name="BOOTRST"/>
+        </register>
+        <register caption="" name="LOW" offset="0x00" size="1" initval="0x5E">
+          <bitfield caption="Divide clock by 8 internally" mask="0x80" name="CKDIV8"/>
+          <bitfield caption="Clock output on PORTC7" mask="0x40" name="CKOUT"/>
+          <bitfield caption="Select Clock Source" mask="0x3F" name="SUT_CKSEL" values="ENUM_SUT_CKSEL"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="ENUM_SUT_CKSEL">
+        <value caption="Ext. Clock; Start-up time: 6 CK + 0 ms" name="EXTCLK_6CK_0MS" value="0x00"/>
+        <value caption="Ext. Clock; Start-up time: 6 CK + 4.1 ms" name="EXTCLK_6CK_4MS1" value="0x10"/>
+        <value caption="Ext. Clock; Start-up time: 6 CK + 65 ms" name="EXTCLK_6CK_65MS" value="0x20"/>
+        <value caption="Int. RC Osc.; Start-up time: 6 CK + 0 ms" name="INTRCOSC_6CK_0MS" value="0x02"/>
+        <value caption="Int. RC Osc.; Start-up time: 6 CK + 4.1 ms" name="INTRCOSC_6CK_4MS1" value="0x12"/>
+        <value caption="Int. RC Osc.; Start-up time: 6 CK + 65 ms" name="INTRCOSC_6CK_65MS" value="0x22"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 32K CK + 0 ms; Int. Cap." name="EXTLOFXTAL_32KCK_0MS_INTCAP" value="0x07"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 32K CK + 4.1 ms; Int. Cap." name="EXTLOFXTAL_32KCK_4MS1_INTCAP" value="0x17"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 32K CK + 65 ms; Int. Cap." name="EXTLOFXTAL_32KCK_65MS_INTCAP" value="0x27"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 1K CK + 0 ms; Int. Cap." name="EXTLOFXTAL_1KCK_0MS_INTCAP" value="0x06"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 1K CK + 4.1 ms; Int. Cap." name="EXTLOFXTAL_1KCK_4MS1_INTCAP" value="0x16"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 1K CK + 65 ms; Int. Cap." name="EXTLOFXTAL_1KCK_65MS_INTCAP" value="0x26"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 32K CK + 0 ms" name="EXTLOFXTAL_32KCK_0MS" value="0x05"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 32K CK + 4.1 ms" name="EXTLOFXTAL_32KCK_4MS1" value="0x15"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 32K CK + 65 ms" name="EXTLOFXTAL_32KCK_65MS" value="0x25"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 1K CK + 0 ms" name="EXTLOFXTAL_1KCK_0MS" value="0x04"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 1K CK + 4.1 ms" name="EXTLOFXTAL_1KCK_4MS1" value="0x14"/>
+        <value caption="Ext. Low-Freq. Crystal; Start-up time: 1K CK + 65 ms" name="EXTLOFXTAL_1KCK_65MS" value="0x24"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 258 CK + 4.1 ms" name="EXTXOSC_0MHZ4_0MHZ9_258CK_4MS1" value="0x08"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 258 CK + 65 ms" name="EXTXOSC_0MHZ4_0MHZ9_258CK_65MS" value="0x18"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 1K CK + 0 ms" name="EXTXOSC_0MHZ4_0MHZ9_1KCK_0MS" value="0x28"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 1K CK + 4.1 ms" name="EXTXOSC_0MHZ4_0MHZ9_1KCK_4MS1" value="0x38"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 1K CK + 65 ms" name="EXTXOSC_0MHZ4_0MHZ9_1KCK_65MS" value="0x09"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 16K CK + 0 ms" name="EXTXOSC_0MHZ4_0MHZ9_16KCK_0MS" value="0x19"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 16K CK + 4.1 ms" name="EXTXOSC_0MHZ4_0MHZ9_16KCK_4MS1" value="0x29"/>
+        <value caption="Ext. Crystal Osc. 0.4-0.9 MHz; Start-up time: 16K CK + 65 ms" name="EXTXOSC_0MHZ4_0MHZ9_16KCK_65MS" value="0x39"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 258 CK + 4.1 ms" name="EXTXOSC_0MHZ9_3MHZ_258CK_4MS1" value="0x0A"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 258 CK + 65 ms" name="EXTXOSC_0MHZ9_3MHZ_258CK_65MS" value="0x1A"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 1K CK + 0 ms" name="EXTXOSC_0MHZ9_3MHZ_1KCK_0MS" value="0x2A"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 1K CK + 4.1 ms" name="EXTXOSC_0MHZ9_3MHZ_1KCK_4MS1" value="0x3A"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 1K CK + 65 ms" name="EXTXOSC_0MHZ9_3MHZ_1KCK_65MS" value="0x0B"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 16K CK + 0 ms" name="EXTXOSC_0MHZ9_3MHZ_16KCK_0MS" value="0x1B"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 16K CK + 4.1 ms" name="EXTXOSC_0MHZ9_3MHZ_16KCK_4MS1" value="0x2B"/>
+        <value caption="Ext. Crystal Osc. 0.9-3.0 MHz; Start-up time: 16K CK + 65 ms" name="EXTXOSC_0MHZ9_3MHZ_16KCK_65MS" value="0x3B"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 258 CK + 4.1 ms" name="EXTXOSC_3MHZ_8MHZ_258CK_4MS1" value="0x0C"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 258 CK + 65 ms" name="EXTXOSC_3MHZ_8MHZ_258CK_65MS" value="0x1C"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 1K CK + 0 ms" name="EXTXOSC_3MHZ_8MHZ_1KCK_0MS" value="0x2C"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 1K CK + 4.1 ms" name="EXTXOSC_3MHZ_8MHZ_1KCK_4MS1" value="0x3C"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 1K CK + 65 ms" name="EXTXOSC_3MHZ_8MHZ_1KCK_65MS" value="0x0D"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 16K CK + 0 ms" name="EXTXOSC_3MHZ_8MHZ_16KCK_0MS" value="0x1D"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 16K CK + 4.1 ms" name="EXTXOSC_3MHZ_8MHZ_16KCK_4MS1" value="0x2D"/>
+        <value caption="Ext. Crystal Osc. 3.0-8.0 MHz; Start-up time: 16K CK + 65 ms" name="EXTXOSC_3MHZ_8MHZ_16KCK_65MS" value="0x3D"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 258 CK + 4.1 ms" name="EXTXOSC_8MHZ_XX_258CK_4MS1" value="0x0E"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 258 CK + 65 ms" name="EXTXOSC_8MHZ_XX_258CK_65MS" value="0x1E"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 1K CK + 0 ms" name="EXTXOSC_8MHZ_XX_1KCK_0MS" value="0x2E"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 1K CK + 4.1 ms" name="EXTXOSC_8MHZ_XX_1KCK_4MS1" value="0x3E"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 1K CK + 65 ms" name="EXTXOSC_8MHZ_XX_1KCK_65MS" value="0x0F"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 16K CK + 0 ms" name="EXTXOSC_8MHZ_XX_16KCK_0MS" value="0x1F"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 16K CK + 4.1 ms" name="EXTXOSC_8MHZ_XX_16KCK_4MS1" value="0x2F"/>
+        <value caption="Ext. Crystal Osc. 8.0-    MHz; Start-up time: 16K CK + 65 ms" name="EXTXOSC_8MHZ_XX_16KCK_65MS" value="0x3F"/>
+      </value-group>
+      <value-group caption="" name="ENUM_BOOTSZ">
+        <value caption="Boot Flash size=512 words start address=$FE00" name="512W_FE00" value="0x03"/>
+        <value caption="Boot Flash size=1024 words start address=$FC00" name="1024W_FC00" value="0x02"/>
+        <value caption="Boot Flash size=2048 words start address=$F800" name="2048W_F800" value="0x01"/>
+        <value caption="Boot Flash size=4096 words start address=$F000" name="4096W_F000" value="0x00"/>
+      </value-group>
+      <value-group caption="" name="ENUM_BODLEVEL">
+        <value caption="Brown-out detection disabled; [BODLEVEL=111]" name="DISABLED" value="0x07"/>
+        <value caption="Brown-out detection at VCC=2.0 V" name="2V0" value="0x06"/>
+        <value caption="Brown-out detection at VCC=2.2 V" name="2V2" value="0x05"/>
+        <value caption="Brown-out detection at VCC=2.4 V" name="2V4" value="0x04"/>
+        <value caption="Brown-out detection at VCC=2.6 V" name="2V6" value="0x03"/>
+        <value caption="Brown-out detection at VCC=3.4 V" name="3V4" value="0x02"/>
+        <value caption="Brown-out detection at VCC=3.5 V" name="3V5" value="0x01"/>
+        <value caption="Brown-out detection at VCC=4.3 V" name="4V3" value="0x00"/>
+      </value-group>
+    </module>
+    <module caption="Lockbits" name="LOCKBIT">
+      <register-group caption="Lockbits" name="LOCKBIT">
+        <register caption="" name="LOCKBIT" offset="0x00" size="1" initval="0xFF">
+          <bitfield caption="Memory Lock" mask="0x03" name="LB" values="ENUM_LB"/>
+          <bitfield caption="Boot Loader Protection Mode" mask="0x0C" name="BLB0" values="ENUM_BLB"/>
+          <bitfield caption="Boot Loader Protection Mode" mask="0x30" name="BLB1" values="ENUM_BLB2"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="ENUM_LB">
+        <value caption="Further programming and verification disabled" name="PROG_VER_DISABLED" value="0x00"/>
+        <value caption="Further programming disabled" name="PROG_DISABLED" value="0x02"/>
+        <value caption="No memory lock features enabled" name="NO_LOCK" value="0x03"/>
+      </value-group>
+      <value-group caption="" name="ENUM_BLB">
+        <value caption="LPM and SPM prohibited in Application Section" name="LPM_SPM_DISABLE" value="0x00"/>
+        <value caption="LPM prohibited in Application Section" name="LPM_DISABLE" value="0x01"/>
+        <value caption="SPM prohibited in Application Section" name="SPM_DISABLE" value="0x02"/>
+        <value caption="No lock on SPM and LPM in Application Section" name="NO_LOCK" value="0x03"/>
+      </value-group>
+      <value-group caption="" name="ENUM_BLB2">
+        <value caption="LPM and SPM prohibited in Boot Section" name="LPM_SPM_DISABLE" value="0x00"/>
+        <value caption="LPM prohibited in Boot Section" name="LPM_DISABLE" value="0x01"/>
+        <value caption="SPM prohibited in Boot Section" name="SPM_DISABLE" value="0x02"/>
+        <value caption="No lock on SPM and LPM in Boot Section" name="NO_LOCK" value="0x03"/>
+      </value-group>
+    </module>
+    <module caption="Watchdog Timer" name="WDT">
+      <register-group caption="Watchdog Timer" name="WDT">
+        <register caption="Watchdog Timer Control Register" name="WDTCSR" offset="0x60" size="1" ocd-rw="R">
+          <bitfield caption="Watchdog Timeout Interrupt Flag" mask="0x80" name="WDIF"/>
+          <bitfield caption="Watchdog Timeout Interrupt Enable" mask="0x40" name="WDIE"/>
+          <bitfield caption="Watchdog Timer Prescaler Bits" mask="0x27" name="WDP" values="WDOG_TIMER_PRESCALE_4BITS"/>
+          <bitfield caption="Watchdog Change Enable" mask="0x10" name="WDCE"/>
+          <bitfield caption="Watch Dog Enable" mask="0x08" name="WDE"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="WDOG_TIMER_PRESCALE_4BITS">
+        <value caption="Oscillator Cycles 2K" name="VAL_0x00" value="0x00"/>
+        <value caption="Oscillator Cycles 4K" name="VAL_0x01" value="0x01"/>
+        <value caption="Oscillator Cycles 8K" name="VAL_0x02" value="0x02"/>
+        <value caption="Oscillator Cycles 16K" name="VAL_0x03" value="0x03"/>
+        <value caption="Oscillator Cycles 32K" name="VAL_0x04" value="0x04"/>
+        <value caption="Oscillator Cycles 64K" name="VAL_0x05" value="0x05"/>
+        <value caption="Oscillator Cycles 128K" name="VAL_0x06" value="0x06"/>
+        <value caption="Oscillator Cycles 256K" name="VAL_0x07" value="0x07"/>
+        <value caption="Oscillator Cycles 512K" name="VAL_0x08" value="0x08"/>
+        <value caption="Oscillator Cycles 1024K" name="VAL_0x09" value="0x09"/>
+      </value-group>
+    </module>
+    <module caption="I/O Port" name="PORT">
+      <register-group caption="I/O Port" name="PORTA">
+        <register caption="Port A Data Register" name="PORTA" offset="0x22" size="1" mask="0xFF"/>
+        <register caption="Port A Data Direction Register" name="DDRA" offset="0x21" size="1" mask="0xFF"/>
+        <register caption="Port A Input Pins" name="PINA" offset="0x20" size="1" mask="0xFF" ocd-rw="R"/>
+      </register-group>
+      <register-group caption="I/O Port" name="PORTB">
+        <register caption="Port B Data Register" name="PORTB" offset="0x25" size="1" mask="0xFF"/>
+        <register caption="Port B Data Direction Register" name="DDRB" offset="0x24" size="1" mask="0xFF"/>
+        <register caption="Port B Input Pins" name="PINB" offset="0x23" size="1" mask="0xFF" ocd-rw="R"/>
+      </register-group>
+      <register-group caption="I/O Port" name="PORTC">
+        <register caption="Port C Data Register" name="PORTC" offset="0x28" size="1" mask="0xFF"/>
+        <register caption="Port C Data Direction Register" name="DDRC" offset="0x27" size="1" mask="0xFF"/>
+        <register caption="Port C Input Pins" name="PINC" offset="0x26" size="1" mask="0xFF" ocd-rw="R"/>
+      </register-group>
+      <register-group caption="I/O Port" name="PORTD">
+        <register caption="Port D Data Register" name="PORTD" offset="0x2B" size="1" mask="0xFF"/>
+        <register caption="Port D Data Direction Register" name="DDRD" offset="0x2A" size="1" mask="0xFF"/>
+        <register caption="Port D Input Pins" name="PIND" offset="0x29" size="1" mask="0xFF" ocd-rw="R"/>
+      </register-group>
+      <register-group caption="I/O Port" name="PORTE">
+        <register caption="Data Register, Port E" name="PORTE" offset="0x2E" size="1" mask="0xFF"/>
+        <register caption="Data Direction Register, Port E" name="DDRE" offset="0x2D" size="1" mask="0xFF"/>
+        <register caption="Input Pins, Port E" name="PINE" offset="0x2C" size="1" mask="0xFF" ocd-rw="R"/>
+      </register-group>
+      <register-group caption="I/O Port" name="PORTF">
+        <register caption="Data Register, Port F" name="PORTF" offset="0x31" size="1" mask="0xFF"/>
+        <register caption="Data Direction Register, Port F" name="DDRF" offset="0x30" size="1" mask="0xFF"/>
+        <register caption="Input Pins, Port F" name="PINF" offset="0x2F" size="1" mask="0xFF" ocd-rw="R"/>
+      </register-group>
+    </module>
+    <module caption="CPU Registers" name="CPU">
+      <register-group caption="CPU Registers" name="CPU">
+        <register caption="Status Register" name="SREG" offset="0x5F" size="1">
+          <bitfield caption="Global Interrupt Enable" mask="0x80" name="I"/>
+          <bitfield caption="Bit Copy Storage" mask="0x40" name="T"/>
+          <bitfield caption="Half Carry Flag" mask="0x20" name="H"/>
+          <bitfield caption="Sign Bit" mask="0x10" name="S"/>
+          <bitfield caption="Two's Complement Overflow Flag" mask="0x08" name="V"/>
+          <bitfield caption="Negative Flag" mask="0x04" name="N"/>
+          <bitfield caption="Zero Flag" mask="0x02" name="Z"/>
+          <bitfield caption="Carry Flag" mask="0x01" name="C"/>
+        </register>
+        <register caption="Stack Pointer " name="SP" offset="0x5D" size="2" mask="0xFFFF"/>
+        <register caption="MCU Control Register" name="MCUCR" offset="0x55" size="1">
+          <bitfield caption="JTAG Interface Disable" mask="0x80" name="JTD"/>
+          <bitfield caption="Pull-up disable" mask="0x10" name="PUD"/>
+          <bitfield caption="Interrupt Vector Select" mask="0x02" name="IVSEL"/>
+          <bitfield caption="Interrupt Vector Change Enable" mask="0x01" name="IVCE"/>
+        </register>
+        <register caption="MCU Status Register" name="MCUSR" offset="0x54" size="1">
+          <bitfield caption="JTAG Reset Flag" mask="0x10" name="JTRF"/>
+          <bitfield caption="Watchdog Reset Flag" mask="0x08" name="WDRF"/>
+          <bitfield caption="Brown-out Reset Flag" mask="0x04" name="BORF"/>
+          <bitfield caption="External Reset Flag" mask="0x02" name="EXTRF"/>
+          <bitfield caption="Power-on reset flag" mask="0x01" name="PORF"/>
+        </register>
+        <register caption="External Memory Control Register A" name="XMCRA" offset="0x74" size="1">
+          <bitfield caption="External SRAM Enable" mask="0x80" name="SRE"/>
+          <bitfield caption="Wait state page limit" mask="0x70" name="SRL" values="CPU_SECTOR_LIMITS3"/>
+          <bitfield caption="Wait state select bit upper page" mask="0x0C" name="SRW1" values="CPU_WAIT_STATES"/>
+          <bitfield caption="Wait state select bit lower page" mask="0x03" name="SRW0" values="CPU_WAIT_STATES"/>
+        </register>
+        <register caption="External Memory Control Register B" name="XMCRB" offset="0x75" size="1">
+          <bitfield caption="External Memory Bus Keeper Enable" mask="0x80" name="XMBK"/>
+          <bitfield caption="External Memory High Mask" mask="0x07" name="XMM" values="CPU_PIN_RELEASE"/>
+        </register>
+        <register caption="Oscillator Calibration Value" name="OSCCAL" offset="0x66" size="1" mask="0xFF">
+          <bitfield caption="Oscillator Calibration " mask="0xFF" name="OSCCAL"/>
+        </register>
+        <register caption="" name="CLKPR" offset="0x61" size="1">
+          <bitfield caption="" mask="0x80" name="CLKPCE"/>
+          <bitfield caption="" mask="0x0F" name="CLKPS" values="CPU_CLK_PRESCALE_4_BITS_SMALL"/>
+        </register>
+        <register caption="Sleep Mode Control Register" name="SMCR" offset="0x53" size="1">
+          <bitfield caption="Sleep Mode Select bits" mask="0x0E" name="SM" values="CPU_SLEEP_MODE_3BITS"/>
+          <bitfield caption="Sleep Enable" mask="0x01" name="SE"/>
+        </register>
+        <register caption="Extended Indirect Register" name="EIND" offset="0x5C" size="1" mask="0x01"/>
+        <register caption="RAM Page Z Select Register" name="RAMPZ" offset="0x5B" size="1" mask="0x01"/>
+        <register caption="General Purpose IO Register 2" name="GPIOR2" offset="0x4B" size="1">
+          <bitfield caption="General Purpose IO Register 2 bis" mask="0xFF" name="GPIOR" lsb="20"/>
+        </register>
+        <register caption="General Purpose IO Register 1" name="GPIOR1" offset="0x4A" size="1">
+          <bitfield caption="General Purpose IO Register 1 bis" mask="0xFF" name="GPIOR" lsb="10"/>
+        </register>
+        <register caption="General Purpose IO Register 0" name="GPIOR0" offset="0x3E" size="1">
+          <bitfield caption="General Purpose IO Register 0 bit 7" mask="0x80" name="GPIOR07"/>
+          <bitfield caption="General Purpose IO Register 0 bit 6" mask="0x40" name="GPIOR06"/>
+          <bitfield caption="General Purpose IO Register 0 bit 5" mask="0x20" name="GPIOR05"/>
+          <bitfield caption="General Purpose IO Register 0 bit 4" mask="0x10" name="GPIOR04"/>
+          <bitfield caption="General Purpose IO Register 0 bit 3" mask="0x08" name="GPIOR03"/>
+          <bitfield caption="General Purpose IO Register 0 bit 2" mask="0x04" name="GPIOR02"/>
+          <bitfield caption="General Purpose IO Register 0 bit 1" mask="0x02" name="GPIOR01"/>
+          <bitfield caption="General Purpose IO Register 0 bit 0" mask="0x01" name="GPIOR00"/>
+        </register>
+        <register caption="Power Reduction Register1" name="PRR1" offset="0x65" size="1">
+          <bitfield caption="Power Reduction USB" mask="0x80" name="PRUSB"/>
+          <bitfield caption="Power Reduction Timer/Counter3" mask="0x08" name="PRTIM3"/>
+          <bitfield caption="Power Reduction USART1" mask="0x01" name="PRUSART1"/>
+        </register>
+        <register caption="Power Reduction Register0" name="PRR0" offset="0x64" size="1">
+          <bitfield caption="Power Reduction TWI" mask="0x80" name="PRTWI"/>
+          <bitfield caption="Power Reduction Timer/Counter2" mask="0x40" name="PRTIM2"/>
+          <bitfield caption="Power Reduction Timer/Counter0" mask="0x20" name="PRTIM0"/>
+          <bitfield caption="Power Reduction Timer/Counter1" mask="0x08" name="PRTIM1"/>
+          <bitfield caption="Power Reduction Serial Peripheral Interface" mask="0x04" name="PRSPI"/>
+          <bitfield caption="Power Reduction ADC" mask="0x01" name="PRADC"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="CPU_SECTOR_LIMITS3">
+        <value caption="LS = N/A, US = 0x1100 - 0xFFFF" name="VAL_0x00" value="0x00"/>
+        <value caption="LS = 0x2100 - 0x1FFF, US = 0x2000 - 0xFFFF" name="VAL_0x01" value="0x01"/>
+        <value caption="LS = 0x2100 - 0x3FFF, US = 0x4000 - 0xFFFF" name="VAL_0x02" value="0x02"/>
+        <value caption="LS = 0x2100 - 0x5FFF, US = 0x6000 - 0xFFFF" name="VAL_0x03" value="0x03"/>
+        <value caption="LS = 0x2100 - 0x7FFF, US = 0x8000 - 0xFFFF" name="VAL_0x04" value="0x04"/>
+        <value caption="LS = 0x2100 - 0x9FFF, US = 0xA000 - 0xFFFF" name="VAL_0x05" value="0x05"/>
+        <value caption="LS = 0x2100 - 0xBFFF, US = 0xC000 - 0xFFFF" name="VAL_0x06" value="0x06"/>
+        <value caption="LS = 0x2100 - 0xDFFF, US = 0xE000 - 0xFFFF" name="VAL_0x07" value="0x07"/>
+      </value-group>
+      <value-group caption="" name="CPU_WAIT_STATES">
+        <value caption="No wait-states" name="VAL_0x00" value="0x00"/>
+        <value caption="Wait one cycle during read/write strobe" name="VAL_0x01" value="0x01"/>
+        <value caption="Wait two cycles during read/write strobe" name="VAL_0x02" value="0x02"/>
+        <value caption="Wait two cycles during read/write and wait one cycle before driving out new address" name="VAL_0x03" value="0x03"/>
+      </value-group>
+      <value-group caption="" name="CPU_PIN_RELEASE">
+        <value caption="None" name="VAL_0x00" value="0x00"/>
+        <value caption="Px7" name="VAL_0x01" value="0x01"/>
+        <value caption="Px7-Px6" name="VAL_0x02" value="0x02"/>
+        <value caption="Px7-Px5" name="VAL_0x03" value="0x03"/>
+        <value caption="Px7-Px4" name="VAL_0x04" value="0x04"/>
+        <value caption="Px7-Px3" name="VAL_0x05" value="0x05"/>
+        <value caption="Px7-Px2" name="VAL_0x06" value="0x06"/>
+        <value caption="Full Port X" name="VAL_0x07" value="0x07"/>
+      </value-group>
+      <value-group caption="" name="CPU_CLK_PRESCALE_4_BITS_SMALL">
+        <value caption="1" name="VAL_0x00" value="0x00"/>
+        <value caption="2" name="VAL_0x01" value="0x01"/>
+        <value caption="4" name="VAL_0x02" value="0x02"/>
+        <value caption="8" name="VAL_0x03" value="0x03"/>
+        <value caption="16" name="VAL_0x04" value="0x04"/>
+        <value caption="32" name="VAL_0x05" value="0x05"/>
+        <value caption="64" name="VAL_0x06" value="0x06"/>
+        <value caption="128" name="VAL_0x07" value="0x07"/>
+        <value caption="256" name="VAL_0x08" value="0x08"/>
+      </value-group>
+      <value-group caption="" name="CPU_SLEEP_MODE_3BITS">
+        <value caption="Idle" name="IDLE" value="0x00"/>
+        <value caption="ADC Noise Reduction (If Available)" name="ADC" value="0x01"/>
+        <value caption="Power Down" name="PDOWN" value="0x02"/>
+        <value caption="Power Save" name="PSAVE" value="0x03"/>
+        <value caption="Reserved" name="VAL_0x04" value="0x04"/>
+        <value caption="Reserved" name="VAL_0x05" value="0x05"/>
+        <value caption="Standby" name="STDBY" value="0x06"/>
+        <value caption="Extended Standby" name="ESTDBY" value="0x07"/>
+      </value-group>
+      <value-group caption="Oscillator Calibration Values" name="OSCCAL_VALUE_ADDRESSES">
+        <value value="0x00" caption="8.0 MHz" name="8_0_MHz"/>
+      </value-group>
+
+    </module>
+    <module caption="Two Wire Serial Interface" name="TWI">
+      <register-group caption="Two Wire Serial Interface" name="TWI">
+        <register caption="TWI (Slave) Address Mask Register" name="TWAMR" offset="0xBD" size="1">
+          <bitfield caption="" mask="0xFE" name="TWAM"/>
+        </register>
+        <register caption="TWI Bit Rate register" name="TWBR" offset="0xB8" size="1" mask="0xFF"/>
+        <register caption="TWI Control Register" name="TWCR" offset="0xBC" size="1" ocd-rw="R">
+          <bitfield caption="TWI Interrupt Flag" mask="0x80" name="TWINT"/>
+          <bitfield caption="TWI Enable Acknowledge Bit" mask="0x40" name="TWEA"/>
+          <bitfield caption="TWI Start Condition Bit" mask="0x20" name="TWSTA"/>
+          <bitfield caption="TWI Stop Condition Bit" mask="0x10" name="TWSTO"/>
+          <bitfield caption="TWI Write Collition Flag" mask="0x08" name="TWWC"/>
+          <bitfield caption="TWI Enable Bit" mask="0x04" name="TWEN"/>
+          <bitfield caption="TWI Interrupt Enable" mask="0x01" name="TWIE"/>
+        </register>
+        <register caption="TWI Status Register" name="TWSR" offset="0xB9" size="1">
+          <bitfield caption="TWI Status" mask="0xF8" name="TWS" lsb="3"/>
+          <bitfield caption="TWI Prescaler" mask="0x03" name="TWPS" values="COMM_TWI_PRESACLE"/>
+        </register>
+        <register caption="TWI Data register" name="TWDR" offset="0xBB" size="1" mask="0xFF"/>
+        <register caption="TWI (Slave) Address register" name="TWAR" offset="0xBA" size="1">
+          <bitfield caption="TWI (Slave) Address register Bits" mask="0xFE" name="TWA"/>
+          <bitfield caption="TWI General Call Recognition Enable Bit" mask="0x01" name="TWGCE"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="COMM_TWI_PRESACLE">
+        <value caption="1" name="VAL_0x00" value="0x00"/>
+        <value caption="4" name="VAL_0x01" value="0x01"/>
+        <value caption="16" name="VAL_0x02" value="0x02"/>
+        <value caption="64" name="VAL_0x03" value="0x03"/>
+      </value-group>
+    </module>
+    <module caption="Serial Peripheral Interface" name="SPI">
+      <register-group caption="Serial Peripheral Interface" name="SPI">
+        <register caption="SPI Control Register" name="SPCR" offset="0x4C" size="1">
+          <bitfield caption="SPI Interrupt Enable" mask="0x80" name="SPIE"/>
+          <bitfield caption="SPI Enable" mask="0x40" name="SPE"/>
+          <bitfield caption="Data Order" mask="0x20" name="DORD"/>
+          <bitfield caption="Master/Slave Select" mask="0x10" name="MSTR"/>
+          <bitfield caption="Clock polarity" mask="0x08" name="CPOL"/>
+          <bitfield caption="Clock Phase" mask="0x04" name="CPHA"/>
+          <bitfield caption="SPI Clock Rate Selects" mask="0x03" name="SPR" values="COMM_SCK_RATE_3BIT"/>
+        </register>
+        <register caption="SPI Status Register" name="SPSR" offset="0x4D" size="1" ocd-rw="R">
+          <bitfield caption="SPI Interrupt Flag" mask="0x80" name="SPIF"/>
+          <bitfield caption="Write Collision Flag" mask="0x40" name="WCOL"/>
+          <bitfield caption="Double SPI Speed Bit" mask="0x01" name="SPI2X"/>
+        </register>
+        <register caption="SPI Data Register" name="SPDR" offset="0x4E" size="1" mask="0xFF" ocd-rw=""/>
+      </register-group>
+      <value-group caption="" name="COMM_SCK_RATE_3BIT">
+        <value caption="fosc/4" name="VAL_0x00" value="0x00"/>
+        <value caption="fosc/16" name="VAL_0x01" value="0x01"/>
+        <value caption="fosc/64" name="VAL_0x02" value="0x02"/>
+        <value caption="fosc/128" name="VAL_0x03" value="0x03"/>
+        <value caption="fosc/2" name="VAL_0x04" value="0x04"/>
+        <value caption="fosc/8" name="VAL_0x05" value="0x05"/>
+        <value caption="fosc/32" name="VAL_0x06" value="0x06"/>
+        <value caption="fosc/64" name="VAL_0x07" value="0x07"/>
+      </value-group>
+    </module>
+    <module caption="USART" name="USART">
+      <register-group caption="USART" name="USART1">
+        <register caption="USART I/O Data Register" name="UDR1" offset="0xCE" size="1" mask="0xFF" ocd-rw=""/>
+        <register caption="USART Control and Status Register A" name="UCSR1A" offset="0xC8" size="1" ocd-rw="R">
+          <bitfield caption="USART Receive Complete" mask="0x80" name="RXC1"/>
+          <bitfield caption="USART Transmitt Complete" mask="0x40" name="TXC1"/>
+          <bitfield caption="USART Data Register Empty" mask="0x20" name="UDRE1"/>
+          <bitfield caption="Framing Error" mask="0x10" name="FE1"/>
+          <bitfield caption="Data overRun" mask="0x08" name="DOR1"/>
+          <bitfield caption="Parity Error" mask="0x04" name="UPE1"/>
+          <bitfield caption="Double the USART transmission speed" mask="0x02" name="U2X1"/>
+          <bitfield caption="Multi-processor Communication Mode" mask="0x01" name="MPCM1"/>
+        </register>
+        <register caption="USART Control and Status Register B" name="UCSR1B" offset="0xC9" size="1">
+          <bitfield caption="RX Complete Interrupt Enable" mask="0x80" name="RXCIE1"/>
+          <bitfield caption="TX Complete Interrupt Enable" mask="0x40" name="TXCIE1"/>
+          <bitfield caption="USART Data register Empty Interrupt Enable" mask="0x20" name="UDRIE1"/>
+          <bitfield caption="Receiver Enable" mask="0x10" name="RXEN1"/>
+          <bitfield caption="Transmitter Enable" mask="0x08" name="TXEN1"/>
+          <bitfield caption="Character Size" mask="0x04" name="UCSZ12"/>
+          <bitfield caption="Receive Data Bit 8" mask="0x02" name="RXB81"/>
+          <bitfield caption="Transmit Data Bit 8" mask="0x01" name="TXB81"/>
+        </register>
+        <register caption="USART Control and Status Register C" name="UCSR1C" offset="0xCA" size="1">
+          <bitfield caption="USART Mode Select" mask="0xC0" name="UMSEL1" values="COMM_USART_MODE_2BIT"/>
+          <bitfield caption="Parity Mode Bits" mask="0x30" name="UPM1" values="COMM_UPM_PARITY_MODE"/>
+          <bitfield caption="Stop Bit Select" mask="0x08" name="USBS1" values="COMM_STOP_BIT_SEL"/>
+          <bitfield caption="Character Size" mask="0x06" name="UCSZ1"/>
+          <bitfield caption="Clock Polarity" mask="0x01" name="UCPOL1"/>
+        </register>
+        <register caption="USART Baud Rate Register  Bytes" name="UBRR1" offset="0xCC" size="2" mask="0x0FFF"/>
+      </register-group>
+      <value-group caption="" name="COMM_USART_MODE_2BIT">
+        <value caption="Asynchronous USART" name="VAL_0x00" value="0x00"/>
+        <value caption="Synchronous USART" name="VAL_0x01" value="0x01"/>
+        <value caption="Master SPI" name="VAL_0x03" value="0x03"/>
+      </value-group>
+      <value-group caption="" name="COMM_UPM_PARITY_MODE">
+        <value caption="Disabled" name="VAL_0x00" value="0x00"/>
+        <value caption="Reserved" name="VAL_0x01" value="0x01"/>
+        <value caption="Enabled, Even Parity" name="VAL_0x02" value="0x02"/>
+        <value caption="Enabled, Odd Parity" name="VAL_0x03" value="0x03"/>
+      </value-group>
+      <value-group caption="" name="COMM_STOP_BIT_SEL">
+        <value caption="1-bit" name="VAL_0x00" value="0x00"/>
+        <value caption="2-bit" name="VAL_0x01" value="0x01"/>
+      </value-group>
+    </module>
+    <module caption="USB Device Registers" name="USB_DEVICE">
+      <register-group caption="USB Device Registers" name="USB_DEVICE">
+        <register caption="" name="UEINT" offset="0xF4" size="1" mask="0x7F"/>
+        <register caption="" name="UEBCHX" offset="0xF3" size="1" mask="0x07" ocd-rw="R"/>
+        <register caption="" name="UEBCLX" offset="0xF2" size="1" mask="0xFF" ocd-rw="R"/>
+        <register caption="" name="UEDATX" offset="0xF1" size="1" mask="0xFF" ocd-rw=""/>
+        <register caption="" name="UEIENX" offset="0xF0" size="1">
+          <bitfield caption="" mask="0x80" name="FLERRE"/>
+          <bitfield caption="" mask="0x40" name="NAKINE"/>
+          <bitfield caption="" mask="0x10" name="NAKOUTE"/>
+          <bitfield caption="" mask="0x08" name="RXSTPE"/>
+          <bitfield caption="" mask="0x04" name="RXOUTE"/>
+          <bitfield caption="" mask="0x02" name="STALLEDE"/>
+          <bitfield caption="" mask="0x01" name="TXINE"/>
+        </register>
+        <register caption="" name="UESTA1X" offset="0xEF" size="1" ocd-rw="R">
+          <bitfield caption="" mask="0x04" name="CTRLDIR"/>
+          <bitfield caption="" mask="0x03" name="CURRBK"/>
+        </register>
+        <register caption="" name="UESTA0X" offset="0xEE" size="1">
+          <bitfield caption="" mask="0x80" name="CFGOK"/>
+          <bitfield caption="" mask="0x40" name="OVERFI"/>
+          <bitfield caption="" mask="0x20" name="UNDERFI"/>
+          <bitfield caption="" mask="0x0C" name="DTSEQ"/>
+          <bitfield caption="" mask="0x03" name="NBUSYBK"/>
+        </register>
+        <register caption="" name="UECFG1X" offset="0xED" size="1">
+          <bitfield caption="" mask="0x70" name="EPSIZE"/>
+          <bitfield caption="" mask="0x0C" name="EPBK"/>
+          <bitfield caption="" mask="0x02" name="ALLOC"/>
+        </register>
+        <register caption="" name="UECFG0X" offset="0xEC" size="1">
+          <bitfield caption="" mask="0xC0" name="EPTYPE"/>
+          <bitfield caption="" mask="0x01" name="EPDIR"/>
+        </register>
+        <register caption="" name="UECONX" offset="0xEB" size="1">
+          <bitfield caption="" mask="0x20" name="STALLRQ"/>
+          <bitfield caption="" mask="0x10" name="STALLRQC"/>
+          <bitfield caption="" mask="0x08" name="RSTDT"/>
+          <bitfield caption="" mask="0x01" name="EPEN"/>
+        </register>
+        <register caption="" name="UERST" offset="0xEA" size="1">
+          <bitfield caption="" mask="0x7F" name="EPRST"/>
+        </register>
+        <register caption="" name="UENUM" offset="0xE9" size="1" mask="0x07"/>
+        <register caption="" name="UEINTX" offset="0xE8" size="1">
+          <bitfield caption="" mask="0x80" name="FIFOCON"/>
+          <bitfield caption="" mask="0x40" name="NAKINI"/>
+          <bitfield caption="" mask="0x20" name="RWAL"/>
+          <bitfield caption="" mask="0x10" name="NAKOUTI"/>
+          <bitfield caption="" mask="0x08" name="RXSTPI"/>
+          <bitfield caption="" mask="0x04" name="RXOUTI"/>
+          <bitfield caption="" mask="0x02" name="STALLEDI"/>
+          <bitfield caption="" mask="0x01" name="TXINI"/>
+        </register>
+        <register caption="" name="UDMFN" offset="0xE6" size="1" ocd-rw="R">
+          <bitfield caption="" mask="0x10" name="FNCERR"/>
+        </register>
+        <register caption="" name="UDFNUM" offset="0xE4" size="2" mask="0x07FF"/>
+        <register caption="" name="UDADDR" offset="0xE3" size="1">
+          <bitfield caption="" mask="0x80" name="ADDEN"/>
+          <bitfield caption="" mask="0x7F" name="UADD"/>
+        </register>
+        <register caption="" name="UDIEN" offset="0xE2" size="1">
+          <bitfield caption="" mask="0x40" name="UPRSME"/>
+          <bitfield caption="" mask="0x20" name="EORSME"/>
+          <bitfield caption="" mask="0x10" name="WAKEUPE"/>
+          <bitfield caption="" mask="0x08" name="EORSTE"/>
+          <bitfield caption="" mask="0x04" name="SOFE"/>
+          <bitfield caption="" mask="0x01" name="SUSPE"/>
+        </register>
+        <register caption="" name="UDINT" offset="0xE1" size="1">
+          <bitfield caption="" mask="0x40" name="UPRSMI"/>
+          <bitfield caption="" mask="0x20" name="EORSMI"/>
+          <bitfield caption="" mask="0x10" name="WAKEUPI"/>
+          <bitfield caption="" mask="0x08" name="EORSTI"/>
+          <bitfield caption="" mask="0x04" name="SOFI"/>
+          <bitfield caption="" mask="0x01" name="SUSPI"/>
+        </register>
+        <register caption="" name="UDCON" offset="0xE0" size="1">
+          <bitfield caption="" mask="0x04" name="LSM"/>
+          <bitfield caption="" mask="0x02" name="RMWKUP"/>
+          <bitfield caption="" mask="0x01" name="DETACH"/>
+        </register>
+      </register-group>
+    </module>
+    <module caption="Bootloader" name="BOOT_LOAD">
+      <register-group caption="Bootloader" name="BOOT_LOAD">
+        <register caption="Store Program Memory Control Register" name="SPMCSR" offset="0x57" size="1">
+          <bitfield caption="SPM Interrupt Enable" mask="0x80" name="SPMIE"/>
+          <bitfield caption="Read While Write Section Busy" mask="0x40" name="RWWSB"/>
+          <bitfield caption="Signature Row Read" mask="0x20" name="SIGRD"/>
+          <bitfield caption="Read While Write section read enable" mask="0x10" name="RWWSRE"/>
+          <bitfield caption="Boot Lock Bit Set" mask="0x08" name="BLBSET"/>
+          <bitfield caption="Page Write" mask="0x04" name="PGWRT"/>
+          <bitfield caption="Page Erase" mask="0x02" name="PGERS"/>
+          <bitfield caption="Store Program Memory Enable" mask="0x01" name="SPMEN"/>
+        </register>
+      </register-group>
+    </module>
+    <module caption="EEPROM" name="EEPROM">
+      <register-group caption="EEPROM" name="EEPROM">
+        <register caption="EEPROM Address Register Low Bytes" name="EEAR" offset="0x41" size="2" mask="0x0FFF"/>
+        <register caption="EEPROM Data Register" name="EEDR" offset="0x40" size="1" mask="0xFF"/>
+        <register caption="EEPROM Control Register" name="EECR" offset="0x3F" size="1">
+          <bitfield caption="EEPROM Programming Mode Bits" mask="0x30" name="EEPM" values="EEP_MODE"/>
+          <bitfield caption="EEPROM Ready Interrupt Enable" mask="0x08" name="EERIE"/>
+          <bitfield caption="EEPROM Master Write Enable" mask="0x04" name="EEMPE"/>
+          <bitfield caption="EEPROM Write Enable" mask="0x02" name="EEPE"/>
+          <bitfield caption="EEPROM Read Enable" mask="0x01" name="EERE"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="EEP_MODE">
+        <value caption="Erase and Write in one operation" name="VAL_0x00" value="0x00"/>
+        <value caption="Erase Only" name="VAL_0x01" value="0x01"/>
+        <value caption="Write Only" name="VAL_0x02" value="0x02"/>
+      </value-group>
+    </module>
+    <module caption="Timer/Counter, 8-bit" name="TC8">
+      <register-group caption="Timer/Counter, 8-bit" name="TC0">
+        <register caption="Timer/Counter0 Output Compare Register" name="OCR0B" offset="0x48" size="1" mask="0xFF"/>
+        <register caption="Timer/Counter0 Output Compare Register" name="OCR0A" offset="0x47" size="1" mask="0xFF"/>
+        <register caption="Timer/Counter0" name="TCNT0" offset="0x46" size="1" mask="0xFF"/>
+        <register caption="Timer/Counter Control Register B" name="TCCR0B" offset="0x45" size="1">
+          <bitfield caption="Force Output Compare A" mask="0x80" name="FOC0A"/>
+          <bitfield caption="Force Output Compare B" mask="0x40" name="FOC0B"/>
+          <bitfield caption="" mask="0x08" name="WGM02"/>
+          <bitfield caption="Clock Select" mask="0x07" name="CS0" values="CLK_SEL_3BIT_EXT"/>
+        </register>
+        <register caption="Timer/Counter  Control Register A" name="TCCR0A" offset="0x44" size="1">
+          <bitfield caption="Compare Output Mode, Phase Correct PWM Mode" mask="0xC0" name="COM0A"/>
+          <bitfield caption="Compare Output Mode, Fast PWm" mask="0x30" name="COM0B"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x03" name="WGM0"/>
+        </register>
+        <register caption="Timer/Counter0 Interrupt Mask Register" name="TIMSK0" offset="0x6E" size="1">
+          <bitfield caption="Timer/Counter0 Output Compare Match B Interrupt Enable" mask="0x04" name="OCIE0B"/>
+          <bitfield caption="Timer/Counter0 Output Compare Match A Interrupt Enable" mask="0x02" name="OCIE0A"/>
+          <bitfield caption="Timer/Counter0 Overflow Interrupt Enable" mask="0x01" name="TOIE0"/>
+        </register>
+        <register caption="Timer/Counter0 Interrupt Flag register" name="TIFR0" offset="0x35" size="1" ocd-rw="R">
+          <bitfield caption="Timer/Counter0 Output Compare Flag 0B" mask="0x04" name="OCF0B"/>
+          <bitfield caption="Timer/Counter0 Output Compare Flag 0A" mask="0x02" name="OCF0A"/>
+          <bitfield caption="Timer/Counter0 Overflow Flag" mask="0x01" name="TOV0"/>
+        </register>
+        <register caption="General Timer/Counter Control Register" name="GTCCR" offset="0x43" size="1">
+          <bitfield caption="Timer/Counter Synchronization Mode" mask="0x80" name="TSM"/>
+          <bitfield caption="Prescaler Reset Timer/Counter1 and Timer/Counter0" mask="0x01" name="PSRSYNC"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="CLK_SEL_3BIT_EXT">
+        <value caption="No Clock Source (Stopped)" name="VAL_0x00" value="0x00"/>
+        <value caption="Running, No Prescaling" name="VAL_0x01" value="0x01"/>
+        <value caption="Running, CLK/8" name="VAL_0x02" value="0x02"/>
+        <value caption="Running, CLK/64" name="VAL_0x03" value="0x03"/>
+        <value caption="Running, CLK/256" name="VAL_0x04" value="0x04"/>
+        <value caption="Running, CLK/1024" name="VAL_0x05" value="0x05"/>
+        <value caption="Running, ExtClk Tx Falling Edge" name="VAL_0x06" value="0x06"/>
+        <value caption="Running, ExtClk Tx Rising Edge" name="VAL_0x07" value="0x07"/>
+      </value-group>
+    </module>
+    <module caption="Timer/Counter, 8-bit Async" name="TC8_ASYNC">
+      <register-group caption="Timer/Counter, 8-bit Async" name="TC2">
+        <register caption="Timer/Counter Interrupt Mask register" name="TIMSK2" offset="0x70" size="1">
+          <bitfield caption="Timer/Counter2 Output Compare Match B Interrupt Enable" mask="0x04" name="OCIE2B"/>
+          <bitfield caption="Timer/Counter2 Output Compare Match A Interrupt Enable" mask="0x02" name="OCIE2A"/>
+          <bitfield caption="Timer/Counter2 Overflow Interrupt Enable" mask="0x01" name="TOIE2"/>
+        </register>
+        <register caption="Timer/Counter Interrupt Flag Register" name="TIFR2" offset="0x37" size="1" ocd-rw="R">
+          <bitfield caption="Output Compare Flag 2B" mask="0x04" name="OCF2B"/>
+          <bitfield caption="Output Compare Flag 2A" mask="0x02" name="OCF2A"/>
+          <bitfield caption="Timer/Counter2 Overflow Flag" mask="0x01" name="TOV2"/>
+        </register>
+        <register caption="Timer/Counter2 Control Register A" name="TCCR2A" offset="0xB0" size="1">
+          <bitfield caption="Compare Output Mode bits" mask="0xC0" name="COM2A"/>
+          <bitfield caption="Compare Output Mode bits" mask="0x30" name="COM2B"/>
+          <bitfield caption="Waveform Genration Mode" mask="0x03" name="WGM2"/>
+        </register>
+        <register caption="Timer/Counter2 Control Register B" name="TCCR2B" offset="0xB1" size="1">
+          <bitfield caption="Force Output Compare A" mask="0x80" name="FOC2A"/>
+          <bitfield caption="Force Output Compare B" mask="0x40" name="FOC2B"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x08" name="WGM22"/>
+          <bitfield caption="Clock Select bits" mask="0x07" name="CS2" values="CLK_SEL_3BIT"/>
+        </register>
+        <register caption="Timer/Counter2" name="TCNT2" offset="0xB2" size="1" mask="0xFF"/>
+        <register caption="Timer/Counter2 Output Compare Register B" name="OCR2B" offset="0xB4" size="1" mask="0xFF"/>
+        <register caption="Timer/Counter2 Output Compare Register A" name="OCR2A" offset="0xB3" size="1" mask="0xFF"/>
+        <register caption="Asynchronous Status Register" name="ASSR" offset="0xB6" size="1">
+          <bitfield caption="Enable External Clock Input" mask="0x40" name="EXCLK"/>
+          <bitfield caption="Asynchronous Timer/Counter2" mask="0x20" name="AS2"/>
+          <bitfield caption="Timer/Counter2 Update Busy" mask="0x10" name="TCN2UB"/>
+          <bitfield caption="Output Compare Register2 Update Busy" mask="0x08" name="OCR2AUB"/>
+          <bitfield caption="Output Compare Register 2 Update Busy" mask="0x04" name="OCR2BUB"/>
+          <bitfield caption="Timer/Counter Control Register2 Update Busy" mask="0x02" name="TCR2AUB"/>
+          <bitfield caption="Timer/Counter Control Register2 Update Busy" mask="0x01" name="TCR2BUB"/>
+        </register>
+        <register caption="General Timer Counter Control register" name="GTCCR" offset="0x43" size="1">
+          <bitfield caption="Timer/Counter Synchronization Mode" mask="0x80" name="TSM"/>
+          <bitfield caption="Prescaler Reset Timer/Counter2" mask="0x02" name="PSRASY"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="CLK_SEL_3BIT">
+        <value caption="No Clock Source (Stopped)" name="VAL_0x00" value="0x00"/>
+        <value caption="Running, No Prescaling" name="VAL_0x01" value="0x01"/>
+        <value caption="Running, CLK/8" name="VAL_0x02" value="0x02"/>
+        <value caption="Running, CLK/32" name="VAL_0x03" value="0x03"/>
+        <value caption="Running, CLK/64" name="VAL_0x04" value="0x04"/>
+        <value caption="Running, CLK/128" name="VAL_0x05" value="0x05"/>
+        <value caption="Running, CLK/256" name="VAL_0x06" value="0x06"/>
+        <value caption="Running, CLK/1024" name="VAL_0x07" value="0x07"/>
+      </value-group>
+    </module>
+    <module caption="Timer/Counter, 16-bit" name="TC16">
+      <register-group caption="Timer/Counter, 16-bit" name="TC3">
+        <register caption="Timer/Counter3 Control Register A" name="TCCR3A" offset="0x90" size="1">
+          <bitfield caption="Compare Output Mode 1A, bits" mask="0xC0" name="COM3A"/>
+          <bitfield caption="Compare Output Mode 3B, bits" mask="0x30" name="COM3B"/>
+          <bitfield caption="Compare Output Mode 3C, bits" mask="0x0C" name="COM3C"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x03" name="WGM3"/>
+        </register>
+        <register caption="Timer/Counter3 Control Register B" name="TCCR3B" offset="0x91" size="1">
+          <bitfield caption="Input Capture 3 Noise Canceler" mask="0x80" name="ICNC3"/>
+          <bitfield caption="Input Capture 3 Edge Select" mask="0x40" name="ICES3"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x18" name="WGM3" lsb="2"/>
+          <bitfield caption="Prescaler source of Timer/Counter 3" mask="0x07" name="CS3" values="CLK_SEL_3BIT_EXT"/>
+        </register>
+        <register caption="Timer/Counter 3 Control Register C" name="TCCR3C" offset="0x92" size="1">
+          <bitfield caption="Force Output Compare 3A" mask="0x80" name="FOC3A"/>
+          <bitfield caption="Force Output Compare 3B" mask="0x40" name="FOC3B"/>
+          <bitfield caption="Force Output Compare 3C" mask="0x20" name="FOC3C"/>
+        </register>
+        <register caption="Timer/Counter3  Bytes" name="TCNT3" offset="0x94" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter3 Output Compare Register A  Bytes" name="OCR3A" offset="0x98" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter3 Output Compare Register B  Bytes" name="OCR3B" offset="0x9A" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter3 Output Compare Register B  Bytes" name="OCR3C" offset="0x9C" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter3 Input Capture Register  Bytes" name="ICR3" offset="0x96" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter3 Interrupt Mask Register" name="TIMSK3" offset="0x71" size="1">
+          <bitfield caption="Timer/Counter3 Input Capture Interrupt Enable" mask="0x20" name="ICIE3"/>
+          <bitfield caption="Timer/Counter3 Output Compare C Match Interrupt Enable" mask="0x08" name="OCIE3C"/>
+          <bitfield caption="Timer/Counter3 Output Compare B Match Interrupt Enable" mask="0x04" name="OCIE3B"/>
+          <bitfield caption="Timer/Counter3 Output Compare A Match Interrupt Enable" mask="0x02" name="OCIE3A"/>
+          <bitfield caption="Timer/Counter3 Overflow Interrupt Enable" mask="0x01" name="TOIE3"/>
+        </register>
+        <register caption="Timer/Counter3 Interrupt Flag register" name="TIFR3" offset="0x38" size="1" ocd-rw="R">
+          <bitfield caption="Input Capture Flag 3" mask="0x20" name="ICF3"/>
+          <bitfield caption="Output Compare Flag 3C" mask="0x08" name="OCF3C"/>
+          <bitfield caption="Output Compare Flag 3B" mask="0x04" name="OCF3B"/>
+          <bitfield caption="Output Compare Flag 3A" mask="0x02" name="OCF3A"/>
+          <bitfield caption="Timer/Counter3 Overflow Flag" mask="0x01" name="TOV3"/>
+        </register>
+      </register-group>
+      <register-group caption="Timer/Counter, 16-bit" name="TC1">
+        <register caption="Timer/Counter1 Control Register A" name="TCCR1A" offset="0x80" size="1">
+          <bitfield caption="Compare Output Mode 1A, bits" mask="0xC0" name="COM1A"/>
+          <bitfield caption="Compare Output Mode 1B, bits" mask="0x30" name="COM1B"/>
+          <bitfield caption="Compare Output Mode 1C, bits" mask="0x0C" name="COM1C"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x03" name="WGM1"/>
+        </register>
+        <register caption="Timer/Counter1 Control Register B" name="TCCR1B" offset="0x81" size="1">
+          <bitfield caption="Input Capture 1 Noise Canceler" mask="0x80" name="ICNC1"/>
+          <bitfield caption="Input Capture 1 Edge Select" mask="0x40" name="ICES1"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x18" name="WGM1" lsb="2"/>
+          <bitfield caption="Prescaler source of Timer/Counter 1" mask="0x07" name="CS1" values="CLK_SEL_3BIT_EXT"/>
+        </register>
+        <register caption="Timer/Counter 1 Control Register C" name="TCCR1C" offset="0x82" size="1">
+          <bitfield caption="Force Output Compare 1A" mask="0x80" name="FOC1A"/>
+          <bitfield caption="Force Output Compare 1B" mask="0x40" name="FOC1B"/>
+          <bitfield caption="Force Output Compare 1C" mask="0x20" name="FOC1C"/>
+        </register>
+        <register caption="Timer/Counter1  Bytes" name="TCNT1" offset="0x84" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter1 Output Compare Register A  Bytes" name="OCR1A" offset="0x88" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter1 Output Compare Register B  Bytes" name="OCR1B" offset="0x8A" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter1 Output Compare Register C  Bytes" name="OCR1C" offset="0x8C" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter1 Input Capture Register  Bytes" name="ICR1" offset="0x86" size="2" mask="0xFFFF"/>
+        <register caption="Timer/Counter1 Interrupt Mask Register" name="TIMSK1" offset="0x6F" size="1">
+          <bitfield caption="Timer/Counter1 Input Capture Interrupt Enable" mask="0x20" name="ICIE1"/>
+          <bitfield caption="Timer/Counter1 Output Compare C Match Interrupt Enable" mask="0x08" name="OCIE1C"/>
+          <bitfield caption="Timer/Counter1 Output Compare B Match Interrupt Enable" mask="0x04" name="OCIE1B"/>
+          <bitfield caption="Timer/Counter1 Output Compare A Match Interrupt Enable" mask="0x02" name="OCIE1A"/>
+          <bitfield caption="Timer/Counter1 Overflow Interrupt Enable" mask="0x01" name="TOIE1"/>
+        </register>
+        <register caption="Timer/Counter1 Interrupt Flag register" name="TIFR1" offset="0x36" size="1" ocd-rw="R">
+          <bitfield caption="Input Capture Flag 1" mask="0x20" name="ICF1"/>
+          <bitfield caption="Output Compare Flag 1C" mask="0x08" name="OCF1C"/>
+          <bitfield caption="Output Compare Flag 1B" mask="0x04" name="OCF1B"/>
+          <bitfield caption="Output Compare Flag 1A" mask="0x02" name="OCF1A"/>
+          <bitfield caption="Timer/Counter1 Overflow Flag" mask="0x01" name="TOV1"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="CLK_SEL_3BIT_EXT">
+        <value caption="No Clock Source (Stopped)" name="VAL_0x00" value="0x00"/>
+        <value caption="Running, No Prescaling" name="VAL_0x01" value="0x01"/>
+        <value caption="Running, CLK/8" name="VAL_0x02" value="0x02"/>
+        <value caption="Running, CLK/64" name="VAL_0x03" value="0x03"/>
+        <value caption="Running, CLK/256" name="VAL_0x04" value="0x04"/>
+        <value caption="Running, CLK/1024" name="VAL_0x05" value="0x05"/>
+        <value caption="Running, ExtClk Tx Falling Edge" name="VAL_0x06" value="0x06"/>
+        <value caption="Running, ExtClk Tx Rising Edge" name="VAL_0x07" value="0x07"/>
+      </value-group>
+    </module>
+    <module caption="JTAG Interface" name="JTAG">
+      <register-group caption="JTAG Interface" name="JTAG">
+        <register caption="On-Chip Debug Related Register in I/O Memory" name="OCDR" offset="0x51" size="1" mask="0xFF" ocd-rw=""/>
+        <register caption="MCU Control Register" name="MCUCR" offset="0x55" size="1">
+          <bitfield caption="JTAG Interface Disable" mask="0x80" name="JTD"/>
+        </register>
+        <register caption="MCU Status Register" name="MCUSR" offset="0x54" size="1" ocd-rw="R">
+          <bitfield caption="JTAG Reset Flag" mask="0x10" name="JTRF"/>
+        </register>
+      </register-group>
+    </module>
+    <module caption="External Interrupts" name="EXINT">
+      <register-group caption="External Interrupts" name="EXINT">
+        <register caption="External Interrupt Control Register A" name="EICRA" offset="0x69" size="1">
+          <bitfield caption="External Interrupt Sense Control Bit" mask="0xC0" name="ISC3" values="INTERRUPT_SENSE_CONTROL"/>
+          <bitfield caption="External Interrupt Sense Control Bit" mask="0x30" name="ISC2" values="INTERRUPT_SENSE_CONTROL"/>
+          <bitfield caption="External Interrupt Sense Control Bit" mask="0x0C" name="ISC1" values="INTERRUPT_SENSE_CONTROL"/>
+          <bitfield caption="External Interrupt Sense Control Bit" mask="0x03" name="ISC0" values="INTERRUPT_SENSE_CONTROL"/>
+        </register>
+        <register caption="External Interrupt Control Register B" name="EICRB" offset="0x6A" size="1">
+          <bitfield caption="External Interrupt 7-4 Sense Control Bit" mask="0xC0" name="ISC7" values="INTERRUPT_SENSE_CONTROL"/>
+          <bitfield caption="External Interrupt 7-4 Sense Control Bit" mask="0x30" name="ISC6" values="INTERRUPT_SENSE_CONTROL"/>
+          <bitfield caption="External Interrupt 7-4 Sense Control Bit" mask="0x0C" name="ISC5" values="INTERRUPT_SENSE_CONTROL"/>
+          <bitfield caption="External Interrupt 7-4 Sense Control Bit" mask="0x03" name="ISC4" values="INTERRUPT_SENSE_CONTROL"/>
+        </register>
+        <register caption="External Interrupt Mask Register" name="EIMSK" offset="0x3D" size="1">
+          <bitfield caption="External Interrupt Request 7 Enable" mask="0xFF" name="INT"/>
+        </register>
+        <register caption="External Interrupt Flag Register" name="EIFR" offset="0x3C" size="1" ocd-rw="R">
+          <bitfield caption="External Interrupt Flags" mask="0xFF" name="INTF"/>
+        </register>
+        <register caption="Pin Change Mask Register 0" name="PCMSK0" offset="0x6B" size="1" mask="0xFF"/>
+        <register caption="Pin Change Interrupt Flag Register" name="PCIFR" offset="0x3B" size="1" ocd-rw="R">
+          <bitfield caption="Pin Change Interrupt Flag 0" mask="0x01" name="PCIF0"/>
+        </register>
+        <register caption="Pin Change Interrupt Control Register" name="PCICR" offset="0x68" size="1">
+          <bitfield caption="Pin Change Interrupt Enable 0" mask="0x01" name="PCIE0"/>
+        </register>
+      </register-group>
+      <value-group caption="Interrupt Sense Control" name="INTERRUPT_SENSE_CONTROL">
+        <value caption="Low Level of INTX" name="VAL_0x00" value="0x00"/>
+        <value caption="Any Logical Change of INTX" name="VAL_0x01" value="0x01"/>
+        <value caption="Falling Edge of INTX" name="VAL_0x02" value="0x02"/>
+        <value caption="Rising Edge of INTX" name="VAL_0x03" value="0x03"/>
+      </value-group>
+    </module>
+    <module caption="Analog-to-Digital Converter" name="ADC">
+      <register-group caption="Analog-to-Digital Converter" name="ADC">
+        <register caption="The ADC multiplexer Selection Register" name="ADMUX" offset="0x7C" size="1">
+          <bitfield caption="Reference Selection Bits" mask="0xC0" name="REFS" values="ANALOG_ADC_V_REF2"/>
+          <bitfield caption="Left Adjust Result" mask="0x20" name="ADLAR"/>
+          <bitfield caption="Analog Channel and Gain Selection Bits" mask="0x1F" name="MUX"/>
+        </register>
+        <register caption="The ADC Control and Status register" name="ADCSRA" offset="0x7A" size="1" ocd-rw="R">
+          <bitfield caption="ADC Enable" mask="0x80" name="ADEN"/>
+          <bitfield caption="ADC Start Conversion" mask="0x40" name="ADSC"/>
+          <bitfield caption="ADC Auto Trigger Enable" mask="0x20" name="ADATE"/>
+          <bitfield caption="ADC Interrupt Flag" mask="0x10" name="ADIF"/>
+          <bitfield caption="ADC Interrupt Enable" mask="0x08" name="ADIE"/>
+          <bitfield caption="ADC Prescaler Select Bits" mask="0x07" name="ADPS" values="ANALOG_ADC_PRESCALER"/>
+        </register>
+        <register caption="ADC Data Register  Bytes" name="ADC" offset="0x78" size="2" mask="0xFFFF"/>
+        <register caption="ADC Control and Status Register B" name="ADCSRB" offset="0x7B" size="1">
+          <bitfield caption="ADC High Speed Mode" mask="0x80" name="ADHSM"/>
+          <bitfield caption="ADC Auto Trigger Sources" mask="0x07" name="ADTS" values="ANALOG_ADC_AUTO_TRIGGER2"/>
+        </register>
+        <register caption="Digital Input Disable Register 1" name="DIDR0" offset="0x7E" size="1">
+          <bitfield caption="ADC7 Digital input Disable" mask="0x80" name="ADC7D"/>
+          <bitfield caption="ADC6 Digital input Disable" mask="0x40" name="ADC6D"/>
+          <bitfield caption="ADC5 Digital input Disable" mask="0x20" name="ADC5D"/>
+          <bitfield caption="ADC4 Digital input Disable" mask="0x10" name="ADC4D"/>
+          <bitfield caption="ADC3 Digital input Disable" mask="0x08" name="ADC3D"/>
+          <bitfield caption="ADC2 Digital input Disable" mask="0x04" name="ADC2D"/>
+          <bitfield caption="ADC1 Digital input Disable" mask="0x02" name="ADC1D"/>
+          <bitfield caption="ADC0 Digital input Disable" mask="0x01" name="ADC0D"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="ANALOG_ADC_V_REF2">
+        <value caption="AREF, Internal Vref turned off" name="VAL_0x00" value="0x00"/>
+        <value caption="AVCC with external capacitor at AREF pin" name="VAL_0x01" value="0x01"/>
+        <value caption="Reserved" name="VAL_0x02" value="0x02"/>
+        <value caption="Internal 2.56V Voltage Reference with external capacitor at AREF pin" name="VAL_0x03" value="0x03"/>
+      </value-group>
+      <value-group caption="" name="ANALOG_ADC_PRESCALER">
+        <value caption="2" name="VAL_0x00" value="0x00"/>
+        <value caption="2" name="VAL_0x01" value="0x01"/>
+        <value caption="4" name="VAL_0x02" value="0x02"/>
+        <value caption="8" name="VAL_0x03" value="0x03"/>
+        <value caption="16" name="VAL_0x04" value="0x04"/>
+        <value caption="32" name="VAL_0x05" value="0x05"/>
+        <value caption="64" name="VAL_0x06" value="0x06"/>
+        <value caption="128" name="VAL_0x07" value="0x07"/>
+      </value-group>
+      <value-group caption="" name="ANALOG_ADC_AUTO_TRIGGER2">
+        <value caption="Free Running mode" name="VAL_0x00" value="0x00"/>
+        <value caption="Analog Comparator" name="VAL_0x01" value="0x01"/>
+        <value caption="External Interrupt Request 0" name="VAL_0x02" value="0x02"/>
+        <value caption="Timer/Counter0 Compare Match A" name="VAL_0x03" value="0x03"/>
+        <value caption="Timer/Counter0 Overflow" name="VAL_0x04" value="0x04"/>
+        <value caption="Timer/Counter1 Compare Match B" name="VAL_0x05" value="0x05"/>
+        <value caption="Timer/Counter1 Overflow" name="VAL_0x06" value="0x06"/>
+        <value caption="Timer/Counter1 Capture Event" name="VAL_0x07" value="0x07"/>
+      </value-group>
+    </module>
+    <module caption="Analog Comparator" name="AC">
+      <register-group caption="Analog Comparator" name="AC">
+        <register caption="ADC Control and Status Register B" name="ADCSRB" offset="0x7B" size="1">
+          <bitfield caption="Analog Comparator Multiplexer Enable" mask="0x40" name="ACME"/>
+        </register>
+        <register caption="Analog Comparator Control And Status Register" name="ACSR" offset="0x50" size="1" ocd-rw="R">
+          <bitfield caption="Analog Comparator Disable" mask="0x80" name="ACD"/>
+          <bitfield caption="Analog Comparator Bandgap Select" mask="0x40" name="ACBG"/>
+          <bitfield caption="Analog Compare Output" mask="0x20" name="ACO"/>
+          <bitfield caption="Analog Comparator Interrupt Flag" mask="0x10" name="ACI"/>
+          <bitfield caption="Analog Comparator Interrupt Enable" mask="0x08" name="ACIE"/>
+          <bitfield caption="Analog Comparator Input Capture Enable" mask="0x04" name="ACIC"/>
+          <bitfield caption="Analog Comparator Interrupt Mode Select bits" mask="0x03" name="ACIS" values="ANALOG_COMP_INTERRUPT"/>
+        </register>
+        <register caption="" name="DIDR1" offset="0x7F" size="1">
+          <bitfield caption="AIN1 Digital Input Disable" mask="0x02" name="AIN1D"/>
+          <bitfield caption="AIN0 Digital Input Disable" mask="0x01" name="AIN0D"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="ANALOG_COMP_INTERRUPT">
+        <value caption="Interrupt on Toggle" name="VAL_0x00" value="0x00"/>
+        <value caption="Reserved" name="VAL_0x01" value="0x01"/>
+        <value caption="Interrupt on Falling Edge" name="VAL_0x02" value="0x02"/>
+        <value caption="Interrupt on Rising Edge" name="VAL_0x03" value="0x03"/>
+      </value-group>
+    </module>
+    <module caption="Phase Locked Loop" name="PLL">
+      <register-group caption="Phase Locked Loop" name="PLL">
+        <register caption="PLL Status and Control register" name="PLLCSR" offset="0x49" size="1">
+          <bitfield caption="PLL prescaler Bits" mask="0x1C" name="PLLP" values="PLL_INPUT_PRESCALER"/>
+          <bitfield caption="PLL Enable Bit" mask="0x02" name="PLLE"/>
+          <bitfield caption="PLL Lock Status Bit" mask="0x01" name="PLOCK"/>
+        </register>
+      </register-group>
+      <value-group caption="" name="PLL_INPUT_PRESCALER">
+        <value caption="Clock/4" name="VAL_0x03" value="0x03"/>
+        <value caption="Clock/8" name="VAL_0x05" value="0x05"/>
+      </value-group>
+    </module>
+    <module caption="USB Controller" name="USB_GLOBAL">
+      <register-group caption="USB Controller" name="USB_GLOBAL">
+        <register caption="" name="USBINT" offset="0xDA" size="1">
+          <bitfield caption="" mask="0x02" name="IDTI"/>
+          <bitfield caption="" mask="0x01" name="VBUSTI"/>
+        </register>
+        <register caption="" name="USBSTA" offset="0xD9" size="1" ocd-rw="R">
+          <bitfield caption="" mask="0x08" name="SPEED"/>
+          <bitfield caption="" mask="0x02" name="ID"/>
+          <bitfield caption="" mask="0x01" name="VBUS"/>
+        </register>
+        <register caption="USB General Control Register" name="USBCON" offset="0xD8" size="1">
+          <bitfield caption="" mask="0x80" name="USBE"/>
+          <bitfield caption="" mask="0x40" name="HOST"/>
+          <bitfield caption="" mask="0x20" name="FRZCLK"/>
+          <bitfield caption="" mask="0x10" name="OTGPADE"/>
+          <bitfield caption="" mask="0x02" name="IDTE"/>
+          <bitfield caption="" mask="0x01" name="VBUSTE"/>
+        </register>
+        <register caption="USB Hardware Configuration Register" name="UHWCON" offset="0xD7" size="1">
+          <bitfield caption="" mask="0x80" name="UIMOD"/>
+          <bitfield caption="" mask="0x40" name="UIDE"/>
+          <bitfield caption="" mask="0x10" name="UVCONE"/>
+          <bitfield caption="" mask="0x01" name="UVREGE"/>
+        </register>
+      </register-group>
+    </module>
+  </modules>
+</avr-tools-device-file>


### PR DESCRIPTION
this is the first patch in an attempt to support the teensy2 board in avr-hal.

i'm not 100% sure that i've chosen the right set of `_includes`, but i'm able to build with `make at90usb1286`.

the next patch adds the chip to avr-hal. i have a basic form of that building successfully against this modified avr-device with `features = ["at90usb1286"]` and using `avr_device::at90usb1286 as pac;` so it seems usable.

finally, i'll need to make the teensy2 board build, which will use the at90usb1286 chip.