### PR TITLE
Upgrades for svd2rust 0.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: Continuous Integration
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+      - wip
+  pull_request:
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: false
-      - name: Install Nightly Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-01-07
-          override: true
-          components: rustfmt
+          default: true
 
       # Python Dependencies
       - name: Install Python dependencies
@@ -40,29 +34,25 @@ jobs:
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: rust-tools-001
+          key: rust-tools-002
       - name: Install svd2rust
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: |
-          mkdir svd2rust
-          cd svd2rust
-          git init
-          git remote add origin https://github.com/rust-embedded/svd2rust.git
-          git fetch origin 56be78729279eeebef65110c13be8d96c0b9270f
-          git checkout FETCH_HEAD
-          cargo +stable install --path .
+        uses: actions-rs/install@v0.1
+        with:
+          crate: svd2rust
+          version: 0.19.0
       - name: Install cargo-form
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1
         with:
           crate: form
-          version: 0.7.0
+          version: 0.8.0
       - name: Install atdf2svd
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1
         with:
           crate: atdf2svd
-          version: 0.2.0
+          version: 0.3.1
       - name: Copy tools to cache directory
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
@@ -72,6 +62,14 @@ jobs:
           cp ~/.cargo/bin/atdf2svd ~/cargo-bin
       - name: Put new cargo binary directory into path
         run: echo "$HOME/cargo-bin" >> $GITHUB_PATH
+
+      - name: Install Nightly Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2021-01-07
+          override: true
+          components: rustfmt
 
       # Actual test run
       - name: Generate chip description sources

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ svd/%.svd.patched: svd/%.svd .deps/%.d
 src/devices/%/mod.full.rs: svd/%.svd.patched
 	@mkdir -p $(@D)
 	@echo -e "\tSVD2RUST\t$*"
-	@cd $(@D); svd2rust --generic_mod --target none -i $(realpath $<)
-	@mv $(@D)/lib.rs $@
+	@cd $(@D); svd2rust --generic_mod --make_mod --target none -i $(realpath $<)
+	@mv $(@D)/mod.rs $@
 	@mv $(@D)/generic.rs $(@D)/../../generic.rs
 
 src/devices/%/mod.rs: src/devices/%/mod.full.rs

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Via the feature you can select which chip you want the register specifications f
 ## Build Instructions
 The version on `crates.io` is pre-built.  The following is only necessary when trying to build this crate from source.
 
-You need to have [atdf2svd][], [svd2rust][], [form][], [rustfmt][](for the *nightly* toolchain) and [svdtools][] (>= 0.1.9) installed:
+You need to have [atdf2svd][] (= 0.3.1), [svd2rust][] (= 0.19), [form][] (>= 0.8), [rustfmt][](for the *nightly* toolchain) and [svdtools][] (>= 0.1.9) installed:
 ```bash
-cargo install atdf2svd
-cargo install svd2rust
+cargo install atdf2svd --version 0.3.1
+cargo install svd2rust --version 0.19
 cargo install form
 rustup component add --toolchain nightly rustfmt
 pip3 install --user svdtools

--- a/patch/attiny841.yaml
+++ b/patch/attiny841.yaml
@@ -38,7 +38,5 @@ TWI*:
   TWSCRB:
     TWAA:
       _replace_enum:
-        ACK_WRITE: [0, "Send ACK when TWCMD is written as 10 or 11"]
-        ACK_READ: [1, "Send ACK when TWSD is read"]
-        NACK_WRITE: [2, "Send NACK when TWCMD is written as 10 or 11"]
-        NACK_READ: [3, "Send NACK when TWSD is read"]
+        SEND_ACK: [0, "Send ACK (timing depends on `TWSME`)"]
+        SEND_NACK: [1, "Send NACK (timing depends on `TWSME`)"]


### PR DESCRIPTION
Upgrade our buildscripts, CI, and documentation for svd2rust 0.19.  This upgrade actually surfaced an error in the ATtiny841 patches which I've fixed as well.