### PR TITLE
Remove "read-only" from UDRE

### DIFF
--- a/patch/common/usart.yaml
+++ b/patch/common/usart.yaml
@@ -7,8 +7,6 @@ USART?:
         access: read-only
       FE?:
         access: read-only
-      UDRE?:
-        access: read-only
       TXC?:
         description: "USART Transmit Complete"
       RXC?:


### PR DESCRIPTION
This enables writing 0 to UDRE. This is not strictly necessary, but
the atmega328p manual suggests that it should be done whenever
writing to UCSR A. This is done for future compatibility. It should
be the same case for other AVR chips.

This will be used in an update to avr-hal.