### PR TITLE
Add support for `asm!()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ cfg-if = "0.1.10"
 path = "macros/"
 version = "=0.3.2"
 optional = true
+
+[build-dependencies]
+rustversion = "1.0"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The version on `crates.io` is pre-built.  The following is only necessary when t
 You need to have [atdf2svd][] (= 0.3.1), [svd2rust][] (= 0.19), [form][] (>= 0.8), [rustfmt][](for the *nightly* toolchain) and [svdtools][] (>= 0.1.9) installed:
 ```bash
 cargo install atdf2svd --version 0.3.1
-cargo install svd2rust --version 0.19
+cargo install svd2rust --version 0.19.0
 cargo install form
 rustup component add --toolchain nightly rustfmt
 pip3 install --user svdtools

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    maybe_enable_asm();
+}
+
+#[rustversion::before(1.59.0)]
+fn maybe_enable_asm() {
+    //
+}
+
+#[rustversion::since(1.59.0)]
+fn maybe_enable_asm() {
+    // https://github.com/rust-lang/rust/pull/92816
+    println!("cargo:rustc-cfg=avr_device_asm_macro");
+}

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1,10 +1,15 @@
 //! Assembly instructions
 
+#[cfg(all(target_arch = "avr", avr_device_asm_macro))]
+use core::arch::asm;
+
 /// No Operation
 #[inline(always)]
 pub fn nop() {
     cfg_if::cfg_if! {
-        if #[cfg(target_arch = "avr")] {
+        if #[cfg(all(target_arch = "avr", avr_device_asm_macro))] {
+            unsafe { asm!("nop") }
+        } else if #[cfg(target_arch = "avr")] {
             unsafe { llvm_asm!("nop") }
         } else {
             unimplemented!()
@@ -16,7 +21,9 @@ pub fn nop() {
 #[inline(always)]
 pub fn sleep() {
     cfg_if::cfg_if! {
-        if #[cfg(target_arch = "avr")] {
+        if #[cfg(all(target_arch = "avr", avr_device_asm_macro))] {
+            unsafe { asm!("sleep") }
+        } else if #[cfg(target_arch = "avr")] {
             unsafe { llvm_asm!("sleep") }
         } else {
             unimplemented!()
@@ -28,7 +35,9 @@ pub fn sleep() {
 #[inline(always)]
 pub fn wdr() {
     cfg_if::cfg_if! {
-        if #[cfg(target_arch = "avr")] {
+        if #[cfg(all(target_arch = "avr", avr_device_asm_macro))] {
+            unsafe { asm!("wdr") }
+        } else if #[cfg(target_arch = "avr")] {
             unsafe { llvm_asm!("wdr") }
         } else {
             unimplemented!()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@
 //! * `attiny861`
 //! * `attiny88`
 #![no_std]
-#![feature(llvm_asm)]
+#![cfg_attr(avr_device_asm_macro, feature(asm_experimental_arch))]
+#![cfg_attr(not(avr_device_asm_macro), feature(llvm_asm))]
 
 pub mod asm;
 pub mod interrupt;
@@ -167,10 +168,10 @@ pub use crate::devices::atmega644;
 pub use crate::devices::atmega8;
 #[cfg(feature = "atmega8u2")]
 pub use crate::devices::atmega8u2;
-#[cfg(feature = "attiny167")]
-pub use crate::devices::attiny167;
 #[cfg(feature = "attiny1614")]
 pub use crate::devices::attiny1614;
+#[cfg(feature = "attiny167")]
+pub use crate::devices::attiny167;
 #[cfg(feature = "attiny202")]
 pub use crate::devices::attiny202;
 #[cfg(feature = "attiny2313")]


### PR DESCRIPTION
Closes https://github.com/Rahix/avr-device/issues/91.

# Abstract

Starting from 1.59.0, rustc has been removed support for the `llvm_asm!()` macro, making it impossible to use `avr-device` with newer compilers.

This merge requests adjusts the code, so that it continues to use `llvm_asm!()` on older compilers (such as the infamous `nightly-2021-01-07`), but switches to `asm!()` on the newer ones.

# Due Diligence

I've checked the code on `nightly-2021-01-07` and a custom-built `rustc` from around yesterday (`b759b2218649016cc40e82bdd6d958e2277ff6d7`), and everything seems to be working correctly.

I've compared the generated LLVM IRs for an application I'm developing, and they are virtually identical:

`enable()`:
```
older rustc:
  tail call addrspace(0) void asm sideeffect "sei", ""() #10, !srcloc !5

newer rustc:
  tail call addrspace(0) void asm sideeffect alignstack "sei", "~{sreg},~{memory}"() #14, !srcloc !6
```

`disable()`:
```
older rustc:
  %0 = tail call addrspace(0) i8 asm sideeffect "in $0,0x3F", "=r"() #10, !srcloc !2
  tail call addrspace(0) void asm sideeffect "cli", ""() #10, !srcloc !3

newer rustc:
  %1 = tail call addrspace(0) i8 asm sideeffect alignstack "in ${0}, 0x3F", "=&r,~{sreg},~{memory}"() #14, !srcloc !2
  tail call addrspace(0) void asm sideeffect alignstack "cli", "~{sreg},~{memory}"() #14, !srcloc !3
```

The compiled binary seems to be working correctly on an Atmega328p, too.

# Follow-ups

I've also got a similar set of changes to `avr-hal`, I'll try pushing the merge request in a few minutes :-)