### PR TITLE
Use the same timer patch for atmega1280 as for atmega2560

### DIFF
--- a/patch/atmega1280.yaml
+++ b/patch/atmega1280.yaml
@@ -7,3 +7,5 @@ _include:
   - "common/twi.yaml"
   - "common/usart.yaml"
   - "common/wdt.yaml"
+
+  - "timer/atmega1280-2560.yaml"

--- a/patch/atmega2560.yaml
+++ b/patch/atmega2560.yaml
@@ -8,4 +8,4 @@ _include:
   - "common/usart.yaml"
   - "common/wdt.yaml"
 
-  - "timer/atmega2560.yaml"
+  - "timer/atmega1280-2560.yaml"

--- a/patch/timer/atmega1280-2560.yaml
+++ b/patch/timer/atmega1280-2560.yaml
@@ -1,0 +1,14 @@
+# This intermediate file is needed because peripheral-level includes are not
+# supported in top-level files.
+
+TC0:
+  _include:
+    - "dev/8bit.yaml"
+
+TC1,TC3,TC4,TC5:
+  _include:
+    - "dev/16bit.yaml"
+
+TC2:
+  _include:
+    - "dev/8bit-async.yaml"


### PR DESCRIPTION
It seems like the timer patch for the atmega2560 is applicable for the atmega1280 as well, unless I'm mistaken.

I stumbled over the lack of timer patches for the atmega1280 while working on https://github.com/Rahix/avr-hal/pull/272 , this PR should fix this by using the same patch for the 1280 as for the 2560.

As far as I can tell the only difference between the two MCU's seems to be the amount of flash memory available(?).