### PR TITLE
Adds patches for the timers on attiny167

### DIFF
--- a/patch/attiny167.yaml
+++ b/patch/attiny167.yaml
@@ -7,9 +7,7 @@ _include:
 #  - "common/twi.yaml"
   - "common/wdt.yaml"
   - "common/tiny/usi.yaml"
-
- 
-#  - "timer/attiny88.yaml"
+  - "timer/attiny167.yaml"
 
 ADC:
   ADMUX:

--- a/patch/timer/attiny167.yaml
+++ b/patch/timer/attiny167.yaml
@@ -1,0 +1,14 @@
+# This intermediate file is needed because peripheral-level includes are not
+# supported in top-level files.
+
+_modify:
+  TC1:
+    description: "Timer/Counter1, 16-bit, PWM"
+
+TC0:
+  _include:
+    - "dev/8bit-tiny167.yaml"
+
+TC1:
+  _include:
+    - "dev/16bit.yaml"

--- a/patch/timer/dev/8bit-tiny167.yaml
+++ b/patch/timer/dev/8bit-tiny167.yaml
@@ -1,0 +1,15 @@
+TCCR?B:
+  _modify:
+    CS?:
+      _write_constraint: enum
+
+  CS?:
+    _replace_enum:
+      NO_CLOCK:      [0, "No clock source (Timer/Counter stopped)"]
+      DIRECT:        [1, "Running, No Prescaling"]
+      PRESCALE_8:    [2, "Running, CLK/8"]
+      PRESCALE_32:   [3, "Running, CLK/32"]
+      PRESCALE_64:   [4, "Running, CLK/64"]
+      PRESCALE_128:  [5, "Running, CLK/128"]
+      PRESCALE_256:  [6, "Running, CLK/256"]
+      PRESCALE_1024: [7, "Running, CLK/1024"]


### PR DESCRIPTION
Adds patches for TC0 and TC1 on the attiny167 so that prescaler values (and the `COMnx` register values) can be set by human readable methods (`.prescale_64()` instead of `.val_0x03()` for example).