### PR TITLE
Cargo.toml: Update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "avr-device"
 version = "0.3.4"
 
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 description = "Register access crate for AVR microcontrollers"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Rahix/avr-device"


### PR DESCRIPTION
We have recently (#104) dropped support for compilers that don't support edition 2021.
This PR makes this explicit up enforcing edition 2021 in Cargo.toml.