### PR TITLE
Small documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Auto-generated wrappers around registers for AVR microcontrollers.
 Add the following to `Cargo.toml`:
 ```toml
 [dependencies.avr-device]
-version = "0.3.4"
+version = "0.4.0"
 features = ["atmega32u4"]
 ```
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -3,7 +3,7 @@ name = "avr-device-macros"
 version = "0.4.0"
 
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 description = "Attribute macros for re-export in `avr-device`"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Rahix/avr-device"

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -18,14 +18,16 @@
 //! // Use RefCell, if the wrapped type is not Copy or if you need a reference to it for other reasons.
 //! static MYGLOBAL: Mutex<Cell<u16>> = Mutex::new(Cell::new(0));
 //!
-//! avr_device::interrupt::free(|cs| {
-//!     // Interrupts are disabled here
+//! fn my_fun() {
+//!     avr_device::interrupt::free(|cs| {
+//!         // Interrupts are disabled here
 //!
-//!     // Acquire mutex to global variable.
-//!     let myglobal_ref = MYGLOBAL.borrow(&cs);
-//!     // Write to the global variable.
-//!     myglobal_ref.set(42);
-//! });
+//!         // Acquire mutex to global variable.
+//!         let myglobal_ref = MYGLOBAL.borrow(cs);
+//!         // Write to the global variable.
+//!         myglobal_ref.set(42);
+//!     });
+//! }
 //! ```
 
 pub use bare_metal::{CriticalSection, Mutex};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@
 //! * Device selection: To enable your device, select the crate feature that matches your device.
 //!   For a full list of supported devices, see the list at the beginning of this documentation.
 //! * To enable the crate's runtime environment, use the `rt` feature.
+//! * To enable `ufmt` formatting (e.g. `uDebug`), use the `ufmt` feature.
 
 #![no_std]
 #![cfg_attr(target_arch = "avr", feature(asm_experimental_arch))] // for experimental AVR asm! macro.


### PR DESCRIPTION
Some minor fixes, that slipped through before release.

* Mutex::borrow() cs parameter is not a reference (in new bare-metal).
* Mutex example: Use proper code in a function body that would actually compile.
* Document the `ufmt` feature.
* Cargo example version

Shall we also bump the macros edition to 2021?