### PR TITLE
Add patches for ATmega8

### DIFF
--- a/patch/atmega8.yaml
+++ b/patch/atmega8.yaml
@@ -78,7 +78,7 @@ WDT:
     WDPL:
       CYCLES_16K:      [0, "- 16K (16384) cycles, ~16ms"]
       CYCLES_32K:      [1, "- 32K (32768) cycles, ~32ms"]
-      CYCLES_64K:      [2, "- 64K (65536) cycles, ~65s"]
+      CYCLES_64K:      [2, "- 64K (65536) cycles, ~65ms"]
       CYCLES_128K:     [3, "- 128K (131072) cycles, ~0.13s"]
       CYCLES_256K:     [4, "- 256K (262144) cycles, ~0.26s"]
       CYCLES_512K:     [5, "- 512K (524288) cycles, ~0.52s"]

--- a/patch/atmega8.yaml
+++ b/patch/atmega8.yaml
@@ -1,1 +1,86 @@
 _svd: ../svd/atmega8.svd
+
+_include:
+  - "common/ac.yaml"
+  - "common/adc.yaml"
+  - "common/spi.yaml"
+
+  - "timer/atmega8.yaml"
+
+TWI:
+  TWCR:
+    _modify:
+      TWWC:
+        access: read-only
+  TWSR:
+    _modify:
+      TWS:
+        access: read-only
+    TWPS:
+      _replace_enum:
+        PRESCALER_1: [0, "Prescaler Value 1"]
+        PRESCALER_4: [1, "Prescaler Value 4"]
+        PRESCALER_16: [2, "Prescaler Value 16"]
+        PRESCALER_64: [3, "Prescaler Value 64"]
+
+USART:
+  UCSRA:
+    _modify:
+      PE:
+        access: read-only
+      DOR:
+        access: read-only
+      FE:
+        access: read-only
+      UDRE:
+        access: read-only
+      TXC:
+        description: "USART Transmit Complete"
+      RXC:
+        access: read-only
+  UCSRB:
+    _modify:
+      RXB8:
+        access: read-only
+  UCSRC:
+    UMSEL:
+      _replace_enum:
+        USART_ASYNC: [0, "Asynchronous USART"]
+        USART_SYNC:  [1, "Synchronous USART"]
+    UPM:
+      _replace_enum:
+        DISABLED:    [0, "Disabled"]
+        PARITY_EVEN: [2, "Enabled, Even Parity"]
+        PARITY_ODD:  [3, "Enabled, Odd Parity"]
+    USBS:
+      _replace_enum:
+        STOP1: [0, "1-bit"]
+        STOP2: [1, "2-bit"]
+    UCSZ:
+      _replace_enum:
+        CHR5: [0, "Character Size: 5 bit"]
+        CHR6: [1, "Character Size: 6 bit"]
+        CHR7: [2, "Character Size: 7 bit"]
+        CHR8: [3, "Character Size: 8 bit"]
+    UCPOL:
+      _replace_enum:
+        RISING_EDGE:  [0, "Transmit on Rising XCK Edge, Receive on Falling XCK Edge"]
+        FALLING_EDGE: [1, "Transmit on Falling XCK Edge, Receive on Rising XCK Edge"]
+
+WDT:
+  WDTCR:
+    _delete:
+      - WDP
+    _add:
+      WDPL:
+        description: "Watchdog Timer Prescaler - Low Bits"
+        bitRange: "[2:0]"
+    WDPL:
+      CYCLES_16K:      [0, "- 16K (16384) cycles, ~16ms"]
+      CYCLES_32K:      [1, "- 32K (32768) cycles, ~32ms"]
+      CYCLES_64K:      [2, "- 64K (65536) cycles, ~65s"]
+      CYCLES_128K:     [3, "- 128K (131072) cycles, ~0.13s"]
+      CYCLES_256K:     [4, "- 256K (262144) cycles, ~0.26s"]
+      CYCLES_512K:     [5, "- 512K (524288) cycles, ~0.52s"]
+      CYCLES_1024K:     [6, "- 1024K (1048576) cycles, ~1.0s"]
+      CYCLES_2048K:     [7, "- 2048K (2097152) cycles, ~2.1s"]

--- a/patch/atmega8.yaml
+++ b/patch/atmega8.yaml
@@ -23,6 +23,21 @@ TWI:
         PRESCALER_16: [2, "Prescaler Value 16"]
         PRESCALER_64: [3, "Prescaler Value 64"]
 
+ADC:
+  ADMUX:
+    MUX:
+      _replace_enum:
+        ADC0: [0, "ADC Single Ended Input pin 0"]
+        ADC1: [1, "ADC Single Ended Input pin 1"]
+        ADC2: [2, "ADC Single Ended Input pin 2"]
+        ADC3: [3, "ADC Single Ended Input pin 3"]
+        ADC4: [4, "ADC Single Ended Input pin 4"]
+        ADC5: [5, "ADC Single Ended Input pin 5"]
+        ADC6: [6, "ADC Single Ended Input pin 6"]
+        ADC7: [7, "ADC Single Ended Input pin 7"]
+        ADC_VBG: [14, "Internal Reference (VBG)"]
+        ADC_GND: [15, "0V (GND)"]
+
 USART:
   UCSRA:
     _modify:

--- a/patch/timer/atmega8.yaml
+++ b/patch/timer/atmega8.yaml
@@ -1,0 +1,14 @@
+# This intermediate file is needed because peripheral-level includes are not
+# supported in top-level files.
+
+TC0:
+  _include:
+    - "dev/8bit-mega8.yaml"
+
+TC1:
+  _include:
+    - "dev/16bit-mega8.yaml"
+
+TC2:
+  _include:
+    - "dev/8bit-async-mega8.yaml"

--- a/patch/timer/dev/16bit-mega8.yaml
+++ b/patch/timer/dev/16bit-mega8.yaml
@@ -11,9 +11,9 @@ TCCR?A:
   COM??:
     _replace_enum:
         DISCONNECTED:  [0, "Normal port operation, OCix disconnected"]
-        MATCH_TOGGLE:  [1, "Toggle OCix on Compare Match (Might depend on WGM)"]
-        MATCH_CLEAR:   [2, "Clear OCix on Compare Match (If PWM is enabled, OCix is set at BOTTOM)"]
-        MATCH_SET:     [3, "Set OCix on Compare Match (If PWM is enabled, OCix is cleared at BOTTOM)"]
+        MATCH_TOGGLE:  [1, "Toggle OC1x on Compare Match (Might depend on WGM)"]
+        MATCH_CLEAR:   [2, "Clear OC1x on Compare Match (If PWM is enabled, OC1x is set at BOTTOM)"]
+        MATCH_SET:     [3, "Set OC1x on Compare Match (If PWM is enabled, OC1x is cleared at BOTTOM)"]
 
 TCCR?B:
   _modify:

--- a/patch/timer/dev/16bit-mega8.yaml
+++ b/patch/timer/dev/16bit-mega8.yaml
@@ -1,0 +1,31 @@
+TCCR?A:
+  _modify:
+    COM?A:
+      description: "Compare Output A Mode"
+      _write_constraint: enum
+    COM?B:
+      description: "Compare Output B Mode"
+      _write_constraint: enum
+    FOC??:
+      access: write-only
+  COM??:
+    _replace_enum:
+        DISCONNECTED:  [0, "Normal port operation, OCix disconnected"]
+        MATCH_TOGGLE:  [1, "Toggle OCix on Compare Match (Might depend on WGM)"]
+        MATCH_CLEAR:   [2, "Clear OCix on Compare Match (If PWM is enabled, OCix is set at BOTTOM)"]
+        MATCH_SET:     [3, "Set OCix on Compare Match (If PWM is enabled, OCix is cleared at BOTTOM)"]
+
+TCCR?B:
+  _modify:
+    CS?:
+      _write_constraint: enum
+  CS?:
+    _replace_enum:
+      NO_CLOCK:      [0, "No clock source (Timer/Counter stopped)"]
+      DIRECT:        [1, "Running, No Prescaling"]
+      PRESCALE_8:    [2, "Running, CLK/8"]
+      PRESCALE_64:   [3, "Running, CLK/64"]
+      PRESCALE_256:  [4, "Running, CLK/256"]
+      PRESCALE_1024: [5, "Running, CLK/1024"]
+      EXT_FALLING:   [6, "Running, ExtClk Tx Falling Edge"]
+      EXT_RISING:    [7, "Running, ExtClk Tx Rising Edge"]

--- a/patch/timer/dev/8bit-async-mega8.yaml
+++ b/patch/timer/dev/8bit-async-mega8.yaml
@@ -2,8 +2,6 @@ TCCR?:
   _modify:
     COM?:
       _write_constraint: enum
-    WGM?:
-      _write_constraint: enum
     FOC?:
       access: write-only
   COM?:
@@ -11,16 +9,6 @@ TCCR?:
       DISCONNECTED:  [0, "Normal port operation, OC2 disconnected"]
       MATCH_CLEAR:   [2, "Clear OC2 on Compare Match (If PWM is enabled, OC2 is set at BOTTOM)"]
       MATCH_SET:     [3, "Set OC2 on Compare Match (If PWM is enabled, OC2 is cleared at BOTTOM)"]
-  WGM?:
-    _replace_enum:
-      # NOTE that the WGMs are in reverse order in the reigster
-      # (WGM20 is at position 6, WGM21 is at position 3), thus
-      # the numbering here is not the same as in datasheet
-      # where it is specified for WGM21 WGM20
-      NORMAL_TOP:    [0, "Normal, Top: `0xff`, Update: *Immediate*, Flag: *MAX*"]
-      PWM_PHASE:     [2, "Phase Correct PWM, Top: `0xff`, Update: *TOP*, Flag: *BOTTOM*"]
-      CTC:           [1, "CTC, Top: *OCR2*, Update: *Immediate*, Flag: *MAX*"]
-      PWM_FAST:      [3, "Fast PWM, Top: `0xff`, Update: *BOTTOM*, Flag: *MAX*"]
   CS?:
     _replace_enum:
       NO_CLOCK:      [0, "No clock source (Timer/Counter stopped)"]

--- a/patch/timer/dev/8bit-async-mega8.yaml
+++ b/patch/timer/dev/8bit-async-mega8.yaml
@@ -13,9 +13,13 @@ TCCR?:
       MATCH_SET:     [3, "Set OC2 on Compare Match (If PWM is enabled, OC2 is cleared at BOTTOM)"]
   WGM?:
     _replace_enum:
+      # NOTE that the WGMs are in reverse order in the reigster
+      # (WGM20 is at position 6, WGM21 is at position 3), thus
+      # the numbering here is not the same as in datasheet
+      # where it is specified for WGM21 WGM20
       NORMAL_TOP:    [0, "Normal, Top: `0xff`, Update: *Immediate*, Flag: *MAX*"]
-      PWM_PHASE:     [1, "Phase Correct PWM, Top: `0xff`, Update: *TOP*, Flag: *BOTTOM*"]
-      CTC:           [2, "CTC, Top: *OCR2*, Update: *Immediate*, Flag: *MAX*"]
+      PWM_PHASE:     [2, "Phase Correct PWM, Top: `0xff`, Update: *TOP*, Flag: *BOTTOM*"]
+      CTC:           [1, "CTC, Top: *OCR2*, Update: *Immediate*, Flag: *MAX*"]
       PWM_FAST:      [3, "Fast PWM, Top: `0xff`, Update: *BOTTOM*, Flag: *MAX*"]
   CS?:
     _replace_enum:

--- a/patch/timer/dev/8bit-async-mega8.yaml
+++ b/patch/timer/dev/8bit-async-mega8.yaml
@@ -1,0 +1,29 @@
+TCCR?:
+  _modify:
+    COM?:
+      _write_constraint: enum
+    WGM?:
+      _write_constraint: enum
+    FOC?:
+      access: write-only
+  COM?:
+    _replace_enum:
+      DISCONNECTED:  [0, "Normal port operation, OC2 disconnected"]
+      MATCH_CLEAR:   [2, "Clear OC2 on Compare Match (If PWM is enabled, OC2 is set at BOTTOM)"]
+      MATCH_SET:     [3, "Set OC2 on Compare Match (If PWM is enabled, OC2 is cleared at BOTTOM)"]
+  WGM?:
+    _replace_enum:
+      NORMAL_TOP:    [0, "Normal, Top: `0xff`, Update: *Immediate*, Flag: *MAX*"]
+      PWM_PHASE:     [1, "Phase Correct PWM, Top: `0xff`, Update: *TOP*, Flag: *BOTTOM*"]
+      CTC:           [2, "CTC, Top: *OCR2*, Update: *Immediate*, Flag: *MAX*"]
+      PWM_FAST:      [3, "Fast PWM, Top: `0xff`, Update: *BOTTOM*, Flag: *MAX*"]
+  CS?:
+    _replace_enum:
+      NO_CLOCK:      [0, "No clock source (Timer/Counter stopped)"]
+      DIRECT:        [1, "Running, No Prescaling"]
+      PRESCALE_8:    [2, "Running, CLK/8"]
+      PRESCALE_32:   [3, "Running, CLK/32"]
+      PRESCALE_64:   [4, "Running, CLK/64"]
+      PRESCALE_128:  [5, "Running, CLK/128"]
+      PRESCALE_256:  [6, "Running, CLK/256"]
+      PRESCALE_1024: [7, "Running, CLK/1024"]

--- a/patch/timer/dev/8bit-mega8.yaml
+++ b/patch/timer/dev/8bit-mega8.yaml
@@ -1,0 +1,11 @@
+TCCR?:
+  CS0:
+    _replace_enum:
+      NO_CLOCK:      [0, "No clock source (Timer/Counter stopped)"]
+      DIRECT:        [1, "Running, No Prescaling"]
+      PRESCALE_8:    [2, "Running, CLK/8"]
+      PRESCALE_64:   [3, "Running, CLK/64"]
+      PRESCALE_256:  [4, "Running, CLK/256"]
+      PRESCALE_1024: [5, "Running, CLK/1024"]
+      EXT_FALLING:   [6, "Running, ExtClk Tx Falling Edge"]
+      EXT_RISING:    [7, "Running, ExtClk Tx Rising Edge"]

--- a/patch/timer/dev/8bit-mega8.yaml
+++ b/patch/timer/dev/8bit-mega8.yaml
@@ -1,4 +1,12 @@
 TCCR?:
+  _delete:
+    - CS00
+    - CS01
+    - CS02
+  _add:
+    CS0:
+      description: "Clock Select 0"
+      bitRange: "[2:0]"
   CS0:
     _replace_enum:
       NO_CLOCK:      [0, "No clock source (Timer/Counter stopped)"]

--- a/vendor/atmega8.atdf
+++ b/vendor/atmega8.atdf
@@ -557,7 +557,9 @@
           <bitfield caption="Timer/Counter0 Overflow Flag" mask="0x01" name="TOV0"/>
         </register>
         <register caption="Timer/Counter0 Control Register" name="TCCR0" offset="0x53" size="1">
-          <bitfield caption="Clock Select0 bit 0" mask="0x07" name="CS0" values="CLK_SEL_3BIT_EXT"/>
+          <bitfield caption="Clock Select0 bit 2" mask="0x04" name="CS02"/>
+          <bitfield caption="Clock Select0 bit 1" mask="0x02" name="CS01"/>
+          <bitfield caption="Clock Select0 bit 0" mask="0x01" name="CS00" values="CLK_SEL_3BIT_EXT"/>
         </register>
         <register caption="Timer Counter 0" name="TCNT0" offset="0x52" size="1" mask="0xFF"/>
       </register-group>

--- a/vendor/atmega8.atdf
+++ b/vendor/atmega8.atdf
@@ -557,9 +557,7 @@
           <bitfield caption="Timer/Counter0 Overflow Flag" mask="0x01" name="TOV0"/>
         </register>
         <register caption="Timer/Counter0 Control Register" name="TCCR0" offset="0x53" size="1">
-          <bitfield caption="Clock Select0 bit 2" mask="0x04" name="CS02"/>
-          <bitfield caption="Clock Select0 bit 1" mask="0x02" name="CS01"/>
-          <bitfield caption="Clock Select0 bit 0" mask="0x01" name="CS00" values="CLK_SEL_3BIT_EXT"/>
+          <bitfield caption="Clock Select0 bit 0" mask="0x07" name="CS0" values="CLK_SEL_3BIT_EXT"/>
         </register>
         <register caption="Timer Counter 0" name="TCNT0" offset="0x52" size="1" mask="0xFF"/>
       </register-group>
@@ -629,9 +627,8 @@
         </register>
         <register caption="Timer/Counter2 Control Register" name="TCCR2" offset="0x45" size="1">
           <bitfield caption="Force Output Compare" mask="0x80" name="FOC2"/>
-          <bitfield caption="Waveform Genration Mode" mask="0x40" name="WGM20" values="WAVEFORM_GEN_MODE"/>
+          <bitfield caption="Waveform Genration Mode" mask="0x48" name="WGM2" values="WAVEFORM_GEN_MODE"/>
           <bitfield caption="Compare Output Mode bits" mask="0x30" name="COM2"/>
-          <bitfield caption="Waveform Generation Mode" mask="0x08" name="WGM21"/>
           <bitfield caption="Clock Select bits" mask="0x07" name="CS2" values="CLK_SEL_3BIT"/>
         </register>
         <register caption="Timer/Counter2" name="TCNT2" offset="0x44" size="1" mask="0xFF"/>

--- a/vendor/atmega8.atdf
+++ b/vendor/atmega8.atdf
@@ -629,8 +629,9 @@
         </register>
         <register caption="Timer/Counter2 Control Register" name="TCCR2" offset="0x45" size="1">
           <bitfield caption="Force Output Compare" mask="0x80" name="FOC2"/>
-          <bitfield caption="Waveform Genration Mode" mask="0x48" name="WGM2" values="WAVEFORM_GEN_MODE"/>
+          <bitfield caption="Waveform Genration Mode" mask="0x40" name="WGM20" values="WAVEFORM_GEN_MODE"/>
           <bitfield caption="Compare Output Mode bits" mask="0x30" name="COM2"/>
+          <bitfield caption="Waveform Generation Mode" mask="0x08" name="WGM21"/>
           <bitfield caption="Clock Select bits" mask="0x07" name="CS2" values="CLK_SEL_3BIT"/>
         </register>
         <register caption="Timer/Counter2" name="TCNT2" offset="0x44" size="1" mask="0xFF"/>


### PR DESCRIPTION
This PR adds patches for ATmega8 needed to implement ATMega8 to avr-hal easily.

Unfortunately I had to edit the vendor file, because there is a field WGM2 consisting of WGM21 and WGM20 that are not directly next to each other. Any idea on how to patch this correctly?