### PR TITLE
Add implementation for critical-section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ attiny88 = ["device-selected"]
 attiny1614 = ["device-selected"]
 rt = ["avr-device-macros"]
 
+critical-section-impl = ["critical-section/restore-state-u8"]
+
 # Unfortunately, we can only build documentation for a subset of the supported
 # MCUs on docs.rs.  If you think a very popular chip is missing from the list,
 # feel free to add it here.
@@ -64,6 +66,7 @@ bare-metal = "1.0.0"
 vcell = "0.1.2"
 cfg-if = "1.0.0"
 ufmt = { version = "0.2.0", optional = true }
+critical-section = { version = "1.1.1", optional = true }
 
 [dependencies.avr-device-macros]
 path = "macros/"


### PR DESCRIPTION
Due to the changed design of the `critical-section` crate, we now have to provide an implementation over here.

Add a `critical-section-impl` feature flag which can be used to enable the implementation.