### PR TITLE
Add asm::delay_cycles

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -38,3 +38,47 @@ pub fn wdr() {
         }
     }
 }
+
+/// Blocks the program for at least `cycles` CPU cycles.
+///
+/// This is intended for very simple delays in low-level drivers, but it
+/// has some caveats:
+///
+/// - The delay may be significantly longer if an interrupt is serviced at the
+/// same time, since the delay loop will not be executing during the interrupt.
+/// If you need precise timing, use a hardware timer peripheral instead.
+///
+/// - The real-time delay depends on the CPU clock frequency. If you want to
+/// conveniently specify a delay value in real-time units like microseconds,
+/// then use the `delay` module in the HAL crate for your platform.
+#[inline(always)]
+pub fn delay_cycles(cycles: u32) {
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            let mut cycles_bytes = cycles.to_le_bytes();
+            // Each loop iteration takes 6 cycles when the branch is taken,
+            // and 5 cycles when the branch is not taken.
+            // So, this loop is guaranteed to run for at least `cycles - 1`
+            // cycles, and there will be approximately 4 cycles before the
+            // loop to initialize the counting registers.
+            unsafe {
+                asm!(
+                    "1:",
+                    "subi {r0}, 6",
+                    "sbci {r1}, 0",
+                    "sbci {r2}, 0",
+                    "sbci {r3}, 0",
+                    "brcc 1b",
+
+                    r0 = inout(reg_upper) cycles_bytes[0],
+                    r1 = inout(reg_upper) cycles_bytes[1],
+                    r2 = inout(reg_upper) cycles_bytes[2],
+                    r3 = inout(reg_upper) cycles_bytes[3],
+                )
+            }
+        } else {
+            let _ = cycles;
+            unimplemented!()
+        }
+    }
+}


### PR DESCRIPTION
This is a counterpart to `cortex_m::asm::delay` but for AVR.

It is intended for very simple delays in low-level drivers that don't require precision or real-time accuracy.

In those situations, it provides these benefits over the alternatives:

- Compared to `Delay` from avr-hal, this dependency is more convenient; Sometimes it is not desired or not even possible to depend on avr-hal, and also the driver does not need to know the CPU clock frequency (if it doesn't care about 16x longer delays at 1MHz vs 16MHz).

- Compared to using hardware timers, this doesn't require ownership of any system resources, leaving more for the end user.