### PR TITLE
Patch attiny85 PCMSK register

### DIFF
--- a/patch/attiny85.yaml
+++ b/patch/attiny85.yaml
@@ -99,6 +99,10 @@ CPU:
       PLOCK:
         access: read-only
 EXINT:
+  # This doesn't work:
+  # _modify:
+  #   PCMSK:
+  #     _write_constraint: [0, 63]
   PCMSK:
     _add:
       PCINT0:

--- a/patch/attiny85.yaml
+++ b/patch/attiny85.yaml
@@ -98,3 +98,36 @@ CPU:
     _modify:
       PLOCK:
         access: read-only
+EXINT:
+  PCMSK:
+    _add:
+      PCINT0:
+        description: Enable pin change interrupt on pin 0
+        bitOffset: 0
+        bitWidth: 1
+        access: read-write
+      PCINT1:
+        description: Enable pin change interrupt on pin 1
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write
+      PCINT2:
+        description: Enable pin change interrupt on pin 2
+        bitOffset: 2
+        bitWidth: 1
+        access: read-write
+      PCINT3:
+        description: Enable pin change interrupt on pin 3
+        bitOffset: 3
+        bitWidth: 1
+        access: read-write
+      PCINT4:
+        description: Enable pin change interrupt on pin 4
+        bitOffset: 4
+        bitWidth: 1
+        access: read-write
+      PCINT5:
+        description: Enable pin change interrupt on pin 5
+        bitOffset: 5
+        bitWidth: 1
+        access: read-write


### PR DESCRIPTION
Fix https://github.com/Rahix/avr-device/issues/130 by adding fields for pins where the pin change interrupt can be enabled. I.e. it is possible to use this

``` rust
self.exint.pcmsk.modify(|_, w| w.pcint0().set_bit());
```
instead of this:
``` rust 
self.exint.pcmsk.modify(|_, w| w.bits(1));
```

Since the two most significant bits of PCMSK on the attiny85 are reserved, it would make sense to change the write constraint to `[0, 63]`, but I failed to achieve this. the code is commented in commit https://github.com/Rahix/avr-device/commit/78b331fd41c9228ba10e3354f5c7d1482eae47e0 . Because of this, the PR is still a draft.