### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ cargo install svd2rust --version 0.28.0
 cargo install form
 rustup component add --toolchain nightly rustfmt
 pip3 install --user svdtools
+
+# check svdtools
+svd --version
+# if a "command not found" error is printed instead of a version,
+# either svdtools is installed incorrectly, or its installation path is missing from the PATH variable.
+# Temporary solution to PATH variable issue is to manually add the path. Like so:
+export PATH=$PATH:~/.local/bin
 ```
 
 [atdf2svd]: https://github.com/Rahix/atdf2svd

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -119,7 +119,8 @@ pub fn interrupt(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let mut f: syn::ItemFn = syn::parse(input).expect("`#[interrupt]` must be applied to a function");
+    let mut f: syn::ItemFn =
+        syn::parse(input).expect("`#[interrupt]` must be applied to a function");
     let args: Vec<_> = args.into_iter().collect();
 
     let fspan = f.span();
@@ -176,17 +177,25 @@ pub fn interrupt(
         Ok(x) => x,
     };
 
-    f.sig.ident = syn::Ident::new(&format!("__avr_device_rt_{}", f.sig.ident), proc_macro2::Span::call_site());
+    f.sig.ident = syn::Ident::new(
+        &format!("__avr_device_rt_{}", f.sig.ident),
+        proc_macro2::Span::call_site(),
+    );
     f.sig.inputs.extend(statics.iter().map(|statik| {
         let ident = &statik.ident;
         let ty = &statik.ty;
         let attrs = &statik.attrs;
-        syn::parse::<syn::FnArg>(quote::quote!(#[allow(non_snake_case)] #(#attrs)* #ident: &mut #ty).into())
-            .unwrap()
+        syn::parse::<syn::FnArg>(
+            quote::quote!(#[allow(non_snake_case)] #(#attrs)* #ident: &mut #ty).into(),
+        )
+        .unwrap()
     }));
     f.block.stmts = stmts;
 
-    let tramp_ident = syn::Ident::new(&format!("{}_trampoline", f.sig.ident), proc_macro2::Span::call_site());
+    let tramp_ident = syn::Ident::new(
+        &format!("{}_trampoline", f.sig.ident),
+        proc_macro2::Span::call_site(),
+    );
     let ident = &f.sig.ident;
 
     let resource_args = statics

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -3,7 +3,6 @@
 #[no_mangle]
 pub(crate) static mut DEVICE_PERIPHERALS: bool = false;
 
-
 /// [AT90USB1286](https://www.microchip.com/wwwproducts/en/AT90USB1286)
 #[cfg(feature = "at90usb1286")]
 pub mod at90usb1286;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,9 @@ pub use avr_device_macros::interrupt;
 /// ```
 /// #[avr_device::entry]
 /// fn main() -> ! {
-///     // ...
+///     loop {
+///         // ...
+///     }
 /// }
 /// ```
 ///


### PR DESCRIPTION
Hey!

I have few minor suggestions at your trial)

1. My IDE (PyCharm) complains about docstring example in entry point's docstring. Technically, since `main` function annotated with `!`, linter expects an infinite loop in it. That's the change.
2. Code-style improvements:
    1. Line length complains. Few lines are longer than 100 chars.
    2. There is a redundant blank line in one place, according to `rustfmt`.
3. During my work with this crate, few times I forgot that `svdtools` might deserve a special handling. Without it `Makefile` commands wouldn't work. Tracing back this issue is time consuming. I'd suggest to add an additional step to `README.md` to check that `svdtools` actually installed correctly.