### PR TITLE
ATtiny828: Fix ADC reference voltage variant name

### DIFF
--- a/patch/attiny828.yaml
+++ b/patch/attiny828.yaml
@@ -33,7 +33,7 @@ ADC:
   ADMUXB:
     REFS:
       _replace_enum:
-        AREF: [0, "Aref Internal Vref turned off"]
+        VCC: [0, "Vcc used as analog reference"]
         INTERNAL: [1, "Internal 1.1V Voltage Reference"]
 
 CPU:


### PR DESCRIPTION
Hey!

Am currently working on a PR to add ATtiny828 to `avr-hal`. Just found out that I previously used a wrong name for an ADC ref voltage variant.

My bad, sorry for the inconvenience.