### PR TITLE
attiny2313{,a}: Add missing pin fields

### DIFF
--- a/patch/attiny2313-common.yaml
+++ b/patch/attiny2313-common.yaml
@@ -26,3 +26,243 @@ CPU:
         PRESCALER_64: [6, "Prescaler Value 64"]
         PRESCALER_128: [7, "Prescaler Value 128"]
         PRESCALER_256: [8, "Prescaler Value 256"]
+
+PORTA:
+  DDRA:
+    _add:
+      PA0:
+        description: "Pin A0"
+        bitRange: "[0:0]"
+        access: read-write
+      PA1:
+        description: "Pin A1"
+        bitRange: "[1:1]"
+        access: read-write
+      PA2:
+        description: "Pin A2"
+        bitRange: "[2:2]"
+        access: read-write
+  PINA:
+    _add:
+      PA0:
+        description: "Pin A0"
+        bitRange: "[0:0]"
+        access: read-write
+      PA1:
+        description: "Pin A1"
+        bitRange: "[1:1]"
+        access: read-write
+      PA2:
+        description: "Pin A2"
+        bitRange: "[2:2]"
+        access: read-write
+  PORTA:
+    _add:
+      PA0:
+        description: "Pin A0"
+        bitRange: "[0:0]"
+        access: read-write
+      PA1:
+        description: "Pin A1"
+        bitRange: "[1:1]"
+        access: read-write
+      PA2:
+        description: "Pin A2"
+        bitRange: "[2:2]"
+        access: read-write
+
+PORTB:
+  DDRB:
+    _add:
+      PB0:
+        description: "Pin B0"
+        bitRange: "[0:0]"
+        access: read-write
+      PB1:
+        description: "Pin B1"
+        bitRange: "[1:1]"
+        access: read-write
+      PB2:
+        description: "Pin B2"
+        bitRange: "[2:2]"
+        access: read-write
+      PB3:
+        description: "Pin B3"
+        bitRange: "[3:3]"
+        access: read-write
+      PB4:
+        description: "Pin B4"
+        bitRange: "[4:4]"
+        access: read-write
+      PB5:
+        description: "Pin B5"
+        bitRange: "[5:5]"
+        access: read-write
+      PB6:
+        description: "Pin B6"
+        bitRange: "[6:6]"
+        access: read-write
+      PB7:
+        description: "Pin B7"
+        bitRange: "[7:7]"
+        access: read-write
+  PINB:
+    _add:
+      PB0:
+        description: "Pin B0"
+        bitRange: "[0:0]"
+        access: read-write
+      PB1:
+        description: "Pin B1"
+        bitRange: "[1:1]"
+        access: read-write
+      PB2:
+        description: "Pin B2"
+        bitRange: "[2:2]"
+        access: read-write
+      PB3:
+        description: "Pin B3"
+        bitRange: "[3:3]"
+        access: read-write
+      PB4:
+        description: "Pin B4"
+        bitRange: "[4:4]"
+        access: read-write
+      PB5:
+        description: "Pin B5"
+        bitRange: "[5:5]"
+        access: read-write
+      PB6:
+        description: "Pin B6"
+        bitRange: "[6:6]"
+        access: read-write
+      PB7:
+        description: "Pin B7"
+        bitRange: "[7:7]"
+        access: read-write
+  PORTB:
+    _add:
+      PB0:
+        description: "Pin B0"
+        bitRange: "[0:0]"
+        access: read-write
+      PB1:
+        description: "Pin B1"
+        bitRange: "[1:1]"
+        access: read-write
+      PB2:
+        description: "Pin B2"
+        bitRange: "[2:2]"
+        access: read-write
+      PB3:
+        description: "Pin B3"
+        bitRange: "[3:3]"
+        access: read-write
+      PB4:
+        description: "Pin B4"
+        bitRange: "[4:4]"
+        access: read-write
+      PB5:
+        description: "Pin B5"
+        bitRange: "[5:5]"
+        access: read-write
+      PB6:
+        description: "Pin B6"
+        bitRange: "[6:6]"
+        access: read-write
+      PB7:
+        description: "Pin B7"
+        bitRange: "[7:7]"
+        access: read-write
+
+PORTD:
+  DDRD:
+    _add:
+      PD0:
+        description: "Pin D0"
+        bitRange: "[0:0]"
+        access: read-write
+      PD1:
+        description: "Pin D1"
+        bitRange: "[1:1]"
+        access: read-write
+      PD2:
+        description: "Pin D2"
+        bitRange: "[2:2]"
+        access: read-write
+      PD3:
+        description: "Pin D3"
+        bitRange: "[3:3]"
+        access: read-write
+      PD4:
+        description: "Pin D4"
+        bitRange: "[4:4]"
+        access: read-write
+      PD5:
+        description: "Pin D5"
+        bitRange: "[5:5]"
+        access: read-write
+      PD6:
+        description: "Pin D6"
+        bitRange: "[6:6]"
+        access: read-write
+  PIND:
+    _add:
+      PD0:
+        description: "Pin D0"
+        bitRange: "[0:0]"
+        access: read-write
+      PD1:
+        description: "Pin D1"
+        bitRange: "[1:1]"
+        access: read-write
+      PD2:
+        description: "Pin D2"
+        bitRange: "[2:2]"
+        access: read-write
+      PD3:
+        description: "Pin D3"
+        bitRange: "[3:3]"
+        access: read-write
+      PD4:
+        description: "Pin D4"
+        bitRange: "[4:4]"
+        access: read-write
+      PD5:
+        description: "Pin D5"
+        bitRange: "[5:5]"
+        access: read-write
+      PD6:
+        description: "Pin D6"
+        bitRange: "[6:6]"
+        access: read-write
+  PORTD:
+    _add:
+      PD0:
+        description: "Pin D0"
+        bitRange: "[0:0]"
+        access: read-write
+      PD1:
+        description: "Pin D1"
+        bitRange: "[1:1]"
+        access: read-write
+      PD2:
+        description: "Pin D2"
+        bitRange: "[2:2]"
+        access: read-write
+      PD3:
+        description: "Pin D3"
+        bitRange: "[3:3]"
+        access: read-write
+      PD4:
+        description: "Pin D4"
+        bitRange: "[4:4]"
+        access: read-write
+      PD5:
+        description: "Pin D5"
+        bitRange: "[5:5]"
+        access: read-write
+      PD6:
+        description: "Pin D6"
+        bitRange: "[6:6]"
+        access: read-write


### PR DESCRIPTION
Usually, atdf2svd generates fields for each pin in the DDR,PORT,PIN registers based on additional information in the ATDF file.  However, it seems for the ATtiny2313{,A} chips, this information is missing.  Patch in the missing fields manually.

This was found via https://github.com/Rahix/avr-hal/pull/500.