### PR TITLE
atmega32u4: Add missing pin PF7

### DIFF
--- a/patch/atmega32u4.yaml
+++ b/patch/atmega32u4.yaml
@@ -10,3 +10,24 @@ _include:
   - "common/wdt.yaml"
 
   - "timer/atmega32u4.yaml"
+
+# Pin F7 is not present in the ATDF file for some reason.
+PORTF:
+  DDRF:
+    _add:
+      PF7:
+        description: "Pin F7"
+        bitRange: "[7:7]"
+        access: read-write
+  PINF:
+    _add:
+      PF7:
+        description: "Pin F7"
+        bitRange: "[7:7]"
+        access: read-write
+  PORTF:
+    _add:
+      PF7:
+        description: "Pin F7"
+        bitRange: "[7:7]"
+        access: read-write


### PR DESCRIPTION
For some reason, the ATDF file does not show the PF7 pin.  But as this pin does exist for the MCU, use a patch to add it.

Diff:

```diff
diff --color -Nur svd-orig/atmega32u4.svd.patched svd/atmega32u4.svd.patched
--- svd-orig/atmega32u4.svd.patched	2024-01-28 20:05:48.682604785 +0100
+++ svd/atmega32u4.svd.patched	2024-01-28 20:05:53.675998585 +0100
@@ -3040,7 +3040,8 @@
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
-          </fields>
+          <field><name>PF7</name><description>Pin F7</description><bitRange>[7:7]</bitRange><access>read-write</access></field>
+            </fields>
         </register>
         <register>
           <name>PINF</name>
@@ -3079,7 +3080,8 @@
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
-          </fields>
+          <field><name>PF7</name><description>Pin F7</description><bitRange>[7:7]</bitRange><access>read-write</access></field>
+            </fields>
         </register>
         <register>
           <name>PORTF</name>
@@ -3118,7 +3120,8 @@
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
-          </fields>
+          <field><name>PF7</name><description>Pin F7</description><bitRange>[7:7]</bitRange><access>read-write</access></field>
+            </fields>
         </register>
       </registers>
     </peripheral>
```

(Needed for https://github.com/Rahix/avr-hal/pull/500)