### PR TITLE
Add support for new AVR USB devices. AVR64DU32 and AVR64DU28.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ attiny85 = ["device-selected"]
 attiny861 = ["device-selected"]
 attiny88 = ["device-selected"]
 attiny1614 = ["device-selected"]
+avr64du32 = ["device-selected"]
+avr64du28 = ["device-selected"]
 rt = ["avr-device-macros"]
 
 critical-section-impl = ["critical-section/restore-state-u8"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: deps chips
 
-CHIPS := at90usb1286 atmega1280 atmega1284p atmega128a atmega128rfa1 atmega164pa atmega168 atmega2560 atmega8 atmega8u2 atmega324pa atmega328p atmega328pb atmega32a atmega32u4 atmega4808 atmega4809 atmega48p atmega64 atmega644 atmega88p attiny13a attiny202 attiny2313 attiny2313a attiny402 attiny404 attiny44a attiny84 attiny85 attiny88 attiny816 attiny828 attiny841 attiny84a attiny861 attiny167 attiny1614
+CHIPS := at90usb1286 atmega1280 atmega1284p atmega128a atmega128rfa1 atmega164pa atmega168 atmega2560 atmega8 atmega8u2 atmega324pa atmega328p atmega328pb atmega32a atmega32u4 atmega4808 atmega4809 atmega48p atmega64 atmega644 atmega88p attiny13a attiny202 attiny2313 attiny2313a attiny402 attiny404 attiny44a attiny84 attiny85 attiny88 attiny816 attiny828 attiny841 attiny84a attiny861 attiny167 attiny1614 avr64du32 avr64du28
 
 RUSTUP_TOOLCHAIN ?= nightly
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Via the feature you can select which chip you want the register specifications f
 | :-------------: | :----------: | :---------------: | :-----------: | :-----------: |
 |    `atmega8`    | `atmega8u2`  |   `atmega4808`    | `at90usb1286` |  `attiny13a`  |
 |   `atmega48p`   | `atmega32u4` |   `atmega4809`    |               |  `attiny167`  |
-|   `atmega64`    |              |                   |               |  `attiny202`  |
-|   `atmega644`   |              |                   |               |  `attiny402`  |
+|   `atmega64`    | `avr64du32`  |                   |               |  `attiny202`  |
+|   `atmega644`   | `avr64du28`  |                   |               |  `attiny402`  |
 |   `atmega88p`   |              |                   |               |  `attiny404`  |
 |   `atmega168`   |              |                   |               |  `attiny44a`  |
 |  `atmega324pa`  |              |                   |               |  `attiny84`   |

--- a/patch/avr64du28.yaml
+++ b/patch/avr64du28.yaml
@@ -1,0 +1,1 @@
+_svd: ../svd/avr64du28.svd

--- a/patch/avr64du32.yaml
+++ b/patch/avr64du32.yaml
@@ -1,0 +1,1 @@
+_svd: ../svd/avr64du32.svd

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -150,3 +150,11 @@ pub mod attiny861;
 /// [ATtiny88](https://www.microchip.com/wwwproducts/en/ATtiny88)
 #[cfg(feature = "attiny88")]
 pub mod attiny88;
+
+/// [AVR64DU32](https://www.microchip.com/wwwproducts/en/AVR64DU32)
+#[cfg(feature = "avr64du32")]
+pub mod avr64du32;
+
+/// [AVR64DU28](https://www.microchip.com/wwwproducts/en/AVR64DU28)
+#[cfg(feature = "avr64du28")]
+pub mod avr64du28;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 #![cfg_attr(feature = "attiny85", doc = "**attiny85**,")]
 #![cfg_attr(feature = "attiny861", doc = "**attiny861**,")]
 #![cfg_attr(feature = "attiny88", doc = "**attiny88**,")]
+#![cfg_attr(feature = "avr64du32", doc = "**avr64du32**,")]
+#![cfg_attr(feature = "avr64du28", doc = "**avr64du28**,")]
 //! and a few things which apply to AVR microcontrollers generally.
 //!
 #![cfg_attr(
@@ -82,6 +84,8 @@
 //! `attiny85`,
 //! `attiny861`,
 //! `attiny88`,
+//! `avr64du32`,
+//! `avr64du28`,
 //!
 //! # How to use this crate?
 //!
@@ -240,6 +244,8 @@ compile_error!(
     * attiny85
     * attiny861
     * attiny88
+    * avr64du32
+    * avr64du28
     "
 );
 
@@ -320,3 +326,7 @@ pub use crate::devices::attiny85;
 pub use crate::devices::attiny861;
 #[cfg(feature = "attiny88")]
 pub use crate::devices::attiny88;
+#[cfg(feature = "avr64du32")]
+pub use crate::devices::avr64du32;
+#[cfg(feature = "avr64du28")]
+pub use crate::devices::avr64du28;

--- a/vendor/avr64du28.atdf
+++ b/vendor/avr64du28.atdf
@@ -1,0 +1,6234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<avr-tools-device-file xmlns:NumHelper="NumHelper"
+                       xmlns:xalan="http://xml.apache.org/xalan"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       schema-version="4.5"
+                       xsi:noNamespaceSchemaLocation="schema/atdf.xsd">
+   <variants>
+      <variant ordercode="AVR64DU28-SSOP/SPDIP"
+               package="DIP28"
+               pinout="SSOP28USB"
+               speedmax="32000000"
+               tempmax="85"
+               tempmin="-40"
+               vccmax="5.5"
+               vccmin="1.8"/>
+      <variant ordercode="AVR64DU28-VQFN"
+               package="QFP28"
+               pinout="QFN28USB"
+               speedmax="32000000"
+               tempmax="85"
+               tempmin="-40"
+               vccmax="5.5"
+               vccmin="1.8"/>
+   </variants>
+   <devices>
+      <device architecture="AVR8X" family="AVR" name="AVR64DU28">
+         <address-spaces>
+            <address-space endianness="little"
+                           id="data"
+                           name="data"
+                           size="0x10000"
+                           start="0x0000">
+               <memory-segment exec="0"
+                               name="IO"
+                               rw="RW"
+                               size="0x103F"
+                               start="0x00"
+                               type="io"/>
+               <memory-segment exec="0"
+                               name="LOCKBITS"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x04"
+                               start="0x1040"
+                               type="lockbits"/>
+               <memory-segment exec="0"
+                               name="FUSES"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x10"
+                               start="0x1050"
+                               type="fuses"/>
+               <memory-segment exec="0"
+                               name="SIGNATURES"
+                               pagesize="0x80"
+                               rw="R"
+                               size="0x03"
+                               start="0x1080"
+                               type="signatures"/>
+               <memory-segment exec="0"
+                               name="PROD_SIGNATURES"
+                               pagesize="0x80"
+                               rw="R"
+                               size="0x7D"
+                               start="0x1083"
+                               type="signatures"/>
+               <memory-segment exec="0"
+                               name="BOOTROW"
+                               pagesize="0x100"
+                               rw="RW"
+                               size="0x100"
+                               start="0x1100"
+                               type="user_signatures"/>
+               <memory-segment exec="0"
+                               name="USER_SIGNATURES"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x200"
+                               start="0x1200"
+                               type="user_signatures"/>
+               <memory-segment exec="0"
+                               name="EEPROM"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x100"
+                               start="0x1400"
+                               type="eeprom"/>
+               <memory-segment exec="0"
+                               name="INTERNAL_SRAM"
+                               rw="RW"
+                               size="0x2000"
+                               start="0x6000"
+                               type="ram"/>
+               <memory-segment exec="0"
+                               name="MAPPED_PROGMEM"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x8000"
+                               start="0x8000"
+                               type="other"/>
+            </address-space>
+            <address-space endianness="little"
+                           id="prog"
+                           name="prog"
+                           size="0x10000"
+                           start="0x0000">
+               <memory-segment exec="1"
+                               name="PROGMEM"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x10000"
+                               start="0x00"
+                               type="flash"/>
+            </address-space>
+         </address-spaces>
+         <peripherals>
+            <module id="cmp_control_v8" name="AC">
+               <instance name="AC0">
+                  <register-group address-space="data"
+                                  name="AC0"
+                                  name-in-module="AC"
+                                  offset="0x0680"/>
+                  <signals>
+                     <signal function="AC0" group="AINN" index="0" pad="PD3"/>
+                     <signal function="AC0" group="AINN" index="1" pad="PD0"/>
+                     <signal function="AC0" group="AINN" index="2" pad="PD7"/>
+                     <signal function="AC0" group="AINP" index="0" pad="PD2"/>
+                     <signal function="AC0" group="AINP" index="3" pad="PD6"/>
+                     <signal function="AC0" group="AINP" index="4" pad="PC3"/>
+                     <signal function="AC0" group="OUT" pad="PA7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="adc_10b_ctrl_avr_v1" name="ADC">
+               <instance name="ADC0">
+                  <register-group address-space="data"
+                                  name="ADC0"
+                                  name-in-module="ADC"
+                                  offset="0x0600"/>
+                  <signals>
+                     <signal function="AIN0" group="AIN" index="0" pad="PD0"/>
+                     <signal function="AIN0" group="AIN" index="1" pad="PD1"/>
+                     <signal function="AIN0" group="AIN" index="2" pad="PD2"/>
+                     <signal function="AIN0" group="AIN" index="3" pad="PD3"/>
+                     <signal function="AIN0" group="AIN" index="4" pad="PD4"/>
+                     <signal function="AIN0" group="AIN" index="5" pad="PD5"/>
+                     <signal function="AIN0" group="AIN" index="6" pad="PD6"/>
+                     <signal function="AIN0" group="AIN" index="7" pad="PD7"/>
+                     <signal function="AIN0" group="AIN" index="16" pad="PF0"/>
+                     <signal function="AIN0" group="AIN" index="17" pad="PF1"/>
+                     <signal function="AIN0" group="AIN" index="22" pad="PA2"/>
+                     <signal function="AIN0" group="AIN" index="23" pad="PA3"/>
+                     <signal function="AIN0" group="AIN" index="24" pad="PA4"/>
+                     <signal function="AIN0" group="AIN" index="25" pad="PA5"/>
+                     <signal function="AIN0" group="AIN" index="26" pad="PA6"/>
+                     <signal function="AIN0" group="AIN" index="27" pad="PA7"/>
+                     <signal function="AIN0" group="AIN" index="31" pad="PC3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="bor_lvd_ctrl_v1" name="BOD">
+               <instance name="BOD">
+                  <register-group address-space="data"
+                                  name="BOD"
+                                  name-in-module="BOD"
+                                  offset="0x00A0"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="BOOTROW">
+               <instance name="BOOTROW">
+                  <register-group address-space="data"
+                                  name="BOOTROW"
+                                  name-in-module="BOOTROW"
+                                  offset="0x1100"/>
+               </instance>
+            </module>
+            <module id="cla_ccl_v1" name="CCL">
+               <instance name="CCL">
+                  <register-group address-space="data"
+                                  name="CCL"
+                                  name-in-module="CCL"
+                                  offset="0x01C0"/>
+                  <signals>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_IN"
+                             index="0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_IN"
+                             index="1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_IN"
+                             index="2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_OUT"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_IN"
+                             index="0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_IN"
+                             index="1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_IN"
+                             index="2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_OUT"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT1"
+                             function="CCL"
+                             group="LUT1_OUT"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_IN"
+                             index="0"
+                             pad="PD0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_IN"
+                             index="1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_IN"
+                             index="2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_OUT"
+                             pad="PD3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_IN"
+                             index="0"
+                             pad="PD0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_IN"
+                             index="1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_IN"
+                             index="2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_OUT"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="CCL"
+                             group="LUT3_IN"
+                             index="0"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="CCL"
+                             group="LUT3_IN"
+                             index="1"
+                             pad="PF1"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="CLKCTRL">
+               <instance name="CLKCTRL">
+                  <register-group address-space="data"
+                                  name="CLKCTRL"
+                                  name-in-module="CLKCTRL"
+                                  offset="0x0060"/>
+                  <signals>
+                     <signal function="CLKCTRL" group="CLKOUT" pad="PA7"/>
+                     <signal function="CLKCTRL" group="EXTCLK" pad="PA0"/>
+                     <signal function="CLKCTRL" group="XTAL32K1" pad="PF0"/>
+                     <signal function="CLKCTRL" group="XTAL32K2" pad="PF1"/>
+                     <signal function="CLKCTRL" group="XTALHF1" pad="PA0"/>
+                     <signal function="CLKCTRL" group="XTALHF2" pad="PA1"/>
+                     <signal function="CLKCTRL_ALT1" group="XTAL32K1" pad="PA0"/>
+                     <signal function="CLKCTRL_ALT1" group="XTAL32K2" pad="PA1"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="cpu_avr_xt_v1" name="CPU">
+               <instance name="CPU">
+                  <register-group address-space="data"
+                                  name="CPU"
+                                  name-in-module="CPU"
+                                  offset="0x0030"/>
+                  <parameters>
+                     <param name="CORE_VERSION" value="V4S"/>
+                  </parameters>
+               </instance>
+            </module>
+            <module id="int_8bit_v3" name="CPUINT">
+               <instance name="CPUINT">
+                  <register-group address-space="data"
+                                  name="CPUINT"
+                                  name-in-module="CPUINT"
+                                  offset="0x0110"/>
+               </instance>
+            </module>
+            <module id="math_pdi_crc_v1" name="CRCSCAN">
+               <instance name="CRCSCAN">
+                  <register-group address-space="data"
+                                  name="CRCSCAN"
+                                  name-in-module="CRCSCAN"
+                                  offset="0x0120"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="EVSYS">
+               <instance name="EVSYS">
+                  <register-group address-space="data"
+                                  name="EVSYS"
+                                  name-in-module="EVSYS"
+                                  offset="0x0200"/>
+                  <signals>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTA"
+                             function="EVSYS"
+                             group="EVOUT"
+                             index="0"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTA"
+                             function="EVSYS_ALT1"
+                             group="EVOUT"
+                             index="0"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTD"
+                             function="EVSYS"
+                             group="EVOUT"
+                             index="3"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTD"
+                             function="EVSYS_ALT1"
+                             group="EVOUT"
+                             index="3"
+                             pad="PD7"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTF"
+                             function="EVSYS_ALT1"
+                             group="EVOUT"
+                             index="5"
+                             pad="PF7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="FUSE">
+               <instance name="FUSE">
+                  <register-group address-space="data"
+                                  name="FUSE"
+                                  name-in-module="FUSE"
+                                  offset="0x1050"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="GPR">
+               <instance name="GPR">
+                  <register-group address-space="data"
+                                  name="GPR"
+                                  name-in-module="GPR"
+                                  offset="0x001C"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="LOCK">
+               <instance name="LOCK">
+                  <register-group address-space="data"
+                                  name="LOCK"
+                                  name-in-module="LOCK"
+                                  offset="0x1040"/>
+               </instance>
+            </module>
+            <module id="nvm_ctrl_avr_v4" name="NVMCTRL">
+               <instance name="NVMCTRL">
+                  <register-group address-space="data"
+                                  name="NVMCTRL"
+                                  name-in-module="NVMCTRL"
+                                  offset="0x1000"/>
+               </instance>
+            </module>
+            <module id="gpio_ports_avr_v3" name="PORT">
+               <instance name="PORTA">
+                  <register-group address-space="data"
+                                  name="PORTA"
+                                  name-in-module="PORT"
+                                  offset="0x0400"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="0" pad="PA0"/>
+                     <signal function="IOPORT" group="PIN" index="1" pad="PA1"/>
+                     <signal function="IOPORT" group="PIN" index="2" pad="PA2"/>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PA3"/>
+                     <signal function="IOPORT" group="PIN" index="4" pad="PA4"/>
+                     <signal function="IOPORT" group="PIN" index="5" pad="PA5"/>
+                     <signal function="IOPORT" group="PIN" index="6" pad="PA6"/>
+                     <signal function="IOPORT" group="PIN" index="7" pad="PA7"/>
+                  </signals>
+               </instance>
+               <instance name="PORTC">
+                  <register-group address-space="data"
+                                  name="PORTC"
+                                  name-in-module="PORT"
+                                  offset="0x0440"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PC3"/>
+                  </signals>
+               </instance>
+               <instance name="PORTD">
+                  <register-group address-space="data"
+                                  name="PORTD"
+                                  name-in-module="PORT"
+                                  offset="0x0460"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="0" pad="PD0"/>
+                     <signal function="IOPORT" group="PIN" index="1" pad="PD1"/>
+                     <signal function="IOPORT" group="PIN" index="2" pad="PD2"/>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PD3"/>
+                     <signal function="IOPORT" group="PIN" index="4" pad="PD4"/>
+                     <signal function="IOPORT" group="PIN" index="5" pad="PD5"/>
+                     <signal function="IOPORT" group="PIN" index="6" pad="PD6"/>
+                     <signal function="IOPORT" group="PIN" index="7" pad="PD7"/>
+                  </signals>
+               </instance>
+               <instance name="PORTF">
+                  <register-group address-space="data"
+                                  name="PORTF"
+                                  name-in-module="PORT"
+                                  offset="0x04A0"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="0" pad="PF0"/>
+                     <signal function="IOPORT" group="PIN" index="1" pad="PF1"/>
+                     <signal function="IOPORT" group="PIN" index="6" pad="PF6"/>
+                     <signal function="IOPORT" group="PIN" index="7" pad="PF7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="PORTMUX">
+               <instance name="PORTMUX">
+                  <register-group address-space="data"
+                                  name="PORTMUX"
+                                  name-in-module="PORTMUX"
+                                  offset="0x05E0"/>
+               </instance>
+            </module>
+            <module id="rst_integration_v8" name="RSTCTRL">
+               <instance name="RSTCTRL">
+                  <register-group address-space="data"
+                                  name="RSTCTRL"
+                                  name-in-module="RSTCTRL"
+                                  offset="0x0040"/>
+                  <signals>
+                     <signal function="OTHER" group="RESET" pad="PF6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_16b_rtc_avr_v2" name="RTC">
+               <instance name="RTC">
+                  <register-group address-space="data"
+                                  name="RTC"
+                                  name-in-module="RTC"
+                                  offset="0x0140"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="SIGROW">
+               <instance name="SIGROW">
+                  <register-group address-space="data"
+                                  name="SIGROW"
+                                  name-in-module="SIGROW"
+                                  offset="0x1080"/>
+               </instance>
+            </module>
+            <module id="clk_sleep_ctrl_avr_v3" name="SLPCTRL">
+               <instance name="SLPCTRL">
+                  <register-group address-space="data"
+                                  name="SLPCTRL"
+                                  name-in-module="SLPCTRL"
+                                  offset="0x0050"/>
+               </instance>
+            </module>
+            <module id="spi_8bit_v2" name="SPI">
+               <instance name="SPI0">
+                  <register-group address-space="data"
+                                  name="SPI0"
+                                  name-in-module="SPI"
+                                  offset="0x0940"/>
+                  <signals>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="MISO"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="MOSI"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="SCK"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="SS"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="MISO"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="MOSI"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="SCK"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="SS"
+                             pad="PD7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="SYSCFG">
+               <instance name="SYSCFG">
+                  <register-group address-space="data"
+                                  name="SYSCFG"
+                                  name-in-module="SYSCFG"
+                                  offset="0x0F00"/>
+               </instance>
+            </module>
+            <module id="tmr_16b_pwm_v1" name="TCA">
+               <instance name="TCA0">
+                  <register-group address-space="data"
+                                  name="TCA0"
+                                  name-in-module="TCA"
+                                  offset="0x0A00"/>
+                  <signals>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="3"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="4"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="5"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT2"
+                             group="WO"
+                             index="3"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="0"
+                             pad="PD0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="3"
+                             pad="PD3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="4"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="5"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="0"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="1"
+                             pad="PF1"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_16b_capture_v1" name="TCB">
+               <instance name="TCB0">
+                  <register-group address-space="data"
+                                  name="TCB0"
+                                  name-in-module="TCB"
+                                  offset="0x0B00"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB0"
+                             function="TCB0"
+                             group="WO"
+                             index="0"
+                             pad="PA2"/>
+                  </signals>
+               </instance>
+               <instance name="TCB1">
+                  <register-group address-space="data"
+                                  name="TCB1"
+                                  name-in-module="TCB"
+                                  offset="0x0B10"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB1"
+                             function="TCB1"
+                             group="WO"
+                             index="0"
+                             pad="PA3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="i2c_8bit_avr_v3" name="TWI">
+               <instance name="TWI0">
+                  <register-group address-space="data"
+                                  name="TWI0"
+                                  name-in-module="TWI"
+                                  offset="0x0900"/>
+                  <signals>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0"
+                             group="SCL"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0"
+                             group="SDA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT1"
+                             group="SCL"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT1"
+                             group="SDA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT3"
+                             group="SCL"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT3"
+                             group="SDA"
+                             pad="PA0"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="uart_autobd_v4" name="USART">
+               <instance name="USART0">
+                  <register-group address-space="data"
+                                  name="USART0"
+                                  name-in-module="USART"
+                                  offset="0x0800"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="RXD"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="TXD"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="XCK"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="XDIR"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="RXD"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="TXD"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="XCK"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="XDIR"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT2"
+                             group="RXD"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT2"
+                             group="TXD"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="RXD"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="TXD"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="XCK"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="XDIR"
+                             pad="PD7"/>
+                  </signals>
+               </instance>
+               <instance name="USART1">
+                  <register-group address-space="data"
+                                  name="USART1"
+                                  name-in-module="USART"
+                                  offset="0x0820"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="USART1_ALT2"
+                             group="RXD"
+                             pad="PD7"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="USART1_ALT2"
+                             group="TXD"
+                             pad="PD6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="usb_fscore_avr_v1" name="USB">
+               <instance name="USB0">
+                  <register-group address-space="data"
+                                  name="USB0"
+                                  name-in-module="USB"
+                                  offset="0xC00"/>
+                  <signals>
+                     <signal function="DEFAULT" group="DM" pad="DM"/>
+                     <signal function="DEFAULT" group="DP" pad="DP"/>
+                  </signals>
+                  <parameters>
+                     <param name="USB_MAX_ENDPOINTS" value="16"/>
+                  </parameters>
+               </instance>
+            </module>
+            <module id="avrdu" name="USERROW">
+               <instance name="USERROW">
+                  <register-group address-space="data"
+                                  name="USERROW"
+                                  name-in-module="USERROW"
+                                  offset="0x1200"/>
+               </instance>
+            </module>
+            <module id="gpio_ports_avr_v3_vport" name="VPORT">
+               <instance name="VPORTA">
+                  <register-group address-space="data"
+                                  name="VPORTA"
+                                  name-in-module="VPORT"
+                                  offset="0x0000"/>
+               </instance>
+               <instance name="VPORTC">
+                  <register-group address-space="data"
+                                  name="VPORTC"
+                                  name-in-module="VPORT"
+                                  offset="0x0008"/>
+               </instance>
+               <instance name="VPORTD">
+                  <register-group address-space="data"
+                                  name="VPORTD"
+                                  name-in-module="VPORT"
+                                  offset="0x000C"/>
+               </instance>
+               <instance name="VPORTF">
+                  <register-group address-space="data"
+                                  name="VPORTF"
+                                  name-in-module="VPORT"
+                                  offset="0x0014"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="VREF">
+               <instance name="VREF">
+                  <register-group address-space="data"
+                                  name="VREF"
+                                  name-in-module="VREF"
+                                  offset="0x00B0"/>
+               </instance>
+            </module>
+            <module id="wdt_windowed_v2" name="WDT">
+               <instance name="WDT">
+                  <register-group address-space="data"
+                                  name="WDT"
+                                  name-in-module="WDT"
+                                  offset="0x0100"/>
+               </instance>
+            </module>
+         </peripherals>
+         <interrupts>
+            <interrupt index="1" module-instance="CRCSCAN" name="NMI"/>
+            <interrupt index="2" module-instance="BOD" name="VLM"/>
+            <interrupt index="3" module-instance="CLKCTRL" name="CFD"/>
+            <interrupt index="4" module-instance="RTC" name="CNT"/>
+            <interrupt index="5" module-instance="RTC" name="PIT"/>
+            <interrupt index="6" module-instance="CCL" name="CCL"/>
+            <interrupt index="7" module-instance="USB0" name="BUSEVENT"/>
+            <interrupt index="8" module-instance="USB0" name="TRNCOMPL"/>
+            <interrupt index="9" module-instance="PORTA" name="PORT"/>
+            <interrupt index="10" module-instance="TCA0" name="LUNF"/>
+            <interrupt index="10" module-instance="TCA0" name="OVF"/>
+            <interrupt index="11" module-instance="TCA0" name="HUNF"/>
+            <interrupt index="12" module-instance="TCA0" name="CMP0"/>
+            <interrupt index="12" module-instance="TCA0" name="LCMP0"/>
+            <interrupt index="13" module-instance="TCA0" name="CMP1"/>
+            <interrupt index="13" module-instance="TCA0" name="LCMP1"/>
+            <interrupt index="14" module-instance="TCA0" name="CMP2"/>
+            <interrupt index="14" module-instance="TCA0" name="LCMP2"/>
+            <interrupt index="15" module-instance="TCB0" name="INT"/>
+            <interrupt index="16" module-instance="TWI0" name="TWIS"/>
+            <interrupt index="17" module-instance="TWI0" name="TWIM"/>
+            <interrupt index="18" module-instance="SPI0" name="INT"/>
+            <interrupt index="19" module-instance="USART0" name="RXC"/>
+            <interrupt index="20" module-instance="USART0" name="DRE"/>
+            <interrupt index="21" module-instance="USART0" name="TXC"/>
+            <interrupt index="22" module-instance="PORTD" name="PORT"/>
+            <interrupt index="23" module-instance="PORTC" name="PORT"/>
+            <interrupt index="24" module-instance="PORTF" name="PORT"/>
+            <interrupt index="25" module-instance="NVMCTRL" name="NVMREADY"/>
+            <interrupt index="26" module-instance="USART1" name="RXC"/>
+            <interrupt index="27" module-instance="USART1" name="DRE"/>
+            <interrupt index="28" module-instance="USART1" name="TXC"/>
+            <interrupt index="29" module-instance="TCB1" name="INT"/>
+            <interrupt index="30" module-instance="AC0" name="AC"/>
+            <interrupt index="31" module-instance="ADC0" name="ERROR"/>
+            <interrupt index="32" module-instance="ADC0" name="RESRDY"/>
+            <interrupt index="33" module-instance="ADC0" name="SAMPRDY"/>
+         </interrupts>
+         <interfaces>
+            <interface name="UPDI" type="updi"/>
+         </interfaces>
+         <property-groups>
+            <property-group name="OCD_FEATURES">
+               <property name="BREAK_PIN" value="PF6"/>
+               <property name="BREAK_PIN_ALT" value="PF2"/>
+            </property-group>
+            <property-group name="PROGRAMMING_INFO">
+               <property name="FUSE_ENABLED_VALUE" value="1"/>
+            </property-group>
+            <property-group name="UPDI_INTERFACE">
+               <property name="HV_IMPLEMENTATION" value="2"/>
+               <property name="PROGMEM_OFFSET" value="0x00800000"/>
+            </property-group>
+            <property-group name="SIGNATURES">
+               <property name="SIGNATURE0" value="0x1E"/>
+               <property name="SIGNATURE1" value="0x96"/>
+               <property name="SIGNATURE2" value="0x22"/>
+            </property-group>
+         </property-groups>
+      </device>
+   </devices>
+   <modules>
+      <module caption="Analog Comparator" id="cmp_control_v8" name="AC">
+         <register-group caption="Analog Comparator" name="AC" size="0x8">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Hysteresis Mode"
+                         mask="0x06"
+                         name="HYSMODE"
+                         rw="RW"
+                         values="AC_HYSMODE"/>
+               <bitfield caption="Power profile"
+                         mask="0x18"
+                         name="POWER"
+                         rw="RW"
+                         values="AC_POWER"/>
+               <bitfield caption="Output Pad Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTDBY"
+                         rw="RW"/>
+            </register>
+            <register caption="Mux Control A"
+                      initval="0x00"
+                      name="MUXCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Negative Input MUX Selection"
+                         mask="0x07"
+                         name="MUXNEG"
+                         rw="RW"
+                         values="AC_MUXNEG"/>
+               <bitfield caption="Positive Input MUX Selection"
+                         mask="0x38"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="AC_MUXPOS"/>
+               <bitfield caption="AC Output Initial Value"
+                         mask="0x40"
+                         name="INITVAL"
+                         rw="RW"
+                         values="AC_INITVAL"/>
+               <bitfield caption="Invert AC Output" mask="0x80" name="INVERT" rw="RW"/>
+            </register>
+            <register caption="DAC Voltage Reference"
+                      initval="0xFF"
+                      name="DACREF"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="DACREF" mask="0xFF" name="DACREF" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <mode name="NORMAL" qualifier="WINSEL" value="0x0"/>
+               <mode name="WINDOW" qualifier="WINSEL" value="0x1 0x2"/>
+               <bitfield caption="Interrupt Enable" mask="0x01" name="CMP" rw="RW"/>
+               <bitfield caption="Interrupt Mode"
+                         mask="0x30"
+                         modes="NORMAL"
+                         name="INTMODE"
+                         rw="RW"
+                         values="AC_NORMAL_INTMODE"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Comparator Interrupt Flag"
+                         mask="0x01"
+                         name="CMPIF"
+                         rw="RW"/>
+               <bitfield caption="Analog Comparator State"
+                         mask="0x10"
+                         name="CMPSTATE"
+                         rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="Hysteresis Mode select" name="AC_HYSMODE">
+            <value caption="No hysteresis" name="NONE" value="0x00"/>
+            <value caption="Small hysteresis" name="SMALL" value="0x01"/>
+            <value caption="Medium hysteresis" name="MEDIUM" value="0x02"/>
+            <value caption="Large hysteresis" name="LARGE" value="0x03"/>
+         </value-group>
+         <value-group caption="Power profile select" name="AC_POWER">
+            <value caption="Power profile 0, lowest consumption and highest response time."
+                   name="PROFILE0"
+                   value="0x00"/>
+            <value caption="Power profile 1" name="PROFILE1" value="0x01"/>
+            <value caption="Power profile 2" name="PROFILE2" value="0x02"/>
+            <value caption="Power profile 3" name="PROFILE3" value="0x03"/>
+         </value-group>
+         <value-group caption="Interrupt Mode select" name="AC_NORMAL_INTMODE">
+            <value caption="Positive and negative inputs crosses"
+                   name="BOTHEDGE"
+                   value="0x0"/>
+            <value caption="Positive input goes below negative input"
+                   name="NEGEDGE"
+                   value="0x2"/>
+            <value caption="Positive input goes above negative input"
+                   name="POSEDGE"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="AC Output Initial Value select" name="AC_INITVAL">
+            <value caption="Output initialized to 0" name="LOW" value="0x0"/>
+            <value caption="Output initialized to 1" name="HIGH" value="0x1"/>
+         </value-group>
+         <value-group caption="Negative Input MUX Selection" name="AC_MUXNEG">
+            <value caption="Negative Pin 0" name="AINN0" value="0x00"/>
+            <value caption="Negative Pin 1" name="AINN1" value="0x01"/>
+            <value caption="Negative Pin 2" name="AINN2" value="0x02"/>
+            <value caption="DAC Reference" name="DACREF" value="0x04"/>
+         </value-group>
+         <value-group caption="Positive Input MUX Selection" name="AC_MUXPOS">
+            <value caption="Positive Pin 0" name="AINP0" value="0x00"/>
+            <value caption="Positive Pin 3" name="AINP3" value="0x03"/>
+            <value caption="Positive Pin 4" name="AINP4" value="0x04"/>
+         </value-group>
+      </module>
+      <module caption="Analog to Digital Converter"
+              id="adc_10b_ctrl_avr_v1"
+              name="ADC">
+         <register-group caption="Analog to Digital Converter" name="ADC" size="0x40">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="ADC Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Conversion mode" mask="0x20" name="LOWLAT" rw="RW"/>
+               <bitfield caption="Run standby mode" mask="0x80" name="RUNSTBY" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Pre-scaler"
+                         mask="0x0F"
+                         name="PRESC"
+                         rw="RW"
+                         values="ADC_PRESC"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference Selection"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="ADC_REFSEL"/>
+            </register>
+            <register caption="Control E"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Window Comparator Mode"
+                         mask="0x07"
+                         name="WINCM"
+                         rw="RW"
+                         values="ADC_WINCM"/>
+               <bitfield caption="Window Mode Source" mask="0x08" name="WINSRC" rw="RW"/>
+            </register>
+            <register caption="Control F"
+                      initval="0x00"
+                      name="CTRLE"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sample Duration" mask="0xFF" name="SAMPDUR" rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLF"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sampling Number"
+                         mask="0x07"
+                         name="SAMPNUM"
+                         rw="RW"
+                         values="ADC_SAMPNUM"/>
+               <bitfield caption="Left Adjust" mask="0x10" name="LEFTADJ" rw="RW"/>
+               <bitfield caption="Free Running" mask="0x20" name="FREERUN" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Result Ready Interrupt Enable"
+                         mask="0x01"
+                         name="RESRDY"
+                         rw="RW"/>
+               <bitfield caption="Sample Ready Interrupt Enable"
+                         mask="0x02"
+                         name="SAMPRDY"
+                         rw="RW"/>
+               <bitfield caption="Window Comparator Interrupt Enable"
+                         mask="0x04"
+                         name="WCMP"
+                         rw="RW"/>
+               <bitfield caption="Result Overwrite Interrupt Enable"
+                         mask="0x08"
+                         name="RESOVR"
+                         rw="RW"/>
+               <bitfield caption="Sample Overwrite Interrupt Enable"
+                         mask="0x10"
+                         name="SAMPOVR"
+                         rw="RW"/>
+               <bitfield caption="Trigger Overrun Interrupt Enable"
+                         mask="0x20"
+                         name="TRIGOVR"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Result Ready Flag" mask="0x01" name="RESRDY" rw="RW"/>
+               <bitfield caption="Sample Ready Flag" mask="0x02" name="SAMPRDY" rw="RW"/>
+               <bitfield caption="Window Comparator Flag"
+                         mask="0x04"
+                         name="WCMP"
+                         rw="RW"/>
+               <bitfield caption="Result OverwriteFlag"
+                         mask="0x08"
+                         name="RESOVR"
+                         rw="RW"/>
+               <bitfield caption="Sample OverwriteFlag"
+                         mask="0x10"
+                         name="SAMPOVR"
+                         rw="RW"/>
+               <bitfield caption="Trigger OverrunFlag"
+                         mask="0x20"
+                         name="TRIGOVR"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="ADC Busy" mask="0x01" name="ADCBUSY" rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Command"
+                      initval="0x00"
+                      name="COMMAND"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Start Conversion"
+                         mask="0x07"
+                         name="START"
+                         rw="RW"
+                         values="ADC_START"/>
+               <bitfield caption="Mode"
+                         mask="0x70"
+                         name="MODE"
+                         rw="RW"
+                         values="ADC_MODE"/>
+            </register>
+            <register caption="Positive mux input"
+                      initval="0x00"
+                      name="MUXPOS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Channel Selection Bits"
+                         mask="0x7F"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="ADC_MUXPOS"/>
+            </register>
+            <register caption="ADC Accumulator Result"
+                      name="RESULT"
+                      offset="0x0C"
+                      rw="R"
+                      size="2">
+               <bitfield caption="ADC Result" mask="0xFFFF" name="RESULT" rw="R"/>
+            </register>
+            <register caption="ADC Sample"
+                      initval="0x0000"
+                      name="SAMPLE"
+                      offset="0x0E"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="ADC Sample" mask="0xFFFF" name="SAMPLE" rw="R"/>
+            </register>
+            <register caption="Window comparator low threshold"
+                      name="WINLT"
+                      offset="0x10"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Window Low Threshold"
+                         mask="0xFFFF"
+                         name="WINLT"
+                         rw="RW"/>
+            </register>
+            <register caption="Window comparator high threshold"
+                      name="WINHT"
+                      offset="0x12"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Window High Threshold"
+                         mask="0xFFFF"
+                         name="WINHT"
+                         rw="RW"/>
+            </register>
+            <register caption="Temporary Data"
+                      initval="0x00"
+                      name="TEMP"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Temporary" mask="0xFF" name="TEMP" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Mode select" name="ADC_MODE">
+            <value caption="Single 8-bit conv" name="SINGLE_8BIT" value="0x0"/>
+            <value caption="Single 10-bit conv" name="SINGLE_10BIT" value="0x1"/>
+            <value caption="Series of 10-bit conv" name="SERIES" value="0x2"/>
+            <value caption="Burst of 10-bit conv" name="BURST" value="0x3"/>
+            <value caption="Acc test mode for FuSa" name="ACCTEST" value="0x7"/>
+         </value-group>
+         <value-group caption="Start Conversion select" name="ADC_START">
+            <value caption="Stop/No ongoing conv" name="STOP" value="0x0"/>
+            <value caption="Start Immediately" name="IMMEDIATE" value="0x1"/>
+            <value caption="Start after a write to MUXPOS"
+                   name="MUXPOS_WRITE"
+                   value="0x2"/>
+            <value caption="Start upon event reception"
+                   name="EVENT_TTRIGGER"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="Clock Pre-scaler select" name="ADC_PRESC">
+            <value caption="CLK_PER divided by 2" name="DIV2" value="0x00"/>
+            <value caption="CLK_PER divided by 4" name="DIV4" value="0x01"/>
+            <value caption="CLK_PER divided by 6" name="DIV6" value="0x02"/>
+            <value caption="CLK_PER divided by 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER divided by 10" name="DIV10" value="0x04"/>
+            <value caption="CLK_PER divided by 12" name="DIV12" value="0x05"/>
+            <value caption="CLK_PER divided by 14" name="DIV14" value="0x06"/>
+            <value caption="CLK_PER divided by 16" name="DIV16" value="0x07"/>
+            <value caption="CLK_PER divided by 20" name="DIV20" value="0x08"/>
+            <value caption="CLK_PER divided by 24" name="DIV24" value="0x09"/>
+            <value caption="CLK_PER divided by 28" name="DIV28" value="0x0A"/>
+            <value caption="CLK_PER divided by 32" name="DIV32" value="0x0B"/>
+            <value caption="CLK_PER divided by 40" name="DIV40" value="0x0C"/>
+            <value caption="CLK_PER divided by 48" name="DIV48" value="0x0D"/>
+            <value caption="CLK_PER divided by 56" name="DIV56" value="0x0E"/>
+            <value caption="CLK_PER divided by 64" name="DIV64" value="0x0F"/>
+         </value-group>
+         <value-group caption="Reference Selection" name="ADC_REFSEL">
+            <value caption="VDD" name="VDD" value="0x00"/>
+            <value caption="VREFA" name="VREFA" value="0x02"/>
+            <value caption="1.024V" name="1V024" value="0x04"/>
+            <value caption="2.048V" name="2V048" value="0x05"/>
+            <value caption="4.096V" name="4V096" value="0x06"/>
+            <value caption="2.5V" name="2V500" value="0x7"/>
+         </value-group>
+         <value-group caption="Window Comparator Mode select" name="ADC_WINCM">
+            <value caption="No Window Comparison" name="NONE" value="0x00"/>
+            <value caption="Below Window" name="BELOW" value="0x01"/>
+            <value caption="Above Window" name="ABOVE" value="0x02"/>
+            <value caption="Inside Window" name="INSIDE" value="0x03"/>
+            <value caption="Outside Window" name="OUTSIDE" value="0x04"/>
+         </value-group>
+         <value-group caption="Sampling Number select" name="ADC_SAMPNUM">
+            <value caption="No accumulation" name="NONE" value="0x0"/>
+            <value caption="2 results accumulated" name="ACC2" value="0x1"/>
+            <value caption="4 results accumulated" name="ACC4" value="0x2"/>
+            <value caption="8 results accumulated" name="ACC8" value="0x3"/>
+            <value caption="16 results accumulated" name="ACC16" value="0x4"/>
+            <value caption="32 results accumulated" name="ACC32" value="0x5"/>
+            <value caption="64 results accumulated" name="ACC64" value="0x6"/>
+         </value-group>
+         <value-group caption="Analog Channel Selection Bits" name="ADC_MUXPOS">
+            <value caption="ADC input pin 0" name="AIN0" value="0x00"/>
+            <value caption="ADC input pin 1" name="AIN1" value="0x01"/>
+            <value caption="ADC input pin 2" name="AIN2" value="0x02"/>
+            <value caption="ADC input pin 3" name="AIN3" value="0x03"/>
+            <value caption="ADC input pin 4" name="AIN4" value="0x04"/>
+            <value caption="ADC input pin 5" name="AIN5" value="0x05"/>
+            <value caption="ADC input pin 6" name="AIN6" value="0x06"/>
+            <value caption="ADC input pin 7" name="AIN7" value="0x07"/>
+            <value caption="ADC input pin 16" name="AIN16" value="0x10"/>
+            <value caption="ADC input pin 17" name="AIN17" value="0x11"/>
+            <value caption="ADC input pin 18" name="AIN18" value="0x12"/>
+            <value caption="ADC input pin 19" name="AIN19" value="0x13"/>
+            <value caption="ADC input pin 20" name="AIN20" value="0x14"/>
+            <value caption="ADC input pin 21" name="AIN21" value="0x15"/>
+            <value caption="ADC input pin 22" name="AIN22" value="0x16"/>
+            <value caption="ADC input pin 23" name="AIN23" value="0x17"/>
+            <value caption="ADC input pin 24" name="AIN24" value="0x18"/>
+            <value caption="ADC input pin 25" name="AIN25" value="0x19"/>
+            <value caption="ADC input pin 26" name="AIN26" value="0x1A"/>
+            <value caption="ADC input pin 27" name="AIN27" value="0x1B"/>
+            <value caption="ADC input pin 31" name="AIN31" value="0x1F"/>
+            <value caption="Ground" name="GND" value="0x40"/>
+            <value caption="Temperature sensor" name="TEMPSENSE" value="0x42"/>
+            <value caption="VDD/10" name="VDDDIV10" value="0x44"/>
+            <value caption="AC0 DAC voltage" name="DACREF0" value="0x49"/>
+         </value-group>
+      </module>
+      <module caption="Bod interface" id="bor_lvd_ctrl_v1" name="BOD">
+         <register-group caption="Bod interface" name="BOD" size="0x10">
+            <register caption="Control A"
+                      initval="0x01"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Operation in sleep mode"
+                         mask="0x03"
+                         name="SLEEP"
+                         rw="RW"
+                         values="BOD_SLEEP"/>
+               <bitfield caption="Operation in active mode"
+                         mask="0x0C"
+                         name="ACTIVE"
+                         rw="R"
+                         values="BOD_ACTIVE"/>
+               <bitfield caption="Sample frequency"
+                         mask="0x10"
+                         name="SAMPFREQ"
+                         rw="R"
+                         values="BOD_SAMPFREQ"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Bod level"
+                         mask="0x07"
+                         name="LVL"
+                         rw="R"
+                         values="BOD_LVL"/>
+            </register>
+            <register caption="Voltage level monitor Control"
+                      initval="0x00"
+                      name="VLMCTRLA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="voltage level monitor level"
+                         mask="0x03"
+                         name="VLMLVL"
+                         rw="RW"
+                         values="BOD_VLMLVL"/>
+            </register>
+            <register caption="Voltage level monitor interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="voltage level monitor interrrupt enable"
+                         mask="0x01"
+                         name="VLMIE"
+                         rw="RW"/>
+               <bitfield caption="Configuration"
+                         mask="0x06"
+                         name="VLMCFG"
+                         rw="RW"
+                         values="BOD_VLMCFG"/>
+            </register>
+            <register caption="Voltage level monitor interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Voltage level monitor interrupt flag"
+                         mask="0x01"
+                         name="VLMIF"
+                         rw="RW"/>
+            </register>
+            <register caption="Voltage level monitor status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Voltage level monitor status"
+                         mask="0x01"
+                         name="VLMS"
+                         rw="R"
+                         values="BOD_VLMS"/>
+            </register>
+         </register-group>
+         <value-group caption="Operation in active mode select" name="BOD_ACTIVE">
+            <value caption="Disabled" name="DIS" value="0x00"/>
+            <value caption="Enabled" name="ENABLED" value="0x01"/>
+            <value caption="Sampled" name="SAMPLED" value="0x02"/>
+            <value caption="Enabled with wake-up halted until BOD is ready"
+                   name="ENWAKE"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Sample frequency select" name="BOD_SAMPFREQ">
+            <value caption="128Hz sampling frequency" name="128HZ" value="0x0"/>
+            <value caption="32Hz sampling frequency" name="32HZ" value="0x1"/>
+         </value-group>
+         <value-group caption="Operation in sleep mode select" name="BOD_SLEEP">
+            <value caption="Disabled" name="DIS" value="0x00"/>
+            <value caption="Enabled" name="ENABLED" value="0x01"/>
+            <value caption="Sampled" name="SAMPLED" value="0x02"/>
+         </value-group>
+         <value-group caption="Bod level select" name="BOD_LVL">
+            <value caption="1.9 V" name="BODLEVEL0" value="0x00"/>
+            <value caption="2.45 V" name="BODLEVEL1" value="0x01"/>
+            <value caption="2.7 V" name="BODLEVEL2" value="0x02"/>
+            <value caption="2.85 V" name="BODLEVEL3" value="0x03"/>
+         </value-group>
+         <value-group caption="Configuration select" name="BOD_VLMCFG">
+            <value caption="VDD falls below VLM threshold" name="FALLING" value="0x00"/>
+            <value caption="VDD rises above VLM threshold" name="RISING" value="0x01"/>
+            <value caption="VDD crosses VLM threshold" name="BOTH" value="0x02"/>
+         </value-group>
+         <value-group caption="Voltage level monitor status select" name="BOD_VLMS">
+            <value caption="The voltage is above the VLM threshold level"
+                   name="ABOVE"
+                   value="0x0"/>
+            <value caption="The voltage is below the VLM threshold level"
+                   name="BELOW"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="voltage level monitor level select" name="BOD_VLMLVL">
+            <value caption="VLM Disabled" name="OFF" value="0x0"/>
+            <value caption="VLM threshold 5% above BOD level"
+                   name="5ABOVE"
+                   value="0x1"/>
+            <value caption="VLM threshold 15% above BOD level"
+                   name="15ABOVE"
+                   value="0x2"/>
+            <value caption="VLM threshold 25% above BOD level"
+                   name="25ABOVE"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="Boot Row" id="avrdu" name="BOOTROW">
+         <register-group caption="Boot Row" name="BOOTROW" size="0x100">
+            <register caption="Boot row"
+                      count="0x100"
+                      name="BOOTROW"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Configurable Custom Logic" id="cla_ccl_v1" name="CCL">
+         <register-group caption="Configurable Custom Logic" name="CCL" size="0x40">
+            <register caption="Control Register A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Run in Standby" mask="0x40" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Sequential Control 0"
+                      initval="0x00"
+                      name="SEQCTRL0"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sequential Selection"
+                         mask="0x0F"
+                         name="SEQSEL"
+                         rw="RW"
+                         values="CCL_SEQSEL"/>
+            </register>
+            <register caption="Sequential Control 1"
+                      initval="0x00"
+                      name="SEQCTRL1"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sequential Selection"
+                         mask="0x0F"
+                         name="SEQSEL"
+                         rw="RW"
+                         values="CCL_SEQSEL"/>
+            </register>
+            <register caption="Interrupt Control 0"
+                      initval="0x00"
+                      name="INTCTRL0"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Mode for LUT0"
+                         mask="0x03"
+                         name="INTMODE0"
+                         rw="RW"
+                         values="CCL_INTMODE0"/>
+               <bitfield caption="Interrupt Mode for LUT1"
+                         mask="0x0C"
+                         name="INTMODE1"
+                         rw="RW"
+                         values="CCL_INTMODE1"/>
+               <bitfield caption="Interrupt Mode for LUT2"
+                         mask="0x30"
+                         name="INTMODE2"
+                         rw="RW"
+                         values="CCL_INTMODE2"/>
+               <bitfield caption="Interrupt Mode for LUT3"
+                         mask="0xC0"
+                         name="INTMODE3"
+                         rw="RW"
+                         values="CCL_INTMODE3"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Flag" mask="0x0F" name="INT" rw="RW"/>
+            </register>
+            <register caption="LUT 0 Control A"
+                      initval="0x00"
+                      name="LUT0CTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 0 Control B"
+                      initval="0x00"
+                      name="LUT0CTRLB"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 0 Control C"
+                      initval="0x00"
+                      name="LUT0CTRLC"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 0"
+                      initval="0x00"
+                      name="TRUTH0"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 1 Control A"
+                      initval="0x00"
+                      name="LUT1CTRLA"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 1 Control B"
+                      initval="0x00"
+                      name="LUT1CTRLB"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 1 Control C"
+                      initval="0x00"
+                      name="LUT1CTRLC"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 1"
+                      initval="0x00"
+                      name="TRUTH1"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 2 Control A"
+                      initval="0x00"
+                      name="LUT2CTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 2 Control B"
+                      initval="0x00"
+                      name="LUT2CTRLB"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 2 Control C"
+                      initval="0x00"
+                      name="LUT2CTRLC"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 2"
+                      initval="0x00"
+                      name="TRUTH2"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 3 Control A"
+                      initval="0x00"
+                      name="LUT3CTRLA"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 3 Control B"
+                      initval="0x00"
+                      name="LUT3CTRLB"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 3 Control C"
+                      initval="0x00"
+                      name="LUT3CTRLC"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 3"
+                      initval="0x00"
+                      name="TRUTH3"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Interrupt Mode for LUT0 select" name="CCL_INTMODE0">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT1 select" name="CCL_INTMODE1">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT2 select" name="CCL_INTMODE2">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT3 select" name="CCL_INTMODE3">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Clock Source Selection" name="CCL_CLKSRC">
+            <value caption="Peripheral Clock" name="CLKPER" value="0x0"/>
+            <value caption="Selection by INSEL2" name="IN2" value="0x1"/>
+            <value caption="Internal High-Frequency Oscillator"
+                   name="OSCHF"
+                   value="0x4"/>
+            <value caption="32.768 kHz oscillator" name="OSC32K" value="0x5"/>
+            <value caption="32.768 kHz oscillator divided by 32"
+                   name="OSC1K"
+                   value="0x6"/>
+         </value-group>
+         <value-group caption="Edge Detection Enable select" name="CCL_EDGEDET">
+            <value caption="Edge detector is disabled" name="DIS" value="0x0"/>
+            <value caption="Edge detector is enabled" name="EN" value="0x1"/>
+         </value-group>
+         <value-group caption="Filter Selection" name="CCL_FILTSEL">
+            <value caption="Filter disabled" name="DISABLE" value="0x0"/>
+            <value caption="Synchronizer enabled" name="SYNCH" value="0x1"/>
+            <value caption="Filter enabled" name="FILTER" value="0x2"/>
+         </value-group>
+         <value-group caption="LUT Input 0 Source Selection" name="CCL_INSEL0">
+            <value caption="Masked input" name="MASK" value="0x0"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x1"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x2"/>
+            <value caption="Event input source A" name="EVENTA" value="0x3"/>
+            <value caption="Event input source B" name="EVENTB" value="0x4"/>
+            <value caption="IO pin LUTn-IN0 input source" name="IN0" value="0x5"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x6"/>
+            <value caption="USART0 TXD input source" name="USART0" value="0x7"/>
+            <value caption="SPI0 MOSI input source" name="SPI0" value="0x8"/>
+            <value caption="TCA0 WO0 input source" name="TCA0" value="0x9"/>
+            <value caption="TCB0 WO input source" name="TCB0" value="0xA"/>
+         </value-group>
+         <value-group caption="LUT Input 1 Source Selection" name="CCL_INSEL1">
+            <value caption="Masked input" name="MASK" value="0x0"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x1"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x2"/>
+            <value caption="Event input source A" name="EVENTA" value="0x3"/>
+            <value caption="Event input source B" name="EVENTB" value="0x4"/>
+            <value caption="IO pin LUTn-IN1 input source" name="IN1" value="0x5"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x6"/>
+            <value caption="USART1 TXD input source" name="USART1" value="0x7"/>
+            <value caption="SPI0 MOSI input source" name="SPI0" value="0x8"/>
+            <value caption="TCA0 WO1 input source" name="TCA0" value="0x9"/>
+            <value caption="TCB1 WO input source" name="TCB1" value="0xA"/>
+         </value-group>
+         <value-group caption="LUT Input 2 Source Selection" name="CCL_INSEL2">
+            <value caption="Masked input" name="MASK" value="0x0"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x1"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x2"/>
+            <value caption="Event input source A" name="EVENTA" value="0x3"/>
+            <value caption="Event input source B" name="EVENTB" value="0x4"/>
+            <value caption="IO pin LUTn-IN2 input source" name="IN2" value="0x5"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x6"/>
+            <value caption="USART1 TXD input source" name="USART1" value="0x7"/>
+            <value caption="SPI0 SCK input source" name="SPI0" value="0x8"/>
+            <value caption="TCA0 WO2 input source" name="TCA0" value="0x9"/>
+            <value caption="TCB1 WO input source" name="TCB1" value="0xA"/>
+         </value-group>
+         <value-group caption="Sequential Selection" name="CCL_SEQSEL">
+            <value caption="Sequential logic disabled" name="DISABLE" value="0x00"/>
+            <value caption="D FlipFlop" name="DFF" value="0x01"/>
+            <value caption="JK FlipFlop" name="JK" value="0x02"/>
+            <value caption="D Latch" name="LATCH" value="0x03"/>
+            <value caption="RS Latch" name="RS" value="0x04"/>
+         </value-group>
+      </module>
+      <module caption="Clock controller" id="avrdu" name="CLKCTRL">
+         <register-group caption="Clock controller" name="CLKCTRL" size="0x40">
+            <register caption="MCLK Control A"
+                      initval="0x00"
+                      name="MCLKCTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock select"
+                         mask="0x07"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="CLKCTRL_CLKSEL"/>
+               <bitfield caption="System clock out" mask="0x80" name="CLKOUT" rw="RW"/>
+            </register>
+            <register caption="MCLK Control B"
+                      initval="0x00"
+                      name="MCLKCTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Prescaler enable" mask="0x01" name="PEN" rw="RW"/>
+               <bitfield caption="Prescaler division"
+                         mask="0x1E"
+                         name="PDIV"
+                         rw="RW"
+                         values="CLKCTRL_PDIV"/>
+            </register>
+            <register caption="MCLK Control C"
+                      initval="0x00"
+                      name="MCLKCTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Enable"
+                         mask="0x01"
+                         name="CFDEN"
+                         rw="RW"/>
+               <bitfield caption="Clock Failure Detect Test"
+                         mask="0x02"
+                         name="CFDTST"
+                         rw="W"/>
+               <bitfield caption="Clock Failure Detect Source"
+                         mask="0x0C"
+                         name="CFDSRC"
+                         rw="RW"
+                         values="CLKCTRL_CFDSRC"/>
+            </register>
+            <register caption="MCLK Interrupt Control"
+                      initval="0x00"
+                      name="MCLKINTCTRL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Interrupt Enable"
+                         mask="0x01"
+                         name="CFD"
+                         rw="RW"/>
+               <bitfield caption="Interrupt type"
+                         mask="0x80"
+                         name="INTTYPE"
+                         rw="RW"
+                         values="CLKCTRL_INTTYPE"/>
+            </register>
+            <register caption="MCLK Interrupt Flags"
+                      initval="0x00"
+                      name="MCLKINTFLAGS"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Interrupt Flag"
+                         mask="0x01"
+                         name="CFD"
+                         rw="RW"/>
+            </register>
+            <register caption="MCLK Status"
+                      initval="0x00"
+                      name="MCLKSTATUS"
+                      offset="0x05"
+                      rw="R"
+                      size="1">
+               <bitfield caption="System Oscillator changing"
+                         mask="0x01"
+                         name="SOSC"
+                         rw="R"/>
+               <bitfield caption="High frequency oscillator status"
+                         mask="0x02"
+                         name="OSCHFS"
+                         rw="R"/>
+               <bitfield caption="32KHz oscillator status"
+                         mask="0x04"
+                         name="OSC32KS"
+                         rw="R"/>
+               <bitfield caption="32.768 kHz Crystal Oscillator status"
+                         mask="0x08"
+                         name="XOSC32KS"
+                         rw="R"/>
+               <bitfield caption="External Clock status" mask="0x10" name="EXTS" rw="R"/>
+            </register>
+            <register caption="Timebase"
+                      initval="0x00"
+                      name="MCLKTIMEBASE"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Timebase" mask="0x1F" name="TIMEBASE" rw="RW"/>
+            </register>
+            <register caption="OSCHF Control A"
+                      initval="0x0C"
+                      name="OSCHFCTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Autotune"
+                         mask="0x03"
+                         name="AUTOTUNE"
+                         rw="RW"
+                         values="CLKCTRL_AUTOTUNE"/>
+               <bitfield caption="Frequency select"
+                         mask="0x3C"
+                         name="FRQSEL"
+                         rw="RW"
+                         values="CLKCTRL_FRQSEL"/>
+               <bitfield caption="Algorithm Selection"
+                         mask="0x40"
+                         name="ALGSEL"
+                         rw="RW"
+                         values="CLKCTRL_ALGSEL"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="OSCHF Tune"
+                      name="OSCHFTUNE"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Tune" mask="0x7F" name="TUNE" rw="RW"/>
+            </register>
+            <register caption="OSCHF Status"
+                      name="OSCHFSTATUS"
+                      offset="0x0A"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Autotune in Lock" mask="0x01" name="ATSYNC" rw="R"/>
+               <bitfield caption="Autotune Synchronized"
+                         mask="0x02"
+                         name="ATLOCK"
+                         rw="R"/>
+            </register>
+            <register caption="OSC32K Control A"
+                      initval="0x00"
+                      name="OSC32KCTRLA"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="XOSC32K Control A"
+                      initval="0x00"
+                      name="XOSC32KCTRLA"
+                      offset="0x1C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Low power mode" mask="0x02" name="LPMODE" rw="RW"/>
+               <bitfield caption="Select"
+                         mask="0x04"
+                         name="SEL"
+                         rw="RW"
+                         values="CLKCTRL_SEL"/>
+               <bitfield caption="Crystal startup time"
+                         mask="0x30"
+                         name="CSUT"
+                         rw="RW"
+                         values="CLKCTRL_CSUT"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="XOSCHF Control A"
+                      initval="0x00"
+                      name="XOSCHFCTRLA"
+                      offset="0x20"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="External Source Select"
+                         mask="0x02"
+                         name="SELHF"
+                         rw="RW"
+                         values="CLKCTRL_SELHF"/>
+               <bitfield caption="Frequency Range"
+                         mask="0x0C"
+                         name="FRQRANGE"
+                         rw="RW"
+                         values="CLKCTRL_FRQRANGE"/>
+               <bitfield caption="Start-up Time Select"
+                         mask="0x30"
+                         name="CSUTHF"
+                         rw="RW"
+                         values="CLKCTRL_CSUTHF"/>
+               <bitfield caption="Run Standby" mask="0x80" name="RUNSTBY" rw="RW"/>
+            </register>
+            <register caption="PLL Status"
+                      initval="0x00"
+                      name="USBPLLSTATUS"
+                      offset="0x25"
+                      rw="R"
+                      size="1">
+               <bitfield caption="PLL Stable" mask="0x01" name="PLLS" rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock select" name="CLKCTRL_CLKSEL">
+            <value caption="Internal high-frequency oscillator"
+                   name="OSCHF"
+                   value="0x0"/>
+            <value caption="Internal 32.768 kHz oscillator" name="OSC32K" value="0x1"/>
+            <value caption="32.768 kHz crystal oscillator" name="XOSC32K" value="0x2"/>
+            <value caption="External clock" name="EXTCLK" value="0x3"/>
+         </value-group>
+         <value-group caption="Prescaler division select" name="CLKCTRL_PDIV">
+            <value caption="Divide by 2" name="DIV2" value="0x00"/>
+            <value caption="Divide by 4" name="DIV4" value="0x01"/>
+            <value caption="Divide by 8" name="DIV8" value="0x02"/>
+            <value caption="Divide by 16" name="DIV16" value="0x03"/>
+            <value caption="Divide by 32" name="DIV32" value="0x04"/>
+            <value caption="Divide by 64" name="DIV64" value="0x05"/>
+            <value caption="Divide by 6" name="DIV6" value="0x08"/>
+            <value caption="Divide by 10" name="DIV10" value="0x09"/>
+            <value caption="Divide by 12" name="DIV12" value="0x0A"/>
+            <value caption="Divide by 24" name="DIV24" value="0x0B"/>
+            <value caption="Divide by 48" name="DIV48" value="0x0C"/>
+         </value-group>
+         <value-group caption="Clock Failure Detect Source select" name="CLKCTRL_CFDSRC">
+            <value caption="Main Clock" name="CLKMAIN" value="0x0"/>
+            <value caption="XOSCHF" name="XOSCHF" value="0x1"/>
+            <value caption="XOSC32K" name="XOSC32K" value="0x2"/>
+         </value-group>
+         <value-group caption="Interrupt type select" name="CLKCTRL_INTTYPE">
+            <value caption="Regular Interrupt" name="INT" value="0x0"/>
+            <value caption="NMI" name="NMI" value="0x1"/>
+         </value-group>
+         <value-group caption="Algorithm Selection" name="CLKCTRL_ALGSEL">
+            <value caption="Binary Search" name="BIN" value="0x0"/>
+            <value caption="Incremental Search" name="INCR" value="0x1"/>
+         </value-group>
+         <value-group caption="Autotune select" name="CLKCTRL_AUTOTUNE">
+            <value caption="Automatic tuning disabled" name="OFF" value="0x0"/>
+            <value caption="Automatic tuning against XOSC32K enabled"
+                   name="32K"
+                   value="0x1"/>
+            <value caption="Automatic tuning against USB SOF enabled"
+                   name="SOF"
+                   value="0x2"/>
+         </value-group>
+         <value-group caption="Frequency select" name="CLKCTRL_FRQSEL">
+            <value caption="1 MHz system clock" name="1M" value="0x0"/>
+            <value caption="2 MHz system clock" name="2M" value="0x1"/>
+            <value caption="3 MHz system clock" name="3M" value="0x2"/>
+            <value caption="4 MHz system clock (default)" name="4M" value="0x3"/>
+            <value caption="8 MHz system clock" name="8M" value="0x5"/>
+            <value caption="12 MHz system clock" name="12M" value="0x6"/>
+            <value caption="16 MHz system clock" name="16M" value="0x7"/>
+            <value caption="20 MHz system clock" name="20M" value="0x8"/>
+            <value caption="24 MHz system clock" name="24M" value="0x9"/>
+            <value caption="28 MHz system clock" name="28M" value="0xA"/>
+            <value caption="32 MHz system clock" name="32M" value="0xB"/>
+         </value-group>
+         <value-group caption="Start-up Time Select" name="CLKCTRL_CSUTHF">
+            <value caption="256 XOSCHF cycles" name="256" value="0x0"/>
+            <value caption="1K XOSCHF cycles" name="1K" value="0x1"/>
+            <value caption="4K XOSCHF cycles" name="4K" value="0x2"/>
+         </value-group>
+         <value-group caption="Frequency Range select" name="CLKCTRL_FRQRANGE">
+            <value caption="Max 8 MHz XTAL Frequency" name="8M" value="0x0"/>
+            <value caption="Max 16 MHz XTAL Frequency" name="16M" value="0x1"/>
+            <value caption="Max 24 MHz XTAL Frequency" name="24M" value="0x2"/>
+            <value caption="Max 32 MHz XTAL Frequency" name="32M" value="0x3"/>
+         </value-group>
+         <value-group caption="External Source Select" name="CLKCTRL_SELHF">
+            <value caption="External Crystal" name="XTAL" value="0x0"/>
+            <value caption="External clock on XTALHF1 pin" name="EXTCLK" value="0x1"/>
+         </value-group>
+         <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+            <value caption="1k cycles" name="1K" value="0x00"/>
+            <value caption="16k cycles" name="16K" value="0x01"/>
+            <value caption="32k cycles" name="32K" value="0x02"/>
+            <value caption="64k cycles" name="64K" value="0x03"/>
+         </value-group>
+         <value-group caption="Select" name="CLKCTRL_SEL">
+            <value caption="External crystal connected to the XTAL32K1 and XTAL32K2 pins"
+                   name="XTAL"
+                   value="0x0"/>
+            <value caption="External clock on the XTAL32K1 pin"
+                   name="EXTCLK"
+                   value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="CPU" id="cpu_avr_xt_v1" name="CPU">
+         <register-group caption="CPU" name="CPU" size="0x10">
+            <register caption="Configuration Change Protection"
+                      initval="0x00"
+                      name="CCP"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CCP signature"
+                         mask="0xFF"
+                         name="CCP"
+                         rw="RW"
+                         values="CPU_CCP"/>
+            </register>
+            <register caption="Extended Z-pointer Register"
+                      initval="0x00"
+                      name="RAMPZ"
+                      offset="0xB"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Stack Pointer"
+                      initval="0x7FFF"
+                      name="SP"
+                      offset="0xD"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Status Register"
+                      initval="0x00"
+                      name="SREG"
+                      offset="0xF"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Carry Flag" mask="0x01" name="C" rw="RW"/>
+               <bitfield caption="Zero Flag" mask="0x02" name="Z" rw="RW"/>
+               <bitfield caption="Negative Flag" mask="0x04" name="N" rw="RW"/>
+               <bitfield caption="Two's Complement Overflow Flag"
+                         mask="0x08"
+                         name="V"
+                         rw="RW"/>
+               <bitfield caption="N Exclusive Or V Flag" mask="0x10" name="S" rw="RW"/>
+               <bitfield caption="Half Carry Flag" mask="0x20" name="H" rw="RW"/>
+               <bitfield caption="Transfer Bit" mask="0x40" name="T" rw="RW"/>
+               <bitfield caption="Global Interrupt Enable Flag"
+                         mask="0x80"
+                         name="I"
+                         rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="CCP signature select" name="CPU_CCP">
+            <value caption="SPM Instruction Protection" name="SPM" value="0x9D"/>
+            <value caption="IO Register Protection" name="IOREG" value="0xD8"/>
+         </value-group>
+      </module>
+      <module caption="Interrupt Controller" id="int_8bit_v3" name="CPUINT">
+         <register-group caption="Interrupt Controller" name="CPUINT" size="0x4">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Round-robin Scheduling Enable"
+                         mask="0x01"
+                         name="LVL0RR"
+                         rw="RW"/>
+               <bitfield caption="Compact Vector Table" mask="0x20" name="CVT" rw="RW"/>
+               <bitfield caption="Interrupt Vector Select"
+                         mask="0x40"
+                         name="IVSEL"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x1"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Level 0 Interrupt Executing"
+                         mask="0x01"
+                         name="LVL0EX"
+                         rw="R"/>
+               <bitfield caption="Level 1 Interrupt Executing"
+                         mask="0x02"
+                         name="LVL1EX"
+                         rw="R"/>
+               <bitfield caption="Non-maskable Interrupt Executing"
+                         mask="0x80"
+                         name="NMIEX"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Level 0 Priority"
+                      initval="0x00"
+                      name="LVL0PRI"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Level Priority"
+                         mask="0xFF"
+                         name="LVL0PRI"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Level 1 Priority Vector"
+                      initval="0x00"
+                      name="LVL1VEC"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Vector with High Priority"
+                         mask="0xFF"
+                         name="LVL1VEC"
+                         rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="CRCSCAN" id="math_pdi_crc_v1" name="CRCSCAN">
+         <register-group caption="CRCSCAN" name="CRCSCAN" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable CRC scan" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Enable NMI Trigger" mask="0x02" name="NMIEN" rw="RW"/>
+               <bitfield caption="Reset CRC scan" mask="0x80" name="RESET" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CRC Source"
+                         mask="0x03"
+                         name="SRC"
+                         rw="RW"
+                         values="CRCSCAN_SRC"/>
+            </register>
+            <register caption="Status"
+                      initval="0x02"
+                      name="STATUS"
+                      offset="0x2"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CRC Busy" mask="0x01" name="BUSY" rw="R"/>
+               <bitfield caption="CRC Ok" mask="0x02" name="OK" rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="CRC Source select" name="CRCSCAN_SRC">
+            <value caption="CRC on entire flash" name="FLASH" value="0x0"/>
+            <value caption="CRC on boot and appl section of flash"
+                   name="APPLICATION"
+                   value="0x1"/>
+            <value caption="CRC on boot section of flash" name="BOOT" value="0x2"/>
+         </value-group>
+      </module>
+      <module caption="Event System" id="avrdu" name="EVSYS">
+         <register-group caption="Event System" name="EVSYS" size="0x40">
+            <register caption="Software Event A"
+                      initval="0x00"
+                      name="SWEVENTA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Software event on channel select"
+                         mask="0xFF"
+                         name="SWEVENTA"
+                         rw="W"
+                         values="EVSYS_SWEVENTA"/>
+            </register>
+            <register caption="Multiplexer Channel 0"
+                      initval="0x00"
+                      name="CHANNEL0"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 1"
+                      initval="0x00"
+                      name="CHANNEL1"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 2"
+                      initval="0x00"
+                      name="CHANNEL2"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 3"
+                      initval="0x00"
+                      name="CHANNEL3"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 4"
+                      initval="0x00"
+                      name="CHANNEL4"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 5"
+                      initval="0x00"
+                      name="CHANNEL5"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="CCL0 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT0A"
+                      offset="0x20"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL0 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT0B"
+                      offset="0x21"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL1 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT1A"
+                      offset="0x22"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL1 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT1B"
+                      offset="0x23"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL2 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT2A"
+                      offset="0x24"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL2 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT2B"
+                      offset="0x25"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL3 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT3A"
+                      offset="0x26"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL3 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT3B"
+                      offset="0x27"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="ADC0"
+                      initval="0x00"
+                      name="USERADC0START"
+                      offset="0x28"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="EVOUTA"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTA"
+                      offset="0x29"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="EVOUTD"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTD"
+                      offset="0x2A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="EVOUTF"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTF"
+                      offset="0x2B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="USART0"
+                      initval="0x00"
+                      name="USERUSART0IRDA"
+                      offset="0x2C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="USART1"
+                      initval="0x00"
+                      name="USERUSART1IRDA"
+                      offset="0x2D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCA0 Event A"
+                      initval="0x00"
+                      name="USERTCA0CNTA"
+                      offset="0x2E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCA0 Event B"
+                      initval="0x00"
+                      name="USERTCA0CNTB"
+                      offset="0x2F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB0 Event A"
+                      initval="0x00"
+                      name="USERTCB0CAPT"
+                      offset="0x30"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB0 Event B"
+                      initval="0x00"
+                      name="USERTCB0COUNT"
+                      offset="0x31"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB1 Event A"
+                      initval="0x00"
+                      name="USERTCB1CAPT"
+                      offset="0x32"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB1 Event B"
+                      initval="0x00"
+                      name="USERTCB1COUNT"
+                      offset="0x33"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+         </register-group>
+         <value-group caption="Channel generator select" name="EVSYS_CHANNEL">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH Character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="Real Time Counter Overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter Compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Real Time Counter Event Output 0"
+                   name="RTC_EVGEN0"
+                   value="0x8"/>
+            <value caption="Real Time Counter Event Output 1"
+                   name="RTC_EVGEN1"
+                   value="0x9"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 Out" name="AC0_OUT" value="0x20"/>
+            <value caption="ADC0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="ADC0 Sample Ready" name="ADC0_SAMPRDY" value="0x25"/>
+            <value caption="ADC0 Window Comparator" name="ADC0_WCMP" value="0x26"/>
+            <value caption="Port A Event 0" name="PORTA_EVGEN0" value="0x40"/>
+            <value caption="Port A Event 1" name="PORTA_EVGEN1" value="0x41"/>
+            <value caption="Port C Event 0" name="PORTC_EVGEN0" value="0x44"/>
+            <value caption="Port C Event 1" name="PORTC_EVGEN1" value="0x45"/>
+            <value caption="Port D Event 0" name="PORTD_EVGEN0" value="0x46"/>
+            <value caption="Port D Event 1" name="PORTD_EVGEN1" value="0x47"/>
+            <value caption="Port F Event 0" name="PORTF_EVGEN0" value="0x4A"/>
+            <value caption="Port F Event 1" name="PORTF_EVGEN1" value="0x4B"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="Timer/Counter A0 Overflow / Low Byte Timer Underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 High Byte Timer Underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 Compare 0 / Low Byte Compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 Compare 1 / Low Byte Compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 Compare 2 / Low Byte Compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 Capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 Overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 Capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 Overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="USB0 Setup Received" name="USB0_SETUP" value="0xC0"/>
+            <value caption="USB0 SOF Received" name="USB0_SOF" value="0xC1"/>
+            <value caption="USB0 CRC Error" name="USB0_CRC" value="0xC2"/>
+            <value caption="USB0 Underflow / Overflow" name="USB0_UNFOVF" value="0xC3"/>
+            <value caption="USB0 Data Byte Received" name="USB0_RX" value="0xC4"/>
+            <value caption="USB0 Data Byte Transmitted" name="USB0_TX" value="0xC5"/>
+         </value-group>
+         <value-group caption="Software event on channel select" name="EVSYS_SWEVENTA">
+            <value caption="Software event on channel 0" name="CH0" value="0x01"/>
+            <value caption="Software event on channel 1" name="CH1" value="0x02"/>
+            <value caption="Software event on channel 2" name="CH2" value="0x04"/>
+            <value caption="Software event on channel 3" name="CH3" value="0x08"/>
+            <value caption="Software event on channel 4" name="CH4" value="0x10"/>
+            <value caption="Software event on channel 5" name="CH5" value="0x20"/>
+            <value caption="Software event on channel 6" name="CH6" value="0x40"/>
+            <value caption="Software event on channel 7" name="CH7" value="0x80"/>
+         </value-group>
+         <value-group caption="User channel select" name="EVSYS_USER">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="Connect user to event channel 0"
+                   name="CHANNEL0"
+                   value="0x1"/>
+            <value caption="Connect user to event channel 1"
+                   name="CHANNEL1"
+                   value="0x2"/>
+            <value caption="Connect user to event channel 2"
+                   name="CHANNEL2"
+                   value="0x3"/>
+            <value caption="Connect user to event channel 3"
+                   name="CHANNEL3"
+                   value="0x4"/>
+            <value caption="Connect user to event channel 4"
+                   name="CHANNEL4"
+                   value="0x5"/>
+            <value caption="Connect user to event channel 5"
+                   name="CHANNEL5"
+                   value="0x6"/>
+         </value-group>
+      </module>
+      <module caption="Fuses" id="avrdu" name="FUSE">
+         <register-group caption="Fuses" name="FUSE" size="0x0B">
+            <register caption="Watchdog Configuration"
+                      initval="0x00"
+                      name="WDTCFG"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Watchdog Timeout Period"
+                         mask="0x0F"
+                         name="PERIOD"
+                         rw="RW"
+                         values="FUSE_PERIOD"/>
+               <bitfield caption="Watchdog Window Timeout Period"
+                         mask="0xF0"
+                         name="WINDOW"
+                         rw="RW"
+                         values="FUSE_WINDOW"/>
+            </register>
+            <register caption="BOD Configuration"
+                      initval="0x00"
+                      name="BODCFG"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="BOD Operation in Sleep Mode"
+                         mask="0x03"
+                         name="SLEEP"
+                         rw="RW"
+                         values="FUSE_SLEEP"/>
+               <bitfield caption="BOD Operation in Active Mode"
+                         mask="0x0C"
+                         name="ACTIVE"
+                         rw="RW"
+                         values="FUSE_ACTIVE"/>
+               <bitfield caption="BOD Sample Frequency"
+                         mask="0x10"
+                         name="SAMPFREQ"
+                         rw="RW"
+                         values="FUSE_SAMPFREQ"/>
+               <bitfield caption="BOD Level"
+                         mask="0xE0"
+                         name="LVL"
+                         rw="RW"
+                         values="FUSE_LVL"/>
+            </register>
+            <register caption="Oscillator Configuration"
+                      initval="0x00"
+                      name="OSCCFG"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Frequency Select"
+                         mask="0x07"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="FUSE_CLKSEL"/>
+            </register>
+            <register caption="System Configuration 0"
+                      initval="0xD0"
+                      name="SYSCFG0"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Save" mask="0x01" name="EESAVE" rw="RW"/>
+               <bitfield caption="Boot Row Save" mask="0x02" name="BROWSAVE" rw="RW"/>
+               <bitfield caption="Reset Pin Configuration"
+                         mask="0x08"
+                         name="RSTPINCFG"
+                         rw="RW"
+                         values="FUSE_RSTPINCFG"/>
+               <bitfield caption="UPDI Pin Configuration"
+                         mask="0x10"
+                         name="UPDIPINCFG"
+                         rw="RW"
+                         values="FUSE_UPDIPINCFG"/>
+               <bitfield caption="CRC Select"
+                         mask="0x20"
+                         name="CRCSEL"
+                         rw="RW"
+                         values="FUSE_CRCSEL"/>
+               <bitfield caption="CRC Source"
+                         mask="0xC0"
+                         name="CRCSRC"
+                         rw="RW"
+                         values="FUSE_CRCSRC"/>
+            </register>
+            <register caption="System Configuration 1"
+                      initval="0x08"
+                      name="SYSCFG1"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Startup Time"
+                         mask="0x07"
+                         name="SUT"
+                         rw="RW"
+                         values="FUSE_SUT"/>
+               <bitfield caption="USB Voltage Regulator Current Sink Enable"
+                         mask="0x08"
+                         name="USBSINK"
+                         rw="RW"
+                         values="FUSE_USBSINK"/>
+            </register>
+            <register caption="Code Section Size"
+                      initval="0x00"
+                      name="CODESIZE"
+                      offset="0x7"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Boot Section Size"
+                      initval="0x00"
+                      name="BOOTSIZE"
+                      offset="0x8"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Programming and Debugging Interface Configuration"
+                      initval="0x0003"
+                      name="PDICFG"
+                      offset="0xA"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Protection Level"
+                         mask="0x03"
+                         name="LEVEL"
+                         rw="RW"
+                         values="FUSE_LEVEL"/>
+               <bitfield caption="NVM Protection Activation Key"
+                         mask="0xFFF0"
+                         name="KEY"
+                         rw="RW"
+                         values="FUSE_KEY"/>
+            </register>
+         </register-group>
+         <value-group caption="BOD Operation in Active Mode select" name="FUSE_ACTIVE">
+            <value caption="BOD disabled" name="DISABLE" value="0x00"/>
+            <value caption="BOD enabled in continuous mode" name="ENABLE" value="0x01"/>
+            <value caption="BOD enabled in sampled mode" name="SAMPLE" value="0x02"/>
+            <value caption="BOD enabled in continuous mode. Execution is halted at wake-up until BOD is running."
+                   name="ENABLEWAIT"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="BOD Level select" name="FUSE_LVL">
+            <value caption="1.9V" name="BODLEVEL0" value="0x00"/>
+            <value caption="2.45V" name="BODLEVEL1" value="0x01"/>
+            <value caption="2.7V" name="BODLEVEL2" value="0x02"/>
+            <value caption="2.85V" name="BODLEVEL3" value="0x03"/>
+         </value-group>
+         <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
+            <value caption="Sample frequency is 128 Hz" name="128Hz" value="0x0"/>
+            <value caption="Sample frequency is 32 Hz" name="32Hz" value="0x1"/>
+         </value-group>
+         <value-group caption="BOD Operation in Sleep Mode select" name="FUSE_SLEEP">
+            <value caption="BOD disabled" name="DISABLE" value="0x00"/>
+            <value caption="BOD enabled in continuous mode" name="ENABLE" value="0x01"/>
+            <value caption="BOD enabled in sampled mode" name="SAMPLE" value="0x02"/>
+         </value-group>
+         <value-group caption="Frequency Select" name="FUSE_CLKSEL">
+            <value caption="1-32MHz internal oscillator" name="OSCHF" value="0x0"/>
+            <value caption="32.768kHz internal oscillator" name="OSC32K" value="0x1"/>
+         </value-group>
+         <value-group caption="NVM Protection Activation Key select" name="FUSE_KEY">
+            <value caption="Not Active" name="NOTACT" value="0x000"/>
+            <value caption="NVM Protection Active" name="NVMACT" value="0xB45"/>
+         </value-group>
+         <value-group caption="Protection Level select" name="FUSE_LEVEL">
+            <value caption="NVM Access through UPDI disabled"
+                   name="NVMACCDIS"
+                   value="0x1"/>
+            <value caption="UPDI and UPDI pins working normally"
+                   name="BASIC"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="CRC Select" name="FUSE_CRCSEL">
+            <value caption="Enable CRC16" name="CRC16" value="0x0"/>
+            <value caption="Enable CRC32" name="CRC32" value="0x1"/>
+         </value-group>
+         <value-group caption="CRC Source select" name="FUSE_CRCSRC">
+            <value caption="CRC of full Flash (boot, application code and application data)"
+                   name="FLASH"
+                   value="0x0"/>
+            <value caption="CRC of boot section" name="BOOT" value="0x1"/>
+            <value caption="CRC of application code and boot sections"
+                   name="BOOTAPP"
+                   value="0x2"/>
+            <value caption="No CRC" name="NOCRC" value="0x3"/>
+         </value-group>
+         <value-group caption="Reset Pin Configuration select" name="FUSE_RSTPINCFG">
+            <value caption="GPIO mode" name="GPIO" value="0x0"/>
+            <value caption="Reset mode" name="RST" value="0x1"/>
+         </value-group>
+         <value-group caption="UPDI Pin Configuration select" name="FUSE_UPDIPINCFG">
+            <value caption="GPIO Mode" name="GPIO" value="0x0"/>
+            <value caption="UPDI Mode" name="UPDI" value="0x1"/>
+         </value-group>
+         <value-group caption="Startup Time select" name="FUSE_SUT">
+            <value caption="0 ms" name="0MS" value="0x00"/>
+            <value caption="1 ms" name="1MS" value="0x01"/>
+            <value caption="2 ms" name="2MS" value="0x02"/>
+            <value caption="4 ms" name="4MS" value="0x03"/>
+            <value caption="8 ms" name="8MS" value="0x04"/>
+            <value caption="16 ms" name="16MS" value="0x05"/>
+            <value caption="32 ms" name="32MS" value="0x06"/>
+            <value caption="64 ms" name="64MS" value="0x07"/>
+         </value-group>
+         <value-group caption="USB Voltage Regulator Current Sink Enable select"
+                      name="FUSE_USBSINK">
+            <value caption="USB VREG can not sink current" name="DISABLE" value="0x0"/>
+            <value caption="USB VREG can sink current" name="ENABLE" value="0x1"/>
+         </value-group>
+         <value-group caption="Watchdog Timeout Period select" name="FUSE_PERIOD">
+            <value caption="Watch-Dog timer Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.0s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.0s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+         <value-group caption="Watchdog Window Timeout Period select" name="FUSE_WINDOW">
+            <value caption="Window mode off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.0s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.0s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+      </module>
+      <module caption="General Purpose Registers" id="avrdu" name="GPR">
+         <register-group caption="General Purpose Registers" name="GPR" size="0x4">
+            <register caption="General Purpose Register 0"
+                      name="GPR0"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 1"
+                      name="GPR1"
+                      offset="0x1"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 2"
+                      name="GPR2"
+                      offset="0x2"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 3"
+                      name="GPR3"
+                      offset="0x3"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Lockbits" id="avrdu" name="LOCK">
+         <register-group caption="Lockbits" name="LOCK" size="0x4">
+            <register caption="Lock Key Bits"
+                      initval="0x5CC5C55C"
+                      name="KEY"
+                      offset="0x0"
+                      rw="RW"
+                      size="4">
+               <bitfield caption="Lock Key"
+                         mask="0xFFFFFFFF"
+                         name="KEY"
+                         rw="RW"
+                         values="LOCK_KEY"/>
+            </register>
+         </register-group>
+         <value-group caption="Lock Key select" name="LOCK_KEY">
+            <value caption="No locks" name="NOLOCK" value="0x5CC5C55C"/>
+            <value caption="Read and write lock" name="RWLOCK" value="0xA33A3AA3"/>
+         </value-group>
+      </module>
+      <module caption="Non-volatile Memory Controller"
+              id="nvm_ctrl_avr_v4"
+              name="NVMCTRL">
+         <register-group caption="Non-volatile Memory Controller" name="NVMCTRL" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x7F"
+                         name="CMD"
+                         rw="RW"
+                         values="NVMCTRL_CMD"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x30"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Application Code Write Protect"
+                         mask="0x01"
+                         name="APPCODEWP"
+                         rw="RW"/>
+               <bitfield caption="Boot Read Protect" mask="0x02" name="BOOTRP" rw="RW"/>
+               <bitfield caption="Application Data Write Protect"
+                         mask="0x04"
+                         name="APPDATAWP"
+                         rw="RW"/>
+               <bitfield caption="EEPROM Write Protect" mask="0x08" name="EEWP" rw="RW"/>
+               <bitfield caption="Flash Mapping in Data space"
+                         mask="0x30"
+                         name="FLMAP"
+                         rw="RW"
+                         values="NVMCTRL_FLMAP"/>
+               <bitfield caption="Flash Mapping Lock"
+                         mask="0x80"
+                         name="FLMAPLOCK"
+                         rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User Row Write Protect"
+                         mask="0x01"
+                         name="UROWWP"
+                         rw="RW"/>
+               <bitfield caption="Boot Row Write Protect"
+                         mask="0x02"
+                         name="BOOTROWWP"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Ready" mask="0x01" name="EEREADY" rw="RW"/>
+               <bitfield caption="Flash Ready" mask="0x02" name="FLREADY" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Ready" mask="0x01" name="EEREADY" rw="RW"/>
+               <bitfield caption="Flash Ready" mask="0x02" name="FLREADY" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x06"
+                      rw="R"
+                      size="1">
+               <bitfield caption="EEPROM busy" mask="0x01" name="EEBUSY" rw="R"/>
+               <bitfield caption="Flash busy" mask="0x02" name="FLBUSY" rw="R"/>
+               <bitfield caption="Write error"
+                         mask="0x70"
+                         name="ERROR"
+                         rw="R"
+                         values="NVMCTRL_ERROR"/>
+            </register>
+            <register caption="Data"
+                      initval="0x00000000"
+                      name="DATA"
+                      offset="0x08"
+                      rw="RW"
+                      size="4"/>
+            <register caption="Address"
+                      name="ADDR"
+                      offset="0x0C"
+                      rw="RW"
+                      size="4"/>
+         </register-group>
+         <value-group caption="Command select" name="NVMCTRL_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="No Operation" name="NOOP" value="0x01"/>
+            <value caption="Flash Write" name="FLWR" value="0x02"/>
+            <value caption="Flash Page Erase" name="FLPER" value="0x08"/>
+            <value caption="Flash Multi-Page Erase 2 pages"
+                   name="FLMPER2"
+                   value="0x09"/>
+            <value caption="Flash Multi-Page Erase 4 pages"
+                   name="FLMPER4"
+                   value="0x0A"/>
+            <value caption="Flash Multi-Page Erase 8 pages"
+                   name="FLMPER8"
+                   value="0x0B"/>
+            <value caption="Flash Multi-Page Erase 16 pages"
+                   name="FLMPER16"
+                   value="0x0C"/>
+            <value caption="Flash Multi-Page Erase 32 pages"
+                   name="FLMPER32"
+                   value="0x0D"/>
+            <value caption="EEPROM Write" name="EEWR" value="0x12"/>
+            <value caption="EEPROM Erase and Write" name="EEERWR" value="0x13"/>
+            <value caption="EEPROM Byte Erase" name="EEBER" value="0x18"/>
+            <value caption="EEPROM Multi-Byte Erase 2 bytes"
+                   name="EEMBER2"
+                   value="0x19"/>
+            <value caption="EEPROM Multi-Byte Erase 4 bytes"
+                   name="EEMBER4"
+                   value="0x1A"/>
+            <value caption="EEPROM Multi-Byte Erase 8 bytes"
+                   name="EEMBER8"
+                   value="0x1B"/>
+            <value caption="EEPROM Multi-Byte Erase 16 bytes"
+                   name="EEMBER16"
+                   value="0x1C"/>
+            <value caption="EEPROM Multi-Byte Erase 32 bytes"
+                   name="EEMBER32"
+                   value="0x1D"/>
+            <value caption="Chip Erase Command" name="CHER" value="0x20"/>
+            <value caption="EEPROM Erase Command" name="EECHER" value="0x30"/>
+         </value-group>
+         <value-group caption="Flash Mapping in Data space select" name="NVMCTRL_FLMAP">
+            <value caption="Flash section 0" name="SECTION0" value="0x0"/>
+            <value caption="Flash section 1" name="SECTION1" value="0x1"/>
+            <value caption="Flash section 2" name="SECTION2" value="0x2"/>
+            <value caption="Flash section 3" name="SECTION3" value="0x3"/>
+         </value-group>
+         <value-group caption="Write error select" name="NVMCTRL_ERROR">
+            <value caption="No Error" name="NOERROR" value="0x0"/>
+            <value caption="Write command not selected or not valid"
+                   name="INVALIDCMD"
+                   value="0x1"/>
+            <value caption="Write to section not allowed"
+                   name="WRITEPROTECT"
+                   value="0x2"/>
+            <value caption="Selecting new write command while programming is ongoing"
+                   name="CMDCOLLISION"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="I/O Ports" id="gpio_ports_avr_v3" name="PORT">
+         <register-group caption="I/O Ports" name="PORT" size="0x20">
+            <register caption="Data Direction"
+                      initval="0x00"
+                      name="DIR"
+                      offset="0x00"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Set"
+                      initval="0x00"
+                      name="DIRSET"
+                      offset="0x01"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Clear"
+                      initval="0x00"
+                      name="DIRCLR"
+                      offset="0x02"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Toggle"
+                      initval="0x00"
+                      name="DIRTGL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value"
+                      initval="0x00"
+                      name="OUT"
+                      offset="0x04"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Set"
+                      initval="0x00"
+                      name="OUTSET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Clear"
+                      initval="0x00"
+                      name="OUTCLR"
+                      offset="0x06"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Toggle"
+                      initval="0x00"
+                      name="OUTTGL"
+                      offset="0x07"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Input Value"
+                      initval="0x00"
+                      name="IN"
+                      offset="0x08"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin Interrupt Flag" mask="0xFF" name="INT" rw="RW"/>
+            </register>
+            <register caption="Port Control"
+                      initval="0x00"
+                      name="PORTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Slew Rate Limit Enable" mask="0x01" name="SRL" rw="RW"/>
+            </register>
+            <register caption="Pin Control Config"
+                      initval="0x00"
+                      name="PINCONFIG"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin Control Update"
+                      initval="0x00"
+                      name="PINCTRLUPD"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Pin Control Set"
+                      initval="0x00"
+                      name="PINCTRLSET"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Pin Control Clear"
+                      initval="0x00"
+                      name="PINCTRLCLR"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Pin 0 Control"
+                      initval="0x00"
+                      name="PIN0CTRL"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 1 Control"
+                      initval="0x00"
+                      name="PIN1CTRL"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 2 Control"
+                      initval="0x00"
+                      name="PIN2CTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 3 Control"
+                      initval="0x00"
+                      name="PIN3CTRL"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 4 Control"
+                      initval="0x00"
+                      name="PIN4CTRL"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 5 Control"
+                      initval="0x00"
+                      name="PIN5CTRL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 6 Control"
+                      initval="0x00"
+                      name="PIN6CTRL"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 7 Control"
+                      initval="0x00"
+                      name="PIN7CTRL"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Event Generation Control A"
+                      initval="0x00"
+                      name="EVGENCTRLA"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Generator 0 Select"
+                         mask="0x07"
+                         name="EVGEN0SEL"
+                         rw="RW"
+                         values="PORT_EVGEN0SEL"/>
+               <bitfield caption="Event Generator 1 Select"
+                         mask="0x70"
+                         name="EVGEN1SEL"
+                         rw="RW"
+                         values="PORT_EVGEN1SEL"/>
+            </register>
+         </register-group>
+         <value-group caption="Event Generator 0 Select" name="PORT_EVGEN0SEL">
+            <value caption="Pin 0 used as event generator" name="PIN0" value="0x0"/>
+            <value caption="Pin 1 used as event generator" name="PIN1" value="0x1"/>
+            <value caption="Pin 2 used as event generator" name="PIN2" value="0x2"/>
+            <value caption="Pin 3 used as event generator" name="PIN3" value="0x3"/>
+            <value caption="Pin 4 used as event generator" name="PIN4" value="0x4"/>
+            <value caption="Pin 5 used as event generator" name="PIN5" value="0x5"/>
+            <value caption="Pin 6 used as event generator" name="PIN6" value="0x6"/>
+            <value caption="Pin 7 used as event generator" name="PIN7" value="0x7"/>
+         </value-group>
+         <value-group caption="Event Generator 1 Select" name="PORT_EVGEN1SEL">
+            <value caption="Pin 0 used as event generator" name="PIN0" value="0x0"/>
+            <value caption="Pin 1 used as event generator" name="PIN1" value="0x1"/>
+            <value caption="Pin 2 used as event generator" name="PIN2" value="0x2"/>
+            <value caption="Pin 3 used as event generator" name="PIN3" value="0x3"/>
+            <value caption="Pin 4 used as event generator" name="PIN4" value="0x4"/>
+            <value caption="Pin 5 used as event generator" name="PIN5" value="0x5"/>
+            <value caption="Pin 6 used as event generator" name="PIN6" value="0x6"/>
+            <value caption="Pin 7 used as event generator" name="PIN7" value="0x7"/>
+         </value-group>
+         <value-group caption="Input Level Select" name="PORT_INLVL">
+            <value caption="Schmitt-Trigger input level" name="ST" value="0x0"/>
+            <value caption="TTL Input level" name="TTL" value="0x1"/>
+         </value-group>
+         <value-group caption="Input/Sense Configuration select" name="PORT_ISC">
+            <value caption="Interrupt disabled but input buffer enabled"
+                   name="INTDISABLE"
+                   value="0x0"/>
+            <value caption="Sense Both Edges" name="BOTHEDGES" value="0x1"/>
+            <value caption="Sense Rising Edge" name="RISING" value="0x2"/>
+            <value caption="Sense Falling Edge" name="FALLING" value="0x3"/>
+            <value caption="Digital Input Buffer disabled"
+                   name="INPUT_DISABLE"
+                   value="0x4"/>
+            <value caption="Sense low Level" name="LEVEL" value="0x5"/>
+         </value-group>
+      </module>
+      <module caption="Port Multiplexer" id="avrdu" name="PORTMUX">
+         <register-group caption="Port Multiplexer" name="PORTMUX" size="0x10">
+            <register caption="EVSYS route A"
+                      initval="0x00"
+                      name="EVSYSROUTEA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Output A"
+                         mask="0x01"
+                         name="EVOUTA"
+                         rw="RW"
+                         values="PORTMUX_EVOUTA"/>
+               <bitfield caption="Event Output D"
+                         mask="0x08"
+                         name="EVOUTD"
+                         rw="RW"
+                         values="PORTMUX_EVOUTD"/>
+               <bitfield caption="Event Output F"
+                         mask="0x20"
+                         name="EVOUTF"
+                         rw="RW"
+                         values="PORTMUX_EVOUTF"/>
+            </register>
+            <register caption="CCL route A"
+                      initval="0x00"
+                      name="CCLROUTEA"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CCL Look-Up Table 0 Signals"
+                         mask="0x01"
+                         name="LUT0"
+                         rw="RW"
+                         values="PORTMUX_LUT0"/>
+               <bitfield caption="CCL Look-Up Table 1 Signals"
+                         mask="0x02"
+                         name="LUT1"
+                         rw="RW"
+                         values="PORTMUX_LUT1"/>
+               <bitfield caption="CCL Look-Up Table 2 Signals"
+                         mask="0x04"
+                         name="LUT2"
+                         rw="RW"
+                         values="PORTMUX_LUT2"/>
+               <bitfield caption="CCL Look-Up Table 3 Signals"
+                         mask="0x08"
+                         name="LUT3"
+                         rw="RW"
+                         values="PORTMUX_LUT3"/>
+            </register>
+            <register caption="USART route A"
+                      initval="0x00"
+                      name="USARTROUTEA"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="USART0 Signals"
+                         mask="0x07"
+                         name="USART0"
+                         rw="RW"
+                         values="PORTMUX_USART0"/>
+               <bitfield caption="USART1 Signals"
+                         mask="0x18"
+                         name="USART1"
+                         rw="RW"
+                         values="PORTMUX_USART1"/>
+            </register>
+            <register caption="SPI route A"
+                      initval="0x00"
+                      name="SPIROUTEA"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SPI0 Signals"
+                         mask="0x07"
+                         name="SPI0"
+                         rw="RW"
+                         values="PORTMUX_SPI0"/>
+            </register>
+            <register caption="TWI route A"
+                      initval="0x00"
+                      name="TWIROUTEA"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TWI0 Signals"
+                         mask="0x03"
+                         name="TWI0"
+                         rw="RW"
+                         values="PORTMUX_TWI0"/>
+            </register>
+            <register caption="TCA route A"
+                      initval="0x00"
+                      name="TCAROUTEA"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCA0 Signals"
+                         mask="0x07"
+                         name="TCA0"
+                         rw="RW"
+                         values="PORTMUX_TCA0"/>
+            </register>
+            <register caption="TCB route A"
+                      initval="0x00"
+                      name="TCBROUTEA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCB0 Output"
+                         mask="0x01"
+                         name="TCB0"
+                         rw="RW"
+                         values="PORTMUX_TCB0"/>
+               <bitfield caption="TCB1 Output"
+                         mask="0x02"
+                         name="TCB1"
+                         rw="RW"
+                         values="PORTMUX_TCB1"/>
+            </register>
+         </register-group>
+         <value-group caption="CCL Look-Up Table 0 Signals select" name="PORTMUX_LUT0">
+            <value caption="In: PA0, PA1, PA2, Out: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="In: PA0, PA1, PA2, Out: PA6" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 1 Signals select" name="PORTMUX_LUT1">
+            <value caption="In: -, -, -, Out: PC3" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 2 Signals select" name="PORTMUX_LUT2">
+            <value caption="In: PD0, PD1, PD2, Out: PD3" name="DEFAULT" value="0x0"/>
+            <value caption="In: PD0, PD1, PD2, Out: PD6" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 3 Signals select" name="PORTMUX_LUT3">
+            <value caption="In: PF0, PF1, -, Out: -" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="Event Output A select" name="PORTMUX_EVOUTA">
+            <value caption="EVOUTA: PA2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTA: PA7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Output D select" name="PORTMUX_EVOUTD">
+            <value caption="EVOUTD: PD2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTD: PD7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Output F select" name="PORTMUX_EVOUTF">
+            <value caption="Not connected to any pins" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTF: PF7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="SPI0 Signals select" name="PORTMUX_SPI0">
+            <value caption="MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7"
+                   name="ALT4"
+                   value="0x4"/>
+            <value caption="Not connected to any pins, SS set to 1"
+                   name="NONE"
+                   value="0x7"/>
+         </value-group>
+         <value-group caption="TCA0 Signals select" name="PORTMUX_TCA0">
+            <value caption="WOn: PA0, PA1, PA2, PA3, PA4, PA5"
+                   name="PORTA"
+                   value="0x0"/>
+            <value caption="WOn: -, -, -, PC3, -, -" name="PORTC" value="0x2"/>
+            <value caption="WOn: PD0, PD1, PD2, PD3, PD4, PD5"
+                   name="PORTD"
+                   value="0x3"/>
+            <value caption="WOn: PF0, PF1, -, -, -, -" name="PORTF" value="0x5"/>
+         </value-group>
+         <value-group caption="TCB0 Output select" name="PORTMUX_TCB0">
+            <value caption="WO: PA2" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="TCB1 Output select" name="PORTMUX_TCB1">
+            <value caption="WO: PA3" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="TWI0 Signals select" name="PORTMUX_TWI0">
+            <value caption="SDA: PA2, SCL: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="SDA: PA0, SCL: PA1" name="ALT3" value="0x3"/>
+         </value-group>
+         <value-group caption="USART0 Signals select" name="PORTMUX_USART0">
+            <value caption="TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7"
+                   name="ALT1"
+                   value="0x1"/>
+            <value caption="TxD: PA2, RxD: PA3, XCK: -, XDIR: -"
+                   name="ALT2"
+                   value="0x2"/>
+            <value caption="TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7"
+                   name="ALT3"
+                   value="0x3"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x5"/>
+         </value-group>
+         <value-group caption="USART1 Signals select" name="PORTMUX_USART1">
+            <value caption="Not connected to any pins" name="DEFAULT" value="0x0"/>
+            <value caption="TxD: PD6, RxD: PD7, XCK: -, XDIR: -"
+                   name="ALT2"
+                   value="0x2"/>
+         </value-group>
+      </module>
+      <module caption="Reset controller" id="rst_integration_v8" name="RSTCTRL">
+         <register-group caption="Reset controller" name="RSTCTRL" size="0x4">
+            <register caption="Reset Flags"
+                      initval="0x00"
+                      name="RSTFR"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Power on Reset flag" mask="0x01" name="PORF" rw="RW"/>
+               <bitfield caption="Brown out detector Reset flag"
+                         mask="0x02"
+                         name="BORF"
+                         rw="RW"/>
+               <bitfield caption="External Reset flag" mask="0x04" name="EXTRF" rw="RW"/>
+               <bitfield caption="Watch dog Reset flag" mask="0x08" name="WDRF" rw="RW"/>
+               <bitfield caption="Software Reset flag" mask="0x10" name="SWRF" rw="RW"/>
+               <bitfield caption="UPDI Reset flag" mask="0x20" name="UPDIRF" rw="RW"/>
+            </register>
+            <register caption="Software Reset"
+                      initval="0x00"
+                      name="SWRR"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Software reset enable"
+                         mask="0x01"
+                         name="SWRST"
+                         rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Real-Time Counter" id="tmr_16b_rtc_avr_v2" name="RTC">
+         <register-group caption="Real-Time Counter" name="RTC" size="0x20">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="RTCEN" rw="RW"/>
+               <bitfield caption="Correction enable" mask="0x04" name="CORREN" rw="RW"/>
+               <bitfield caption="Prescaling Factor"
+                         mask="0x78"
+                         name="PRESCALER"
+                         rw="RW"
+                         values="RTC_PRESCALER"/>
+               <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x01"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CTRLA Synchronization Busy Flag"
+                         mask="0x01"
+                         name="CTRLABUSY"
+                         rw="R"/>
+               <bitfield caption="Count Synchronization Busy Flag"
+                         mask="0x02"
+                         name="CNTBUSY"
+                         rw="R"/>
+               <bitfield caption="Period Synchronization Busy Flag"
+                         mask="0x04"
+                         name="PERBUSY"
+                         rw="R"/>
+               <bitfield caption="Comparator Synchronization Busy Flag"
+                         mask="0x08"
+                         name="CMPBUSY"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt enable"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Compare Match Interrupt enable"
+                         mask="0x02"
+                         name="CMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Flag"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Compare Match Interrupt"
+                         mask="0x02"
+                         name="CMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Temporary"
+                      name="TEMP"
+                      offset="0x04"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Debug control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in debug" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Calibration"
+                      initval="0x00"
+                      name="CALIB"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Error Correction Value"
+                         mask="0x7F"
+                         name="ERROR"
+                         rw="RW"/>
+               <bitfield caption="Error Correction Sign Bit"
+                         mask="0x80"
+                         name="SIGN"
+                         rw="RW"/>
+            </register>
+            <register caption="Clock Select"
+                      initval="0x00"
+                      name="CLKSEL"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Select"
+                         mask="0x03"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="RTC_CLKSEL"/>
+            </register>
+            <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
+            <register caption="Period"
+                      initval="0xFFFF"
+                      name="PER"
+                      offset="0x0A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
+            <register caption="PIT Control A"
+                      initval="0x00"
+                      name="PITCTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="PITEN" rw="RW"/>
+               <bitfield caption="Period"
+                         mask="0x78"
+                         name="PERIOD"
+                         rw="RW"
+                         values="RTC_PERIOD"/>
+            </register>
+            <register caption="PIT Status"
+                      initval="0x00"
+                      name="PITSTATUS"
+                      offset="0x11"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CTRLA Synchronization Busy Flag"
+                         mask="0x01"
+                         name="CTRLBUSY"
+                         rw="R"/>
+            </register>
+            <register caption="PIT Interrupt Control"
+                      initval="0x00"
+                      name="PITINTCTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Periodic Interrupt" mask="0x01" name="PI" rw="RW"/>
+            </register>
+            <register caption="PIT Interrupt Flags"
+                      initval="0x00"
+                      name="PITINTFLAGS"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Periodic Interrupt" mask="0x01" name="PI" rw="RW"/>
+            </register>
+            <register caption="PIT Debug control"
+                      initval="0x00"
+                      name="PITDBGCTRL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in debug" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="PIT Event Generation Control A"
+                      initval="0x00"
+                      name="PITEVGENCTRLA"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Generation 0 Select"
+                         mask="0x0F"
+                         name="EVGEN0SEL"
+                         rw="RW"
+                         values="RTC_EVGEN0SEL"/>
+               <bitfield caption="Event Generation 1 Select"
+                         mask="0xF0"
+                         name="EVGEN1SEL"
+                         rw="RW"
+                         values="RTC_EVGEN1SEL"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock Select" name="RTC_CLKSEL">
+            <value caption="Internal 32.768 kHz Oscillator Divided by 32"
+                   name="OSC32K"
+                   value="0x0"/>
+            <value caption="32.768 kHz Crystal Oscillator" name="OSC1K" value="0x1"/>
+            <value caption="Internal 32.768 kHz Oscillator" name="XOSC32K" value="0x2"/>
+            <value caption="External Clock" name="EXTCLK" value="0x3"/>
+         </value-group>
+         <value-group caption="Prescaling Factor select" name="RTC_PRESCALER">
+            <value caption="RTC Clock / 1" name="DIV1" value="0x00"/>
+            <value caption="RTC Clock / 2" name="DIV2" value="0x01"/>
+            <value caption="RTC Clock / 4" name="DIV4" value="0x02"/>
+            <value caption="RTC Clock / 8" name="DIV8" value="0x03"/>
+            <value caption="RTC Clock / 16" name="DIV16" value="0x04"/>
+            <value caption="RTC Clock / 32" name="DIV32" value="0x05"/>
+            <value caption="RTC Clock / 64" name="DIV64" value="0x06"/>
+            <value caption="RTC Clock / 128" name="DIV128" value="0x07"/>
+            <value caption="RTC Clock / 256" name="DIV256" value="0x08"/>
+            <value caption="RTC Clock / 512" name="DIV512" value="0x09"/>
+            <value caption="RTC Clock / 1024" name="DIV1024" value="0x0A"/>
+            <value caption="RTC Clock / 2048" name="DIV2048" value="0x0B"/>
+            <value caption="RTC Clock / 4096" name="DIV4096" value="0x0C"/>
+            <value caption="RTC Clock / 8192" name="DIV8192" value="0x0D"/>
+            <value caption="RTC Clock / 16384" name="DIV16384" value="0x0E"/>
+            <value caption="RTC Clock / 32768" name="DIV32768" value="0x0F"/>
+         </value-group>
+         <value-group caption="Period select" name="RTC_PERIOD">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="RTC Clock Cycles 4" name="CYC4" value="0x01"/>
+            <value caption="RTC Clock Cycles 8" name="CYC8" value="0x02"/>
+            <value caption="RTC Clock Cycles 16" name="CYC16" value="0x03"/>
+            <value caption="RTC Clock Cycles 32" name="CYC32" value="0x04"/>
+            <value caption="RTC Clock Cycles 64" name="CYC64" value="0x05"/>
+            <value caption="RTC Clock Cycles 128" name="CYC128" value="0x06"/>
+            <value caption="RTC Clock Cycles 256" name="CYC256" value="0x07"/>
+            <value caption="RTC Clock Cycles 512" name="CYC512" value="0x08"/>
+            <value caption="RTC Clock Cycles 1024" name="CYC1024" value="0x09"/>
+            <value caption="RTC Clock Cycles 2048" name="CYC2048" value="0x0A"/>
+            <value caption="RTC Clock Cycles 4096" name="CYC4096" value="0x0B"/>
+            <value caption="RTC Clock Cycles 8192" name="CYC8192" value="0x0C"/>
+            <value caption="RTC Clock Cycles 16384" name="CYC16384" value="0x0D"/>
+            <value caption="RTC Clock Cycles 32768" name="CYC32768" value="0x0E"/>
+         </value-group>
+         <value-group caption="Event Generation 0 Select" name="RTC_EVGEN0SEL">
+            <value caption="No Event Generated" name="OFF" value="0x0"/>
+            <value caption="CLK_RTC divided by 4" name="DIV4" value="0x1"/>
+            <value caption="CLK_RTC divided by 8" name="DIV8" value="0x2"/>
+            <value caption="CLK_RTC divided by 16" name="DIV16" value="0x3"/>
+            <value caption="CLK_RTC divided by 32" name="DIV32" value="0x4"/>
+            <value caption="CLK_RTC divided by 64" name="DIV64" value="0x5"/>
+            <value caption="CLK_RTC divided by 128" name="DIV128" value="0x6"/>
+            <value caption="CLK_RTC divided by 256" name="DIV256" value="0x7"/>
+            <value caption="CLK_RTC divided by 512" name="DIV512" value="0x8"/>
+            <value caption="CLK_RTC divided by 1024" name="DIV1024" value="0x9"/>
+            <value caption="CLK_RTC divided by 2048" name="DIV2048" value="0xA"/>
+            <value caption="CLK_RTC divided by 4096" name="DIV4096" value="0xB"/>
+            <value caption="CLK_RTC divided by 8192" name="DIV8192" value="0xC"/>
+            <value caption="CLK_RTC divided by 16384" name="DIV16384" value="0xD"/>
+            <value caption="CLK_RTC divided by 32768" name="DIV32768" value="0xE"/>
+         </value-group>
+         <value-group caption="Event Generation 1 Select" name="RTC_EVGEN1SEL">
+            <value caption="No Event Generated" name="OFF" value="0x0"/>
+            <value caption="CLK_RTC divided by 4" name="DIV4" value="0x1"/>
+            <value caption="CLK_RTC divided by 8" name="DIV8" value="0x2"/>
+            <value caption="CLK_RTC divided by 16" name="DIV16" value="0x3"/>
+            <value caption="CLK_RTC divided by 32" name="DIV32" value="0x4"/>
+            <value caption="CLK_RTC divided by 64" name="DIV64" value="0x5"/>
+            <value caption="CLK_RTC divided by 128" name="DIV128" value="0x6"/>
+            <value caption="CLK_RTC divided by 256" name="DIV256" value="0x7"/>
+            <value caption="CLK_RTC divided by 512" name="DIV512" value="0x8"/>
+            <value caption="CLK_RTC divided by 1024" name="DIV1024" value="0x9"/>
+            <value caption="CLK_RTC divided by 2048" name="DIV2048" value="0xA"/>
+            <value caption="CLK_RTC divided by 4096" name="DIV4096" value="0xB"/>
+            <value caption="CLK_RTC divided by 8192" name="DIV8192" value="0xC"/>
+            <value caption="CLK_RTC divided by 16384" name="DIV16384" value="0xD"/>
+            <value caption="CLK_RTC divided by 32768" name="DIV32768" value="0xE"/>
+         </value-group>
+      </module>
+      <module caption="Signature row" id="avrdu" name="SIGROW">
+         <register-group caption="Signature row" name="SIGROW" size="0x40">
+            <register caption="Device ID Byte 0"
+                      name="DEVICEID0"
+                      offset="0x00"
+                      rw="R"
+                      size="1"/>
+            <register caption="Device ID Byte 1"
+                      name="DEVICEID1"
+                      offset="0x01"
+                      rw="R"
+                      size="1"/>
+            <register caption="Device ID Byte 2"
+                      name="DEVICEID2"
+                      offset="0x02"
+                      rw="R"
+                      size="1"/>
+            <register caption="Temperature Calibration 0"
+                      name="TEMPSENSE0"
+                      offset="0x04"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Temperature Calibration 0"
+                         mask="0xFFFF"
+                         name="TEMPSENSE0"
+                         rw="R"/>
+            </register>
+            <register caption="Temperature Calibration 1"
+                      name="TEMPSENSE1"
+                      offset="0x06"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Temperature Calibration 1"
+                         mask="0xFFFF"
+                         name="TEMPSENSE1"
+                         rw="R"/>
+            </register>
+            <register caption="LOTNUM0"
+                      name="SERNUM0"
+                      offset="0x10"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM1"
+                      name="SERNUM1"
+                      offset="0x11"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM2"
+                      name="SERNUM2"
+                      offset="0x12"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM3"
+                      name="SERNUM3"
+                      offset="0x13"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM4"
+                      name="SERNUM4"
+                      offset="0x14"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM5"
+                      name="SERNUM5"
+                      offset="0x15"
+                      rw="R"
+                      size="1"/>
+            <register caption="RANDOM"
+                      name="SERNUM6"
+                      offset="0x16"
+                      rw="R"
+                      size="1"/>
+            <register caption="SCRIBE"
+                      name="SERNUM7"
+                      offset="0x17"
+                      rw="R"
+                      size="1"/>
+            <register caption="XPOS0"
+                      name="SERNUM8"
+                      offset="0x18"
+                      rw="R"
+                      size="1"/>
+            <register caption="XPOS1"
+                      name="SERNUM9"
+                      offset="0x19"
+                      rw="R"
+                      size="1"/>
+            <register caption="YPOS0"
+                      name="SERNUM10"
+                      offset="0x1A"
+                      rw="R"
+                      size="1"/>
+            <register caption="YPOS1"
+                      name="SERNUM11"
+                      offset="0x1B"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES0"
+                      name="SERNUM12"
+                      offset="0x1C"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES1"
+                      name="SERNUM13"
+                      offset="0x1D"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES2"
+                      name="SERNUM14"
+                      offset="0x1E"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES3"
+                      name="SERNUM15"
+                      offset="0x1F"
+                      rw="R"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Sleep Controller"
+              id="clk_sleep_ctrl_avr_v3"
+              name="SLPCTRL">
+         <register-group caption="Sleep Controller" name="SLPCTRL" size="0x2">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sleep enable" mask="0x01" name="SEN" rw="RW"/>
+               <bitfield caption="Sleep mode"
+                         mask="0x06"
+                         name="SMODE"
+                         rw="RW"
+                         values="SLPCTRL_SMODE"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="VREGCTRL"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Performance Mode"
+                         mask="0x07"
+                         name="PMODE"
+                         rw="RW"
+                         values="SLPCTRL_PMODE"/>
+               <bitfield caption="High Temperature Low Leakage Enable"
+                         mask="0x10"
+                         name="HTLLEN"
+                         rw="RW"
+                         values="SLPCTRL_HTLLEN"/>
+            </register>
+         </register-group>
+         <value-group caption="Sleep mode select" name="SLPCTRL_SMODE">
+            <value caption="Idle mode" name="IDLE" value="0x00"/>
+            <value caption="Standby Mode" name="STDBY" value="0x01"/>
+            <value caption="Power-down Mode" name="PDOWN" value="0x02"/>
+         </value-group>
+         <value-group caption="High Temperature Low Leakage Enable select"
+                      name="SLPCTRL_HTLLEN">
+            <value caption="Disabled" name="OFF" value="0x0"/>
+            <value caption="Enabled" name="ON" value="0x1"/>
+         </value-group>
+         <value-group caption="Performance Mode select" name="SLPCTRL_PMODE">
+            <value caption="" name="AUTO" value="0x0"/>
+            <value caption="" name="FULL" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="Serial Peripheral Interface" id="spi_8bit_v2" name="SPI">
+         <register-group caption="Serial Peripheral Interface" name="SPI" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable Module" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Prescaler"
+                         mask="0x06"
+                         name="PRESC"
+                         rw="RW"
+                         values="SPI_PRESC"/>
+               <bitfield caption="Enable Double Speed" mask="0x10" name="CLK2X" rw="RW"/>
+               <bitfield caption="Host Operation Enable"
+                         mask="0x20"
+                         name="MASTER"
+                         rw="RW"/>
+               <bitfield caption="Data Order Setting" mask="0x40" name="DORD" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SPI Mode"
+                         mask="0x03"
+                         name="MODE"
+                         rw="RW"
+                         values="SPI_MODE"/>
+               <bitfield caption="SPI Select Disable" mask="0x04" name="SSD" rw="RW"/>
+               <bitfield caption="Buffer Mode Wait for Receive"
+                         mask="0x40"
+                         name="BUFWR"
+                         rw="RW"/>
+               <bitfield caption="Buffer Mode Enable" mask="0x80" name="BUFEN" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Enable" mask="0x01" name="IE" rw="RW"/>
+               <bitfield caption="SPI Select Trigger Interrupt Enable"
+                         mask="0x10"
+                         name="SSIE"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Enable"
+                         mask="0x20"
+                         name="DREIE"
+                         rw="RW"/>
+               <bitfield caption="Transfer Complete Interrupt Enable"
+                         mask="0x40"
+                         name="TXCIE"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Enable"
+                         mask="0x80"
+                         name="RXCIE"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="SPI.CTRLB.BUFEN" value="0"/>
+               <mode name="BUFFERED" qualifier="SPI.CTRLB.BUFEN" value="1"/>
+               <bitfield caption="Buffer Overflow"
+                         mask="0x01"
+                         modes="BUFFERED"
+                         name="BUFOVF"
+                         rw="RW"/>
+               <bitfield caption="SPI Select Trigger Interrupt Flag"
+                         mask="0x10"
+                         modes="BUFFERED"
+                         name="SSIF"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Flag"
+                         mask="0x20"
+                         modes="BUFFERED"
+                         name="DREIF"
+                         rw="RW"/>
+               <bitfield caption="Transfer Complete Interrupt Flag"
+                         mask="0x40"
+                         modes="BUFFERED"
+                         name="TXCIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         modes="BUFFERED"
+                         name="RXCIF"
+                         rw="RW"/>
+               <bitfield caption="Write Collision"
+                         mask="0x40"
+                         modes="DEFAULT"
+                         name="WRCOL"
+                         rw="RW"/>
+               <bitfield caption="Interrupt Flag"
+                         mask="0x80"
+                         modes="DEFAULT"
+                         name="IF"
+                         rw="RW"/>
+            </register>
+            <register caption="Data" name="DATA" offset="0x4" rw="RW" size="1"/>
+         </register-group>
+         <value-group caption="Prescaler select" name="SPI_PRESC">
+            <value caption="CLK_PER / 4" name="DIV4" value="0x00"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x01"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x02"/>
+            <value caption="CLK_PER / 128" name="DIV128" value="0x03"/>
+         </value-group>
+         <value-group caption="SPI Mode select" name="SPI_MODE">
+            <value caption="SPI Mode 0" name="0" value="0x00"/>
+            <value caption="SPI Mode 1" name="1" value="0x01"/>
+            <value caption="SPI Mode 2" name="2" value="0x02"/>
+            <value caption="SPI Mode 3" name="3" value="0x03"/>
+         </value-group>
+      </module>
+      <module caption="System Configuration Registers" id="avrdu" name="SYSCFG">
+         <register-group caption="System Configuration Registers" name="SYSCFG" size="0x20">
+            <register caption="Revision ID"
+                      name="REVID"
+                      offset="0x01"
+                      rw="RW"
+                      size="1"/>
+            <register caption="USB Voltage System Control"
+                      initval="0x00"
+                      name="VUSBCTRL"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="USB Voltage Regulator"
+                         mask="0x01"
+                         name="USBVREG"
+                         rw="RW"
+                         values="SYSCFG_USBVREG"/>
+            </register>
+         </register-group>
+         <value-group caption="USB Voltage Regulator select" name="SYSCFG_USBVREG">
+            <value caption="USBVREG is disabled" name="DISABLE" value="0x0"/>
+            <value caption="USBVREG is enabled" name="ENABLE" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="16-bit Timer/Counter Type A"
+              id="tmr_16b_pwm_v1"
+              name="TCA">
+         <register-group caption="16-bit Timer/Counter Type A" name="TCA" size="0x40">
+            <mode caption="Single Mode"
+                  name="SINGLE"
+                  qualifier="TCA.SINGLE.CTRLD.SPLITM"
+                  value="0"/>
+            <mode caption="Split Mode"
+                  name="SPLIT"
+                  qualifier="TCA.SPLIT.CTRLD.SPLITM"
+                  value="1"/>
+            <register caption="Control A"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Module Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Selection"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCA_SINGLE_CLKSEL"/>
+               <bitfield caption="Run in Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Waveform generation mode"
+                         mask="0x07"
+                         name="WGMODE"
+                         rw="RW"
+                         values="TCA_SINGLE_WGMODE"/>
+               <bitfield caption="Auto Lock Update" mask="0x08" name="ALUPD" rw="RW"/>
+               <bitfield caption="Compare 0 Enable" mask="0x10" name="CMP0EN" rw="RW"/>
+               <bitfield caption="Compare 1 Enable" mask="0x20" name="CMP1EN" rw="RW"/>
+               <bitfield caption="Compare 2 Enable" mask="0x40" name="CMP2EN" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Compare 0 Waveform Output Value"
+                         mask="0x01"
+                         name="CMP0OV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Waveform Output Value"
+                         mask="0x02"
+                         name="CMP1OV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Waveform Output Value"
+                         mask="0x04"
+                         name="CMP2OV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Split Mode Enable" mask="0x01" name="SPLITM" rw="RW"/>
+            </register>
+            <register caption="Control E Clear"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLECLR"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Direction" mask="0x01" name="DIR" rw="RW"/>
+               <bitfield caption="Lock Update" mask="0x02" name="LUPD" rw="RW"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SINGLE_CMD"/>
+            </register>
+            <register caption="Control E Set"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLESET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Direction"
+                         mask="0x01"
+                         name="DIR"
+                         rw="RW"
+                         values="TCA_SINGLE_DIR"/>
+               <bitfield caption="Lock Update" mask="0x02" name="LUPD" rw="RW"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SINGLE_CMD"/>
+            </register>
+            <register caption="Control F Clear"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLFCLR"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period Buffer Valid" mask="0x01" name="PERBV" rw="RW"/>
+               <bitfield caption="Compare 0 Buffer Valid"
+                         mask="0x02"
+                         name="CMP0BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Buffer Valid"
+                         mask="0x04"
+                         name="CMP1BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Buffer Valid"
+                         mask="0x08"
+                         name="CMP2BV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control F Set"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLFSET"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period Buffer Valid" mask="0x01" name="PERBV" rw="RW"/>
+               <bitfield caption="Compare 0 Buffer Valid"
+                         mask="0x02"
+                         name="CMP0BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Buffer Valid"
+                         mask="0x04"
+                         name="CMP1BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Buffer Valid"
+                         mask="0x08"
+                         name="CMP2BV"
+                         rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="EVCTRL"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Count on Event Input A"
+                         mask="0x01"
+                         name="CNTAEI"
+                         rw="RW"/>
+               <bitfield caption="Event Action A"
+                         mask="0x0E"
+                         name="EVACTA"
+                         rw="RW"
+                         values="TCA_SINGLE_EVACTA"/>
+               <bitfield caption="Count on Event Input B"
+                         mask="0x10"
+                         name="CNTBEI"
+                         rw="RW"/>
+               <bitfield caption="Event Action B"
+                         mask="0xE0"
+                         name="EVACTB"
+                         rw="RW"
+                         values="TCA_SINGLE_EVACTB"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="INTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt" mask="0x01" name="OVF" rw="RW"/>
+               <bitfield caption="Compare 0 Interrupt" mask="0x10" name="CMP0" rw="RW"/>
+               <bitfield caption="Compare 1 Interrupt" mask="0x20" name="CMP1" rw="RW"/>
+               <bitfield caption="Compare 2 Interrupt" mask="0x40" name="CMP2" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="INTFLAGS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt" mask="0x01" name="OVF" rw="RW"/>
+               <bitfield caption="Compare 0 Interrupt" mask="0x10" name="CMP0" rw="RW"/>
+               <bitfield caption="Compare 1 Interrupt" mask="0x20" name="CMP1" rw="RW"/>
+               <bitfield caption="Compare 2 Interrupt" mask="0x40" name="CMP2" rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary data for 16-bit Access"
+                      modes="SINGLE"
+                      name="TEMP"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Count"
+                      modes="SINGLE"
+                      name="CNT"
+                      offset="0x20"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Period"
+                      modes="SINGLE"
+                      name="PER"
+                      offset="0x26"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 0"
+                      modes="SINGLE"
+                      name="CMP0"
+                      offset="0x28"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 1"
+                      modes="SINGLE"
+                      name="CMP1"
+                      offset="0x2A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 2"
+                      modes="SINGLE"
+                      name="CMP2"
+                      offset="0x2C"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Period Buffer"
+                      modes="SINGLE"
+                      name="PERBUF"
+                      offset="0x36"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 0 Buffer"
+                      modes="SINGLE"
+                      name="CMP0BUF"
+                      offset="0x38"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 1 Buffer"
+                      modes="SINGLE"
+                      name="CMP1BUF"
+                      offset="0x3A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 2 Buffer"
+                      modes="SINGLE"
+                      name="CMP2BUF"
+                      offset="0x3C"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Control A"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Module Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Selection"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCA_SPLIT_CLKSEL"/>
+               <bitfield caption="Run in Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Compare 0 Enable"
+                         mask="0x01"
+                         name="LCMP0EN"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Enable"
+                         mask="0x02"
+                         name="LCMP1EN"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Enable"
+                         mask="0x04"
+                         name="LCMP2EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 0 Enable"
+                         mask="0x10"
+                         name="HCMP0EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 1 Enable"
+                         mask="0x20"
+                         name="HCMP1EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 2 Enable"
+                         mask="0x40"
+                         name="HCMP2EN"
+                         rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Compare 0 Output Value"
+                         mask="0x01"
+                         name="LCMP0OV"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Output Value"
+                         mask="0x02"
+                         name="LCMP1OV"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Output Value"
+                         mask="0x04"
+                         name="LCMP2OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 0 Output Value"
+                         mask="0x10"
+                         name="HCMP0OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 1 Output Value"
+                         mask="0x20"
+                         name="HCMP1OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 2 Output Value"
+                         mask="0x40"
+                         name="HCMP2OV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Split Mode Enable" mask="0x01" name="SPLITM" rw="RW"/>
+            </register>
+            <register caption="Control E Clear"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLECLR"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command Enable"
+                         mask="0x03"
+                         name="CMDEN"
+                         rw="RW"
+                         values="TCA_SPLIT_CMDEN"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SPLIT_CMD"/>
+            </register>
+            <register caption="Control E Set"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLESET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command Enable"
+                         mask="0x03"
+                         name="CMDEN"
+                         rw="RW"
+                         values="TCA_SPLIT_CMDEN"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SPLIT_CMD"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="INTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Underflow Interrupt Enable"
+                         mask="0x01"
+                         name="LUNF"
+                         rw="RW"/>
+               <bitfield caption="High Underflow Interrupt Enable"
+                         mask="0x02"
+                         name="HUNF"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 0 Interrupt Enable"
+                         mask="0x10"
+                         name="LCMP0"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Interrupt Enable"
+                         mask="0x20"
+                         name="LCMP1"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Interrupt Enable"
+                         mask="0x40"
+                         name="LCMP2"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="INTFLAGS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Underflow Interrupt Flag"
+                         mask="0x01"
+                         name="LUNF"
+                         rw="RW"/>
+               <bitfield caption="High Underflow Interrupt Flag"
+                         mask="0x02"
+                         name="HUNF"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Interrupt Flag"
+                         mask="0x10"
+                         name="LCMP0"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Interrupt Flag"
+                         mask="0x20"
+                         name="LCMP1"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 0 Interrupt Flag"
+                         mask="0x40"
+                         name="LCMP2"
+                         rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Low Count"
+                      modes="SPLIT"
+                      name="LCNT"
+                      offset="0x20"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Count"
+                      modes="SPLIT"
+                      name="HCNT"
+                      offset="0x21"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Period"
+                      modes="SPLIT"
+                      name="LPER"
+                      offset="0x26"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Period"
+                      modes="SPLIT"
+                      name="HPER"
+                      offset="0x27"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP0"
+                      offset="0x28"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP0"
+                      offset="0x29"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP1"
+                      offset="0x2A"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP1"
+                      offset="0x2B"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP2"
+                      offset="0x2C"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP2"
+                      offset="0x2D"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+         <value-group caption="Clock Selection" name="TCA_SINGLE_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER / 2" name="DIV2" value="0x01"/>
+            <value caption="CLK_PER / 4" name="DIV4" value="0x02"/>
+            <value caption="CLK_PER / 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x05"/>
+            <value caption="CLK_PER / 256" name="DIV256" value="0x06"/>
+            <value caption="CLK_PER / 1024" name="DIV1024" value="0x07"/>
+         </value-group>
+         <value-group caption="Waveform generation mode select" name="TCA_SINGLE_WGMODE">
+            <value caption="Normal Mode" name="NORMAL" value="0x00"/>
+            <value caption="Frequency Generation Mode" name="FRQ" value="0x01"/>
+            <value caption="Single Slope PWM" name="SINGLESLOPE" value="0x03"/>
+            <value caption="Dual Slope PWM, overflow on TOP" name="DSTOP" value="0x05"/>
+            <value caption="Dual Slope PWM, overflow on TOP and BOTTOM"
+                   name="DSBOTH"
+                   value="0x06"/>
+            <value caption="Dual Slope PWM, overflow on BOTTOM"
+                   name="DSBOTTOM"
+                   value="0x07"/>
+         </value-group>
+         <value-group caption="Command select" name="TCA_SINGLE_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="Force Update" name="UPDATE" value="0x01"/>
+            <value caption="Force Restart" name="RESTART" value="0x02"/>
+            <value caption="Force Hard Reset" name="RESET" value="0x03"/>
+         </value-group>
+         <value-group caption="Direction select" name="TCA_SINGLE_DIR">
+            <value caption="Count up" name="UP" value="0x0"/>
+            <value caption="Count down" name="DOWN" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Action A select" name="TCA_SINGLE_EVACTA">
+            <value caption="Count on positive edge event"
+                   name="CNT_POSEDGE"
+                   value="0x00"/>
+            <value caption="Count on any edge event" name="CNT_ANYEDGE" value="0x01"/>
+            <value caption="Count on prescaled clock while event line is 1."
+                   name="CNT_HIGHLVL"
+                   value="0x02"/>
+            <value caption="Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1."
+                   name="UPDOWN"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Event Action B select" name="TCA_SINGLE_EVACTB">
+            <value caption="No Action" name="NONE" value="0x00"/>
+            <value caption="Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1."
+                   name="UPDOWN"
+                   value="0x03"/>
+            <value caption="Restart counter at positive edge event"
+                   name="RESTART_POSEDGE"
+                   value="0x04"/>
+            <value caption="Restart counter on any edge event"
+                   name="RESTART_ANYEDGE"
+                   value="0x05"/>
+            <value caption="Restart counter while event line is 1."
+                   name="RESTART_HIGHLVL"
+                   value="0x06"/>
+         </value-group>
+         <value-group caption="Clock Selection" name="TCA_SPLIT_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER / 2" name="DIV2" value="0x01"/>
+            <value caption="CLK_PER / 4" name="DIV4" value="0x02"/>
+            <value caption="CLK_PER / 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x05"/>
+            <value caption="CLK_PER / 256" name="DIV256" value="0x06"/>
+            <value caption="CLK_PER / 1024" name="DIV1024" value="0x07"/>
+         </value-group>
+         <value-group caption="Command select" name="TCA_SPLIT_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="Force Update" name="UPDATE" value="0x01"/>
+            <value caption="Force Restart" name="RESTART" value="0x02"/>
+            <value caption="Force Hard Reset" name="RESET" value="0x03"/>
+         </value-group>
+         <value-group caption="Command Enable select" name="TCA_SPLIT_CMDEN">
+            <value caption="None" name="NONE" value="0x0"/>
+            <value caption="Both low byte and high byte counter"
+                   name="BOTH"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="16-bit Timer Type B" id="tmr_16b_capture_v1" name="TCB">
+         <register-group caption="16-bit Timer Type B" name="TCB" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Select"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCB_CLKSEL"/>
+               <bitfield caption="Synchronize Update" mask="0x10" name="SYNCUPD" rw="RW"/>
+               <bitfield caption="Cascade two timers" mask="0x20" name="CASCADE" rw="RW"/>
+               <bitfield caption="Run Standby" mask="0x40" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control Register B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Timer Mode"
+                         mask="0x07"
+                         name="CNTMODE"
+                         rw="RW"
+                         values="TCB_CNTMODE"/>
+               <bitfield caption="Pin Output Enable" mask="0x10" name="CCMPEN" rw="RW"/>
+               <bitfield caption="Pin Initial State" mask="0x20" name="CCMPINIT" rw="RW"/>
+               <bitfield caption="Asynchronous Enable" mask="0x40" name="ASYNC" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Input Enable" mask="0x01" name="CAPTEI" rw="RW"/>
+               <bitfield caption="Event Edge" mask="0x10" name="EDGE" rw="RW"/>
+               <bitfield caption="Input Capture Noise Cancellation Filter"
+                         mask="0x40"
+                         name="FILTER"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Capture or Timeout" mask="0x01" name="CAPT" rw="RW"/>
+               <bitfield caption="Overflow" mask="0x02" name="OVF" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Capture or Timeout" mask="0x01" name="CAPT" rw="RW"/>
+               <bitfield caption="Overflow" mask="0x02" name="OVF" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x7"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Run" mask="0x01" name="RUN" rw="R"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary Value"
+                      name="TEMP"
+                      offset="0x9"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Count"
+                      initval="0x0000"
+                      name="CNT"
+                      offset="0xA"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare or Capture"
+                      name="CCMP"
+                      offset="0xC"
+                      rw="RW"
+                      size="2"/>
+         </register-group>
+         <value-group caption="Clock Select" name="TCB_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER/2" name="DIV2" value="0x01"/>
+            <value caption="Use CLK_TCA from TCA0" name="TCA0" value="0x02"/>
+            <value caption="Count on event edge" name="EVENT" value="0x07"/>
+         </value-group>
+         <value-group caption="Timer Mode select" name="TCB_CNTMODE">
+            <value caption="Periodic Interrupt" name="INT" value="0x00"/>
+            <value caption="Periodic Timeout" name="TIMEOUT" value="0x01"/>
+            <value caption="Input Capture Event" name="CAPT" value="0x02"/>
+            <value caption="Input Capture Frequency measurement"
+                   name="FRQ"
+                   value="0x03"/>
+            <value caption="Input Capture Pulse-Width measurement"
+                   name="PW"
+                   value="0x04"/>
+            <value caption="Input Capture Frequency and Pulse-Width measurement"
+                   name="FRQPW"
+                   value="0x05"/>
+            <value caption="Single Shot" name="SINGLE" value="0x06"/>
+            <value caption="8-bit PWM" name="PWM8" value="0x07"/>
+         </value-group>
+      </module>
+      <module caption="Two-Wire Interface" id="i2c_8bit_avr_v3" name="TWI">
+         <register-group caption="Two-Wire Interface" name="TWI" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Fast-mode Plus Enable"
+                         mask="0x02"
+                         name="FMPEN"
+                         rw="RW"
+                         values="TWI_FMPEN"/>
+               <bitfield caption="SDA Hold Time"
+                         mask="0x0C"
+                         name="SDAHOLD"
+                         rw="RW"
+                         values="TWI_SDAHOLD"/>
+               <bitfield caption="SDA Setup Time"
+                         mask="0x10"
+                         name="SDASETUP"
+                         rw="RW"
+                         values="TWI_SDASETUP"/>
+               <bitfield caption="Input voltage transition level"
+                         mask="0x40"
+                         name="INPUTLVL"
+                         rw="RW"
+                         values="TWI_INPUTLVL"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run"
+                         mask="0x01"
+                         name="DBGRUN"
+                         rw="RW"
+                         values="TWI_DBGRUN"/>
+            </register>
+            <register caption="Host Control A"
+                      initval="0x00"
+                      name="MCTRLA"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Smart Mode Enable" mask="0x02" name="SMEN" rw="RW"/>
+               <bitfield caption="Inactive Bus Time-Out"
+                         mask="0x0C"
+                         name="TIMEOUT"
+                         rw="RW"
+                         values="TWI_TIMEOUT"/>
+               <bitfield caption="Quick Command Enable" mask="0x10" name="QCEN" rw="RW"/>
+               <bitfield caption="Write Interrupt Enable"
+                         mask="0x40"
+                         name="WIEN"
+                         rw="RW"/>
+               <bitfield caption="Read Interrupt Enable" mask="0x80" name="RIEN" rw="RW"/>
+            </register>
+            <register caption="Host Control B"
+                      initval="0x00"
+                      name="MCTRLB"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x03"
+                         name="MCMD"
+                         rw="RW"
+                         values="TWI_MCMD"/>
+               <bitfield caption="Acknowledge Action"
+                         mask="0x04"
+                         name="ACKACT"
+                         rw="RW"
+                         values="TWI_ACKACT"/>
+               <bitfield caption="Flush" mask="0x08" name="FLUSH" rw="RW"/>
+            </register>
+            <register caption="Host STATUS"
+                      initval="0x00"
+                      name="MSTATUS"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Bus State"
+                         mask="0x03"
+                         name="BUSSTATE"
+                         rw="RW"
+                         values="TWI_BUSSTATE"/>
+               <bitfield caption="Bus Error" mask="0x04" name="BUSERR" rw="RW"/>
+               <bitfield caption="Arbitration Lost" mask="0x08" name="ARBLOST" rw="RW"/>
+               <bitfield caption="Received Acknowledge" mask="0x10" name="RXACK" rw="R"/>
+               <bitfield caption="Clock Hold" mask="0x20" name="CLKHOLD" rw="RW"/>
+               <bitfield caption="Write Interrupt Flag" mask="0x40" name="WIF" rw="RW"/>
+               <bitfield caption="Read Interrupt Flag" mask="0x80" name="RIF" rw="RW"/>
+            </register>
+            <register caption="Host Baud Rate"
+                      initval="0x00"
+                      name="MBAUD"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Baud Rate" mask="0xFF" name="BAUD" rw="RW"/>
+            </register>
+            <register caption="Host Address"
+                      initval="0x00"
+                      name="MADDR"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address" mask="0xFF" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="Host Data"
+                      initval="0x00"
+                      name="MDATA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Data" mask="0xFF" name="DATA" rw="RW"/>
+            </register>
+            <register caption="Client Control A"
+                      initval="0x00"
+                      name="SCTRLA"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Smart Mode Enable" mask="0x02" name="SMEN" rw="RW"/>
+               <bitfield caption="Address Recognition Mode"
+                         mask="0x04"
+                         name="PMEN"
+                         rw="RW"/>
+               <bitfield caption="Stop Interrupt Enable" mask="0x20" name="PIEN" rw="RW"/>
+               <bitfield caption="Address or Stop Interrupt Enable"
+                         mask="0x40"
+                         name="APIEN"
+                         rw="RW"/>
+               <bitfield caption="Data Interrupt Enable" mask="0x80" name="DIEN" rw="RW"/>
+            </register>
+            <register caption="Client Control B"
+                      initval="0x00"
+                      name="SCTRLB"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x03"
+                         name="SCMD"
+                         rw="RW"
+                         values="TWI_SCMD"/>
+               <bitfield caption="Acknowledge Action"
+                         mask="0x04"
+                         name="ACKACT"
+                         rw="RW"
+                         values="TWI_ACKACT"/>
+            </register>
+            <register caption="Client Status"
+                      initval="0x00"
+                      name="SSTATUS"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address or Stop"
+                         mask="0x01"
+                         name="AP"
+                         rw="R"
+                         values="TWI_AP"/>
+               <bitfield caption="Read/Write Direction" mask="0x02" name="DIR" rw="R"/>
+               <bitfield caption="Bus Error" mask="0x04" name="BUSERR" rw="RW"/>
+               <bitfield caption="Collision" mask="0x08" name="COLL" rw="RW"/>
+               <bitfield caption="Received Acknowledge" mask="0x10" name="RXACK" rw="R"/>
+               <bitfield caption="Clock Hold" mask="0x20" name="CLKHOLD" rw="R"/>
+               <bitfield caption="Address or Stop Interrupt Flag"
+                         mask="0x40"
+                         name="APIF"
+                         rw="R"/>
+               <bitfield caption="Data Interrupt Flag" mask="0x80" name="DIF" rw="R"/>
+            </register>
+            <register caption="Client Address"
+                      initval="0x00"
+                      name="SADDR"
+                      offset="0xC"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address" mask="0xFF" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="Client Data"
+                      initval="0x00"
+                      name="SDATA"
+                      offset="0xD"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Data" mask="0xFF" name="DATA" rw="RW"/>
+            </register>
+            <register caption="Client Address Mask"
+                      initval="0x00"
+                      name="SADDRMASK"
+                      offset="0xE"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address Mask Enable" mask="0x01" name="ADDREN" rw="RW"/>
+               <bitfield caption="Address Mask" mask="0xFE" name="ADDRMASK" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Fast-mode Plus Enable select" name="TWI_FMPEN">
+            <value caption="Operating in Standard-mode or Fast-mode"
+                   name="OFF"
+                   value="0x0"/>
+            <value caption="Operating in Fast-mode Plus" name="ON" value="0x1"/>
+         </value-group>
+         <value-group caption="Input voltage transition level select" name="TWI_INPUTLVL">
+            <value caption="I2C input voltage transition level" name="I2C" value="0x0"/>
+            <value caption="SMBus 3.0 input voltage transition level"
+                   name="SMBUS"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="SDA Hold Time select" name="TWI_SDAHOLD">
+            <value caption="No SDA Hold Delay" name="OFF" value="0x0"/>
+            <value caption="Short SDA hold time" name="50NS" value="0x1"/>
+            <value caption="Meets SMBUS 2.0 specification under typical conditions"
+                   name="300NS"
+                   value="0x2"/>
+            <value caption="Meets SMBUS 2.0 specificaiton across all corners"
+                   name="500NS"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="SDA Setup Time select" name="TWI_SDASETUP">
+            <value caption="SDA setup time is four clock cycles" name="4CYC" value="0"/>
+            <value caption="SDA setup time is eight clock cycle" name="8CYC" value="1"/>
+         </value-group>
+         <value-group caption="Debug Run select" name="TWI_DBGRUN">
+            <value caption="The peripheral is halted in Break Debug mode and ignores events"
+                   name="HALT"
+                   value="0"/>
+            <value caption="The peripheral will continue to run in Break Debug mode when the CPU is halted"
+                   name="RUN"
+                   value="1"/>
+         </value-group>
+         <value-group caption="Inactive Bus Time-Out select" name="TWI_TIMEOUT">
+            <value caption="Bus time-out disabled. I2C." name="DISABLED" value="0"/>
+            <value caption="50us - SMBus" name="50US" value="1"/>
+            <value caption="100us" name="100US" value="2"/>
+            <value caption="200us" name="200US" value="3"/>
+         </value-group>
+         <value-group caption="Acknowledge Action select" name="TWI_ACKACT">
+            <value caption="Send ACK" name="ACK" value="0x0"/>
+            <value caption="Send NACK" name="NACK" value="0x1"/>
+         </value-group>
+         <value-group caption="Command select" name="TWI_MCMD">
+            <value caption="No action" name="NOACT" value="0"/>
+            <value caption="Execute Acknowledge Action followed by repeated Start."
+                   name="REPSTART"
+                   value="1"/>
+            <value caption="Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR."
+                   name="RECVTRANS"
+                   value="2"/>
+            <value caption="Execute Acknowledge Action followed by issuing a Stop condition."
+                   name="STOP"
+                   value="3"/>
+         </value-group>
+         <value-group caption="Bus State select" name="TWI_BUSSTATE">
+            <value caption="Unknown bus state" name="UNKNOWN" value="0"/>
+            <value caption="Bus is idle" name="IDLE" value="1"/>
+            <value caption="This TWI controls the bus" name="OWNER" value="2"/>
+            <value caption="The bus is busy" name="BUSY" value="3"/>
+         </value-group>
+         <value-group caption="Command select" name="TWI_SCMD">
+            <value caption="No Action" name="NOACT" value="0"/>
+            <value caption="Complete transaction" name="COMPTRANS" value="2"/>
+            <value caption="Used in response to an interrupt"
+                   name="RESPONSE"
+                   value="3"/>
+         </value-group>
+         <value-group caption="Address or Stop select" name="TWI_AP">
+            <value caption="A Stop condition generated the interrupt on APIF flag"
+                   name="STOP"
+                   value="0"/>
+            <value caption="Address detection generated the interrupt on APIF flag"
+                   name="ADR"
+                   value="1"/>
+         </value-group>
+      </module>
+      <module caption="Universal Synchronous and Asynchronous Receiver and Transmitter"
+              id="uart_autobd_v4"
+              name="USART">
+         <register-group caption="Universal Synchronous and Asynchronous Receiver and Transmitter"
+                         name="USART"
+                         size="0x10">
+            <register caption="Receive Data Low Byte"
+                      initval="0x00"
+                      name="RXDATAL"
+                      offset="0x0"
+                      rw="R"
+                      size="1">
+               <bitfield caption="RX Data" mask="0xFF" name="DATA" rw="R"/>
+            </register>
+            <register caption="Receive Data High Byte"
+                      initval="0x00"
+                      name="RXDATAH"
+                      offset="0x1"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Receiver Data Register"
+                         mask="0x01"
+                         name="DATA8"
+                         rw="R"/>
+               <bitfield caption="Parity Error" mask="0x02" name="PERR" rw="R"/>
+               <bitfield caption="Frame Error" mask="0x04" name="FERR" rw="R"/>
+               <bitfield caption="Buffer Overflow" mask="0x40" name="BUFOVF" rw="R"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         name="RXCIF"
+                         rw="R"/>
+            </register>
+            <register caption="Transmit Data Low Byte"
+                      initval="0x00"
+                      name="TXDATAL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit Data Register"
+                         mask="0xFF"
+                         name="DATA"
+                         rw="RW"/>
+            </register>
+            <register caption="Transmit Data High Byte"
+                      initval="0x00"
+                      name="TXDATAH"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit Data Register (CHSIZE=9bit)"
+                         mask="0x01"
+                         name="DATA8"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x20"
+                      name="STATUS"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Wait For Break" mask="0x01" name="WFB" rw="RW"/>
+               <bitfield caption="Break Detected Flag" mask="0x02" name="BDF" rw="RW"/>
+               <bitfield caption="Inconsistent Sync Field Interrupt Flag"
+                         mask="0x08"
+                         name="ISFIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Start Interrupt"
+                         mask="0x10"
+                         name="RXSIF"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Flag"
+                         mask="0x20"
+                         name="DREIF"
+                         rw="R"/>
+               <bitfield caption="Transmit Interrupt Flag"
+                         mask="0x40"
+                         name="TXCIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         name="RXCIF"
+                         rw="R"/>
+            </register>
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="RS485 Mode internal transmitter"
+                         mask="0x01"
+                         name="RS485"
+                         rw="RW"
+                         values="USART_RS485"/>
+               <bitfield caption="Auto-baud Error Interrupt Enable"
+                         mask="0x04"
+                         name="ABEIE"
+                         rw="RW"/>
+               <bitfield caption="Loop-back Mode Enable" mask="0x08" name="LBME" rw="RW"/>
+               <bitfield caption="Receiver Start Frame Interrupt Enable"
+                         mask="0x10"
+                         name="RXSIE"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Enable"
+                         mask="0x20"
+                         name="DREIE"
+                         rw="RW"/>
+               <bitfield caption="Transmit Complete Interrupt Enable"
+                         mask="0x40"
+                         name="TXCIE"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Enable"
+                         mask="0x80"
+                         name="RXCIE"
+                         rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Multi-processor Communication Mode"
+                         mask="0x01"
+                         name="MPCM"
+                         rw="RW"/>
+               <bitfield caption="Receiver Mode"
+                         mask="0x06"
+                         name="RXMODE"
+                         rw="RW"
+                         values="USART_RXMODE"/>
+               <bitfield caption="Open Drain Mode Enable"
+                         mask="0x08"
+                         name="ODME"
+                         rw="RW"/>
+               <bitfield caption="Start Frame Detection Enable"
+                         mask="0x10"
+                         name="SFDEN"
+                         rw="RW"/>
+               <bitfield caption="Transmitter Enable" mask="0x40" name="TXEN" rw="RW"/>
+               <bitfield caption="Reciever enable" mask="0x80" name="RXEN" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x03"
+                      name="CTRLC"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <mode name="NORMAL" qualifier="USART.CTRLC.CMODE" value="0x00 0x01 0x02"/>
+               <mode name="MSPI" qualifier="USART.CTRLC.CMODE" value="0x03"/>
+               <bitfield caption="Communication Mode"
+                         mask="0xC0"
+                         name="CMODE"
+                         rw="RW"
+                         values="USART_CMODE"/>
+               <bitfield caption="SPI Host Mode, Clock Phase"
+                         mask="0x02"
+                         modes="MSPI"
+                         name="UCPHA"
+                         rw="RW"/>
+               <bitfield caption="SPI Host Mode, Data Order"
+                         mask="0x04"
+                         modes="MSPI"
+                         name="UDORD"
+                         rw="RW"/>
+               <bitfield caption="Character Size"
+                         mask="0x07"
+                         modes="NORMAL"
+                         name="CHSIZE"
+                         rw="RW"
+                         values="USART_NORMAL_CHSIZE"/>
+               <bitfield caption="Stop Bit Mode"
+                         mask="0x08"
+                         modes="NORMAL"
+                         name="SBMODE"
+                         rw="RW"
+                         values="USART_NORMAL_SBMODE"/>
+               <bitfield caption="Parity Mode"
+                         mask="0x30"
+                         modes="NORMAL"
+                         name="PMODE"
+                         rw="RW"
+                         values="USART_NORMAL_PMODE"/>
+            </register>
+            <register caption="Baud Rate"
+                      initval="0x0000"
+                      name="BAUD"
+                      offset="0x8"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Auto Baud Window"
+                         mask="0xC0"
+                         name="ABW"
+                         rw="RW"
+                         values="USART_ABW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0xC"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="IrDA Event Input Enable"
+                         mask="0x01"
+                         name="IREI"
+                         rw="RW"/>
+            </register>
+            <register caption="IRCOM Transmitter Pulse Length Control"
+                      initval="0x00"
+                      name="TXPLCTRL"
+                      offset="0xD"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit pulse length" mask="0xFF" name="TXPL" rw="RW"/>
+            </register>
+            <register caption="IRCOM Receiver Pulse Length Control"
+                      initval="0x00"
+                      name="RXPLCTRL"
+                      offset="0xE"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Receiver Pulse Lenght" mask="0x7F" name="RXPL" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="RS485 Mode internal transmitter select" name="USART_RS485">
+            <value caption="RS485 Mode disabled" name="DISABLE" value="0x0"/>
+            <value caption="RS485 Mode enabled" name="ENABLE" value="0x1"/>
+         </value-group>
+         <value-group caption="Receiver Mode select" name="USART_RXMODE">
+            <value caption="Normal mode" name="NORMAL" value="0x0"/>
+            <value caption="CLK2x mode" name="CLK2X" value="0x1"/>
+            <value caption="Generic autobaud mode" name="GENAUTO" value="0x2"/>
+            <value caption="LIN constrained autobaud mode" name="LINAUTO" value="0x3"/>
+         </value-group>
+         <value-group caption="Communication Mode select" name="USART_CMODE">
+            <value caption="Asynchronous Mode" name="ASYNCHRONOUS" value="0x00"/>
+            <value caption="Synchronous Mode" name="SYNCHRONOUS" value="0x01"/>
+            <value caption="Infrared Communication" name="IRCOM" value="0x02"/>
+            <value caption="SPI Host Mode" name="MSPI" value="0x03"/>
+         </value-group>
+         <value-group caption="Character Size select" name="USART_NORMAL_CHSIZE">
+            <value caption="Character size: 5 bit" name="5BIT" value="0x00"/>
+            <value caption="Character size: 6 bit" name="6BIT" value="0x01"/>
+            <value caption="Character size: 7 bit" name="7BIT" value="0x02"/>
+            <value caption="Character size: 8 bit" name="8BIT" value="0x03"/>
+            <value caption="Character size: 9 bit read low byte first"
+                   name="9BITL"
+                   value="0x06"/>
+            <value caption="Character size: 9 bit read high byte first"
+                   name="9BITH"
+                   value="0x07"/>
+         </value-group>
+         <value-group caption="Parity Mode select" name="USART_NORMAL_PMODE">
+            <value caption="No Parity" name="DISABLED" value="0x00"/>
+            <value caption="Even Parity" name="EVEN" value="0x02"/>
+            <value caption="Odd Parity" name="ODD" value="0x03"/>
+         </value-group>
+         <value-group caption="Stop Bit Mode select" name="USART_NORMAL_SBMODE">
+            <value caption="1 stop bit" name="1BIT" value="0x0"/>
+            <value caption="2 stop bits" name="2BIT" value="0x1"/>
+         </value-group>
+         <value-group caption="Auto Baud Window select" name="USART_ABW">
+            <value caption="18% tolerance" name="WDW0" value="0x0"/>
+            <value caption="15% tolerance" name="WDW1" value="0x1"/>
+            <value caption="21% tolerance" name="WDW2" value="0x2"/>
+            <value caption="25% tolerance" name="WDW3" value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="USB Device Controller" id="usb_fscore_avr_v1" name="USB">
+         <register-group caption="USB Device Controller EP" name="USB_EP" size="0x8">
+            <register caption="Endpoint Status"
+                      name="STATUS"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="USB.CTRL.TYPE" value="0x00 0x01 0x02"/>
+               <mode name="ISO" qualifier="USB.CTRL.TYPE" value="0x03"/>
+               <bitfield caption="Data Buffer NAK" mask="0x02" name="BUSNAK" rw="RW"/>
+               <bitfield caption="Transaction Complete"
+                         mask="0x20"
+                         name="TRNCOMPL"
+                         rw="RW"/>
+               <bitfield caption="Underflow/Overflow EP"
+                         mask="0x40"
+                         name="UNFOVF"
+                         rw="RW"/>
+               <bitfield caption="Data Toggle"
+                         mask="0x01"
+                         modes="DEFAULT"
+                         name="TOGGLE"
+                         rw="RW"
+                         values="USB_DEFAULT_TOGGLE"/>
+               <bitfield caption="EP Stalled"
+                         mask="0x08"
+                         modes="DEFAULT"
+                         name="STALLED"
+                         rw="RW"/>
+               <bitfield caption="EP Setup Complete"
+                         mask="0x10"
+                         modes="DEFAULT"
+                         name="EPSETUP"
+                         rw="RW"/>
+               <bitfield caption="CRC Error"
+                         mask="0x80"
+                         modes="ISO"
+                         name="CRC"
+                         rw="RW"/>
+            </register>
+            <register caption="Endpoint Control"
+                      name="CTRL"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="USB.CTRL.TYPE" value="0x00 0x01 0x02"/>
+               <mode name="ISO" qualifier="USB.CTRL.TYPE" value="0x03"/>
+               <bitfield caption="TRNCOMPL Interrupt Disable"
+                         mask="0x08"
+                         name="TCDSBL"
+                         rw="RW"/>
+               <bitfield caption="Multipacket transfer enable"
+                         mask="0x20"
+                         name="MULTIPKT"
+                         rw="RW"/>
+               <bitfield caption="Endpoint type"
+                         mask="0xC0"
+                         name="TYPE"
+                         rw="RW"
+                         values="USB_TYPE"/>
+               <bitfield caption="Data Size default"
+                         mask="0x03"
+                         modes="DEFAULT"
+                         name="BUFSIZE"
+                         rw="RW"
+                         values="USB_DEFAULT_BUFSIZE"/>
+               <bitfield caption="Endpoint will respond with STALL"
+                         mask="0x04"
+                         modes="DEFAULT"
+                         name="DOSTALL"
+                         rw="RW"/>
+               <bitfield caption="Automatic zero length packet"
+                         mask="0x10"
+                         modes="DEFAULT"
+                         name="AZLP"
+                         rw="RW"/>
+               <bitfield caption="Data Size isochronous"
+                         mask="0x07"
+                         modes="ISO"
+                         name="BUFSIZE"
+                         rw="RW"
+                         values="USB_ISO_BUFSIZE"/>
+            </register>
+            <register caption="Endpoint Byte Count"
+                      name="CNT"
+                      offset="0x02"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Endpoint Byte Count" mask="0xFFFF" name="CNT" rw="RW"/>
+            </register>
+            <register caption="Endpoint Data Pointer"
+                      name="DATAPTR"
+                      offset="0x04"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Endpoint data pointer"
+                         mask="0xFFFF"
+                         name="DATAPTR"
+                         rw="RW"/>
+            </register>
+            <register caption="Endpoint Multi-packet Byte Count"
+                      name="MCNT"
+                      offset="0x06"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Multi-packet byte count"
+                         mask="0xFFFF"
+                         name="MCNT"
+                         rw="RW"/>
+            </register>
+         </register-group>
+         <register-group caption="USB Device Controller EP_PAIR"
+                         name="USB_EP_PAIR"
+                         size="0x10">
+            <register-group caption="USB Device Controller OUT"
+                            name="OUT"
+                            name-in-module="USB_EP"
+                            offset="0x00"
+                            size="0x08"/>
+            <register-group caption="USB Device Controller IN"
+                            name="IN"
+                            name-in-module="USB_EP"
+                            offset="0x08"
+                            size="0x08"/>
+         </register-group>
+         <register-group caption="USB Device Controller EP_TABLE"
+                         name="USB_EP_TABLE"
+                         size="0x122">
+            <register caption="FIFO Pointer Table"
+                      count="0x20"
+                      name="FIFO"
+                      offset="0x00"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Endpoint Direction"
+                         mask="0x08"
+                         name="DIR"
+                         rw="R"
+                         values="USB_DIR"/>
+               <bitfield caption="Endpoint Number" mask="0xF0" name="EPNUM" rw="R"/>
+            </register>
+            <register-group caption="USB Device Controller EP"
+                            count="0x10"
+                            name="EP"
+                            name-in-module="USB_EP_PAIR"
+                            offset="0x20"
+                            size="0x100"/>
+            <register caption="FRAMENUM count"
+                      name="FRAMENUM"
+                      offset="0x120"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Frame Number" mask="0x7FF" name="FRAMENUM" rw="R"/>
+               <bitfield caption="Frame Error" mask="0x8000" name="FRAMEERR" rw="R"/>
+            </register>
+         </register-group>
+         <register-group caption="USB Device Controller STATUS" name="USB_STATUS" size="0x4">
+            <register caption="Endpoint n OUT Status Clear"
+                      initval="0x00"
+                      name="OUTCLR"
+                      offset="0x00"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+            <register caption="Endpoint n OUT Status Set"
+                      initval="0x00"
+                      name="OUTSET"
+                      offset="0x01"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+            <register caption="Endpoint n IN Status Clear"
+                      initval="0x00"
+                      name="INCLR"
+                      offset="0x02"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+            <register caption="Endpoint n IN Status Set"
+                      initval="0x00"
+                      name="INSET"
+                      offset="0x03"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+         </register-group>
+         <register-group caption="USB Device Controller" name="USB" size="0x80">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Maximum Endpoint Address"
+                         mask="0x0F"
+                         name="MAXEP"
+                         rw="RW"/>
+               <bitfield caption="Store Frame Number Enable"
+                         mask="0x10"
+                         name="STFRNUM"
+                         rw="RW"/>
+               <bitfield caption="Transaction Complete FIFO Enable"
+                         mask="0x20"
+                         name="FIFOEN"
+                         rw="RW"/>
+               <bitfield caption="USB Enable" mask="0x80" name="ENABLE" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Attach" mask="0x01" name="ATTACH" rw="RW"/>
+               <bitfield caption="Respond with NAK on all Endpoints"
+                         mask="0x02"
+                         name="GNAK"
+                         rw="RW"/>
+               <bitfield caption="Set GNAK Automatically after SETUP"
+                         mask="0x04"
+                         name="GNAUTO"
+                         rw="RW"/>
+               <bitfield caption="Send Upstream Resume"
+                         mask="0x08"
+                         name="URESUME"
+                         rw="RW"/>
+            </register>
+            <register caption="Bus State"
+                      initval="0x00"
+                      name="BUSSTATE"
+                      offset="0x02"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Bus Reset" mask="0x01" name="BUSRST" rw="R"/>
+               <bitfield caption="Bus Suspended" mask="0x02" name="SUSPENDED" rw="R"/>
+               <bitfield caption="Downstram Resume" mask="0x04" name="DRESUME" rw="R"/>
+               <bitfield caption="Upstream Resume" mask="0x08" name="URESUME" rw="R"/>
+               <bitfield caption="Wait Time Resume" mask="0x10" name="WTRSM" rw="R"/>
+            </register>
+            <register caption="Address"
+                      initval="0x00"
+                      name="ADDR"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Device Address" mask="0x7F" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="FIFO Write Pointer"
+                      initval="0xFF"
+                      name="FIFOWP"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="FIFO Write Pointer" mask="0x1F" name="FIFOWP" rw="RW"/>
+            </register>
+            <register caption="FIFO Read Pointer"
+                      initval="0xFF"
+                      name="FIFORP"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="FIFO Read Pointer" mask="0x1F" name="FIFORP" rw="RW"/>
+            </register>
+            <register caption="Endpoint Configuration Table Pointer"
+                      initval="0x0000"
+                      name="EPPTR"
+                      offset="0x06"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Endpoint Configuration Table Pointer"
+                         mask="0xFFFF"
+                         name="EPPTR"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Control A"
+                      initval="0x00"
+                      name="INTCTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Enable"
+                         mask="0x02"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Underflow Interrupt Enable"
+                         mask="0x04"
+                         name="UNF"
+                         rw="RW"/>
+               <bitfield caption="STALL Interrupt Enable"
+                         mask="0x08"
+                         name="STALLED"
+                         rw="RW"/>
+               <bitfield caption="Reset Interrupt Enable"
+                         mask="0x10"
+                         name="RESET"
+                         rw="RW"/>
+               <bitfield caption="Resume Interrupt Enable"
+                         mask="0x20"
+                         name="RESUME"
+                         rw="RW"/>
+               <bitfield caption="Suspend Interrupt Enable"
+                         mask="0x40"
+                         name="SUSPEND"
+                         rw="RW"/>
+               <bitfield caption="Start Of Frame Interrupt Enable"
+                         mask="0x80"
+                         name="SOF"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control B"
+                      initval="0x00"
+                      name="INTCTRLB"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SETUP Transaction Complete Interrupt Enable"
+                         mask="0x01"
+                         name="SETUP"
+                         rw="RW"/>
+               <bitfield caption="GNAK Operation Done Interrupt Enable"
+                         mask="0x02"
+                         name="GNDONE"
+                         rw="RW"/>
+               <bitfield caption="Transaction Complete Interrupt Enable"
+                         mask="0x20"
+                         name="TRNCOMPL"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags A"
+                      initval="0x00"
+                      name="INTFLAGSA"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Flag"
+                         mask="0x02"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Underflow Interrupt Flag"
+                         mask="0x04"
+                         name="UNF"
+                         rw="RW"/>
+               <bitfield caption="STALL Interrupt Flag"
+                         mask="0x08"
+                         name="STALLED"
+                         rw="RW"/>
+               <bitfield caption="Reset Interrupt Flag" mask="0x10" name="RESET" rw="RW"/>
+               <bitfield caption="Resume Interrupt Flag"
+                         mask="0x20"
+                         name="RESUME"
+                         rw="RW"/>
+               <bitfield caption="Suspend Interrupt Flag"
+                         mask="0x40"
+                         name="SUSPEND"
+                         rw="RW"/>
+               <bitfield caption="Start Of Frame Interrupt Flag"
+                         mask="0x80"
+                         name="SOF"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags B"
+                      initval="0x00"
+                      name="INTFLAGSB"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SETUP Transaction Complete Interrupt Flag"
+                         mask="0x01"
+                         name="SETUP"
+                         rw="RW"/>
+               <bitfield caption="GNAK Operation Done Interrupt Flag"
+                         mask="0x02"
+                         name="GNDONE"
+                         rw="RW"/>
+               <bitfield caption="RMW Busy Flag" mask="0x04" name="RMWBUSY" rw="RW"/>
+               <bitfield caption="Transaction Complete Interrupt Flag"
+                         mask="0x20"
+                         name="TRNCOMPL"
+                         rw="RW"/>
+            </register>
+            <register-group caption="USB Device Controller STATUS"
+                            count="0x10"
+                            name="STATUS"
+                            name-in-module="USB_STATUS"
+                            offset="0x40"
+                            size="0x40"/>
+         </register-group>
+         <value-group caption="Data Size default select" name="USB_DEFAULT_BUFSIZE">
+            <value caption="8 bytes buffer size" name="BUF8" value="0x0"/>
+            <value caption="16 bytes buffer size" name="BUF16" value="0x1"/>
+            <value caption="32 bytes buffer size" name="BUF32" value="0x2"/>
+            <value caption="64 bytes buffer size" name="BUF64" value="0x3"/>
+         </value-group>
+         <value-group caption="Endpoint type select" name="USB_TYPE">
+            <value caption="Endpoint Disabled" name="DISABLE" value="0x0"/>
+            <value caption="Control" name="CONTROL" value="0x1"/>
+            <value caption="Bulk or Interrupt" name="BULKINT" value="0x2"/>
+            <value caption="Isochronous" name="ISO" value="0x3"/>
+         </value-group>
+         <value-group caption="Data Size isochronous select" name="USB_ISO_BUFSIZE">
+            <value caption="8 bytes buffer size" name="BUF8" value="0x0"/>
+            <value caption="16 bytes buffer size" name="BUF16" value="0x1"/>
+            <value caption="32 bytes buffer size" name="BUF32" value="0x2"/>
+            <value caption="64 bytes buffer size" name="BUF64" value="0x3"/>
+            <value caption="128 bytes buffer size" name="BUF128" value="0x4"/>
+            <value caption="256 bytes buffer size" name="BUF256" value="0x5"/>
+            <value caption="512 bytes buffer size" name="BUF512" value="0x6"/>
+            <value caption="1023 bytes buffer size" name="BUF1023" value="0x7"/>
+         </value-group>
+         <value-group caption="Endpoint Direction select" name="USB_DIR">
+            <value caption="OUT Endpoint" name="OUT" value="0x0"/>
+            <value caption="In Endpoint" name="IN" value="0x1"/>
+         </value-group>
+         <value-group caption="Data Toggle select" name="USB_DEFAULT_TOGGLE">
+            <value caption="DATA0 PID in next transaction" name="DATA0" value="0x0"/>
+            <value caption="DATA1 PID in next transaction" name="DATA1" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="User Row" id="avrdu" name="USERROW">
+         <register-group caption="User Row" name="USERROW" size="0x200">
+            <register caption="User Row"
+                      count="0x200"
+                      name="USERROW"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Virtual Ports" id="gpio_ports_avr_v3_vport" name="VPORT">
+         <register-group caption="Virtual Ports" name="VPORT" size="0x4">
+            <register caption="Data Direction"
+                      initval="0x00"
+                      name="DIR"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value"
+                      initval="0x00"
+                      name="OUT"
+                      offset="0x1"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Input Value"
+                      initval="0x00"
+                      name="IN"
+                      offset="0x2"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin Interrupt Flag" mask="0xFF" name="INT" rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Voltage reference" id="avrdu" name="VREF">
+         <register-group caption="Voltage reference" name="VREF" size="0x2">
+            <register caption="ADC0 Reference"
+                      initval="0x00"
+                      name="ACREF"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference select"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="VREF_REFSEL"/>
+               <bitfield caption="Always on" mask="0x80" name="ALWAYSON" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Reference select" name="VREF_REFSEL">
+            <value caption="Internal 1.024V reference" name="1V024" value="0x0"/>
+            <value caption="Internal 2.048V reference" name="2V048" value="0x1"/>
+            <value caption="Internal 4.096V reference" name="4V096" value="0x2"/>
+            <value caption="Internal 2.500V reference" name="2V500" value="0x3"/>
+            <value caption="VDD as reference" name="VDD" value="0x5"/>
+            <value caption="External reference on VREFA pin" name="VREFA" value="0x6"/>
+         </value-group>
+      </module>
+      <module caption="Watch-Dog Timer" id="wdt_windowed_v2" name="WDT">
+         <register-group caption="Watch-Dog Timer" name="WDT" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period"
+                         mask="0x0F"
+                         name="PERIOD"
+                         rw="RW"
+                         values="WDT_PERIOD"/>
+               <bitfield caption="Window"
+                         mask="0xF0"
+                         name="WINDOW"
+                         rw="RW"
+                         values="WDT_WINDOW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Syncronization busy"
+                         mask="0x01"
+                         name="SYNCBUSY"
+                         rw="R"/>
+               <bitfield caption="Lock enable" mask="0x80" name="LOCK" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Period select" name="WDT_PERIOD">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.1s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.2s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+         <value-group caption="Window select" name="WDT_WINDOW">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.1s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.2s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+      </module>
+   </modules>
+   <pinouts>
+      <pinout name="QFN28USB">
+         <pin pad="PA3" position="1"/>
+         <pin pad="PA4" position="2"/>
+         <pin pad="PA5" position="3"/>
+         <pin pad="PA6" position="4"/>
+         <pin pad="PA7" position="5"/>
+         <pin pad="VUSB" position="6"/>
+         <pin pad="DM" position="7"/>
+         <pin pad="DP" position="8"/>
+         <pin pad="PC3" position="9"/>
+         <pin pad="PD0" position="10"/>
+         <pin pad="PD1" position="11"/>
+         <pin pad="PD2" position="12"/>
+         <pin pad="PD3" position="13"/>
+         <pin pad="PD4" position="14"/>
+         <pin pad="PD5" position="15"/>
+         <pin pad="PD6" position="16"/>
+         <pin pad="PD7" position="17"/>
+         <pin pad="VDD1" position="18"/>
+         <pin pad="GND1" position="19"/>
+         <pin pad="PF0" position="20"/>
+         <pin pad="PF1" position="21"/>
+         <pin pad="PF6" position="22"/>
+         <pin pad="PF7" position="23"/>
+         <pin pad="VDD0" position="24"/>
+         <pin pad="GND0" position="25"/>
+         <pin pad="PA0" position="26"/>
+         <pin pad="PA1" position="27"/>
+         <pin pad="PA2" position="28"/>
+      </pinout>
+      <pinout name="SSOP28USB">
+         <pin pad="PA7" position="1"/>
+         <pin pad="VUSB" position="2"/>
+         <pin pad="DM" position="3"/>
+         <pin pad="DP" position="4"/>
+         <pin pad="PC3" position="5"/>
+         <pin pad="PD0" position="6"/>
+         <pin pad="PD1" position="7"/>
+         <pin pad="PD2" position="8"/>
+         <pin pad="PD3" position="9"/>
+         <pin pad="PD4" position="10"/>
+         <pin pad="PD5" position="11"/>
+         <pin pad="PD6" position="12"/>
+         <pin pad="PD7" position="13"/>
+         <pin pad="VDD1" position="14"/>
+         <pin pad="GND1" position="15"/>
+         <pin pad="PF0" position="16"/>
+         <pin pad="PF1" position="17"/>
+         <pin pad="PF6" position="18"/>
+         <pin pad="PF7" position="19"/>
+         <pin pad="VDD0" position="20"/>
+         <pin pad="GND0" position="21"/>
+         <pin pad="PA0" position="22"/>
+         <pin pad="PA1" position="23"/>
+         <pin pad="PA2" position="24"/>
+         <pin pad="PA3" position="25"/>
+         <pin pad="PA4" position="26"/>
+         <pin pad="PA5" position="27"/>
+         <pin pad="PA6" position="28"/>
+      </pinout>
+   </pinouts>
+</avr-tools-device-file>

--- a/vendor/avr64du32.atdf
+++ b/vendor/avr64du32.atdf
@@ -1,0 +1,6256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<avr-tools-device-file xmlns:NumHelper="NumHelper"
+                       xmlns:xalan="http://xml.apache.org/xalan"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       schema-version="4.5"
+                       xsi:noNamespaceSchemaLocation="schema/atdf.xsd">
+   <variants>
+      <variant ordercode="AVR64DU32-VQFN/TQFP"
+               package="QFP32"
+               pinout="QFN32USB"
+               speedmax="32000000"
+               tempmax="85"
+               tempmin="-40"
+               vccmax="5.5"
+               vccmin="1.8"/>
+   </variants>
+   <devices>
+      <device architecture="AVR8X" family="AVR" name="AVR64DU32">
+         <address-spaces>
+            <address-space endianness="little"
+                           id="data"
+                           name="data"
+                           size="0x10000"
+                           start="0x0000">
+               <memory-segment exec="0"
+                               name="IO"
+                               rw="RW"
+                               size="0x103F"
+                               start="0x00"
+                               type="io"/>
+               <memory-segment exec="0"
+                               name="LOCKBITS"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x04"
+                               start="0x1040"
+                               type="lockbits"/>
+               <memory-segment exec="0"
+                               name="FUSES"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x10"
+                               start="0x1050"
+                               type="fuses"/>
+               <memory-segment exec="0"
+                               name="SIGNATURES"
+                               pagesize="0x80"
+                               rw="R"
+                               size="0x03"
+                               start="0x1080"
+                               type="signatures"/>
+               <memory-segment exec="0"
+                               name="PROD_SIGNATURES"
+                               pagesize="0x80"
+                               rw="R"
+                               size="0x7D"
+                               start="0x1083"
+                               type="signatures"/>
+               <memory-segment exec="0"
+                               name="BOOTROW"
+                               pagesize="0x100"
+                               rw="RW"
+                               size="0x100"
+                               start="0x1100"
+                               type="user_signatures"/>
+               <memory-segment exec="0"
+                               name="USER_SIGNATURES"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x200"
+                               start="0x1200"
+                               type="user_signatures"/>
+               <memory-segment exec="0"
+                               name="EEPROM"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x100"
+                               start="0x1400"
+                               type="eeprom"/>
+               <memory-segment exec="0"
+                               name="INTERNAL_SRAM"
+                               rw="RW"
+                               size="0x2000"
+                               start="0x6000"
+                               type="ram"/>
+               <memory-segment exec="0"
+                               name="MAPPED_PROGMEM"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x8000"
+                               start="0x8000"
+                               type="other"/>
+            </address-space>
+            <address-space endianness="little"
+                           id="prog"
+                           name="prog"
+                           size="0x10000"
+                           start="0x0000">
+               <memory-segment exec="1"
+                               name="PROGMEM"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x10000"
+                               start="0x00"
+                               type="flash"/>
+            </address-space>
+         </address-spaces>
+         <peripherals>
+            <module id="cmp_control_v8" name="AC">
+               <instance name="AC0">
+                  <register-group address-space="data"
+                                  name="AC0"
+                                  name-in-module="AC"
+                                  offset="0x0680"/>
+                  <signals>
+                     <signal function="AC0" group="AINN" index="0" pad="PD3"/>
+                     <signal function="AC0" group="AINN" index="1" pad="PD0"/>
+                     <signal function="AC0" group="AINN" index="2" pad="PD7"/>
+                     <signal function="AC0" group="AINP" index="0" pad="PD2"/>
+                     <signal function="AC0" group="AINP" index="3" pad="PD6"/>
+                     <signal function="AC0" group="AINP" index="4" pad="PC3"/>
+                     <signal function="AC0" group="OUT" pad="PA7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="adc_10b_ctrl_avr_v1" name="ADC">
+               <instance name="ADC0">
+                  <register-group address-space="data"
+                                  name="ADC0"
+                                  name-in-module="ADC"
+                                  offset="0x0600"/>
+                  <signals>
+                     <signal function="AIN0" group="AIN" index="0" pad="PD0"/>
+                     <signal function="AIN0" group="AIN" index="1" pad="PD1"/>
+                     <signal function="AIN0" group="AIN" index="2" pad="PD2"/>
+                     <signal function="AIN0" group="AIN" index="3" pad="PD3"/>
+                     <signal function="AIN0" group="AIN" index="4" pad="PD4"/>
+                     <signal function="AIN0" group="AIN" index="5" pad="PD5"/>
+                     <signal function="AIN0" group="AIN" index="6" pad="PD6"/>
+                     <signal function="AIN0" group="AIN" index="7" pad="PD7"/>
+                     <signal function="AIN0" group="AIN" index="16" pad="PF0"/>
+                     <signal function="AIN0" group="AIN" index="17" pad="PF1"/>
+                     <signal function="AIN0" group="AIN" index="18" pad="PF2"/>
+                     <signal function="AIN0" group="AIN" index="19" pad="PF3"/>
+                     <signal function="AIN0" group="AIN" index="20" pad="PF4"/>
+                     <signal function="AIN0" group="AIN" index="21" pad="PF5"/>
+                     <signal function="AIN0" group="AIN" index="22" pad="PA2"/>
+                     <signal function="AIN0" group="AIN" index="23" pad="PA3"/>
+                     <signal function="AIN0" group="AIN" index="24" pad="PA4"/>
+                     <signal function="AIN0" group="AIN" index="25" pad="PA5"/>
+                     <signal function="AIN0" group="AIN" index="26" pad="PA6"/>
+                     <signal function="AIN0" group="AIN" index="27" pad="PA7"/>
+                     <signal function="AIN0" group="AIN" index="31" pad="PC3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="bor_lvd_ctrl_v1" name="BOD">
+               <instance name="BOD">
+                  <register-group address-space="data"
+                                  name="BOD"
+                                  name-in-module="BOD"
+                                  offset="0x00A0"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="BOOTROW">
+               <instance name="BOOTROW">
+                  <register-group address-space="data"
+                                  name="BOOTROW"
+                                  name-in-module="BOOTROW"
+                                  offset="0x1100"/>
+               </instance>
+            </module>
+            <module id="cla_ccl_v1" name="CCL">
+               <instance name="CCL">
+                  <register-group address-space="data"
+                                  name="CCL"
+                                  name-in-module="CCL"
+                                  offset="0x01C0"/>
+                  <signals>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_IN"
+                             index="0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_IN"
+                             index="1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_IN"
+                             index="2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL"
+                             group="LUT0_OUT"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_IN"
+                             index="0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_IN"
+                             index="1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_IN"
+                             index="2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="CCL_ALT1"
+                             group="LUT0_OUT"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT1"
+                             function="CCL"
+                             group="LUT1_OUT"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_IN"
+                             index="0"
+                             pad="PD0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_IN"
+                             index="1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_IN"
+                             index="2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL"
+                             group="LUT2_OUT"
+                             pad="PD3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_IN"
+                             index="0"
+                             pad="PD0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_IN"
+                             index="1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_IN"
+                             index="2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="CCL_ALT1"
+                             group="LUT2_OUT"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="CCL"
+                             group="LUT3_IN"
+                             index="0"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="CCL"
+                             group="LUT3_IN"
+                             index="1"
+                             pad="PF1"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="CCL"
+                             group="LUT3_IN"
+                             index="2"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="CCL"
+                             group="LUT3_OUT"
+                             pad="PF3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="CLKCTRL">
+               <instance name="CLKCTRL">
+                  <register-group address-space="data"
+                                  name="CLKCTRL"
+                                  name-in-module="CLKCTRL"
+                                  offset="0x0060"/>
+                  <signals>
+                     <signal function="CLKCTRL" group="CLKOUT" pad="PA7"/>
+                     <signal function="CLKCTRL" group="EXTCLK" pad="PA0"/>
+                     <signal function="CLKCTRL" group="XTAL32K1" pad="PF0"/>
+                     <signal function="CLKCTRL" group="XTAL32K2" pad="PF1"/>
+                     <signal function="CLKCTRL" group="XTALHF1" pad="PA0"/>
+                     <signal function="CLKCTRL" group="XTALHF2" pad="PA1"/>
+                     <signal function="CLKCTRL_ALT1" group="XTAL32K1" pad="PA0"/>
+                     <signal function="CLKCTRL_ALT1" group="XTAL32K2" pad="PA1"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="cpu_avr_xt_v1" name="CPU">
+               <instance name="CPU">
+                  <register-group address-space="data"
+                                  name="CPU"
+                                  name-in-module="CPU"
+                                  offset="0x0030"/>
+                  <parameters>
+                     <param name="CORE_VERSION" value="V4S"/>
+                  </parameters>
+               </instance>
+            </module>
+            <module id="int_8bit_v3" name="CPUINT">
+               <instance name="CPUINT">
+                  <register-group address-space="data"
+                                  name="CPUINT"
+                                  name-in-module="CPUINT"
+                                  offset="0x0110"/>
+               </instance>
+            </module>
+            <module id="math_pdi_crc_v1" name="CRCSCAN">
+               <instance name="CRCSCAN">
+                  <register-group address-space="data"
+                                  name="CRCSCAN"
+                                  name-in-module="CRCSCAN"
+                                  offset="0x0120"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="EVSYS">
+               <instance name="EVSYS">
+                  <register-group address-space="data"
+                                  name="EVSYS"
+                                  name-in-module="EVSYS"
+                                  offset="0x0200"/>
+                  <signals>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTA"
+                             function="EVSYS"
+                             group="EVOUT"
+                             index="0"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTA"
+                             function="EVSYS_ALT1"
+                             group="EVOUT"
+                             index="0"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTD"
+                             function="EVSYS"
+                             group="EVOUT"
+                             index="3"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTD"
+                             function="EVSYS_ALT1"
+                             group="EVOUT"
+                             index="3"
+                             pad="PD7"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTF"
+                             function="EVSYS"
+                             group="EVOUT"
+                             index="5"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTF"
+                             function="EVSYS_ALT1"
+                             group="EVOUT"
+                             index="5"
+                             pad="PF7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="FUSE">
+               <instance name="FUSE">
+                  <register-group address-space="data"
+                                  name="FUSE"
+                                  name-in-module="FUSE"
+                                  offset="0x1050"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="GPR">
+               <instance name="GPR">
+                  <register-group address-space="data"
+                                  name="GPR"
+                                  name-in-module="GPR"
+                                  offset="0x001C"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="LOCK">
+               <instance name="LOCK">
+                  <register-group address-space="data"
+                                  name="LOCK"
+                                  name-in-module="LOCK"
+                                  offset="0x1040"/>
+               </instance>
+            </module>
+            <module id="nvm_ctrl_avr_v4" name="NVMCTRL">
+               <instance name="NVMCTRL">
+                  <register-group address-space="data"
+                                  name="NVMCTRL"
+                                  name-in-module="NVMCTRL"
+                                  offset="0x1000"/>
+               </instance>
+            </module>
+            <module id="gpio_ports_avr_v3" name="PORT">
+               <instance name="PORTA">
+                  <register-group address-space="data"
+                                  name="PORTA"
+                                  name-in-module="PORT"
+                                  offset="0x0400"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="0" pad="PA0"/>
+                     <signal function="IOPORT" group="PIN" index="1" pad="PA1"/>
+                     <signal function="IOPORT" group="PIN" index="2" pad="PA2"/>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PA3"/>
+                     <signal function="IOPORT" group="PIN" index="4" pad="PA4"/>
+                     <signal function="IOPORT" group="PIN" index="5" pad="PA5"/>
+                     <signal function="IOPORT" group="PIN" index="6" pad="PA6"/>
+                     <signal function="IOPORT" group="PIN" index="7" pad="PA7"/>
+                  </signals>
+               </instance>
+               <instance name="PORTC">
+                  <register-group address-space="data"
+                                  name="PORTC"
+                                  name-in-module="PORT"
+                                  offset="0x0440"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PC3"/>
+                  </signals>
+               </instance>
+               <instance name="PORTD">
+                  <register-group address-space="data"
+                                  name="PORTD"
+                                  name-in-module="PORT"
+                                  offset="0x0460"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="0" pad="PD0"/>
+                     <signal function="IOPORT" group="PIN" index="1" pad="PD1"/>
+                     <signal function="IOPORT" group="PIN" index="2" pad="PD2"/>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PD3"/>
+                     <signal function="IOPORT" group="PIN" index="4" pad="PD4"/>
+                     <signal function="IOPORT" group="PIN" index="5" pad="PD5"/>
+                     <signal function="IOPORT" group="PIN" index="6" pad="PD6"/>
+                     <signal function="IOPORT" group="PIN" index="7" pad="PD7"/>
+                  </signals>
+               </instance>
+               <instance name="PORTF">
+                  <register-group address-space="data"
+                                  name="PORTF"
+                                  name-in-module="PORT"
+                                  offset="0x04A0"/>
+                  <signals>
+                     <signal function="IOPORT" group="PIN" index="0" pad="PF0"/>
+                     <signal function="IOPORT" group="PIN" index="1" pad="PF1"/>
+                     <signal function="IOPORT" group="PIN" index="2" pad="PF2"/>
+                     <signal function="IOPORT" group="PIN" index="3" pad="PF3"/>
+                     <signal function="IOPORT" group="PIN" index="4" pad="PF4"/>
+                     <signal function="IOPORT" group="PIN" index="5" pad="PF5"/>
+                     <signal function="IOPORT" group="PIN" index="6" pad="PF6"/>
+                     <signal function="IOPORT" group="PIN" index="7" pad="PF7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="PORTMUX">
+               <instance name="PORTMUX">
+                  <register-group address-space="data"
+                                  name="PORTMUX"
+                                  name-in-module="PORTMUX"
+                                  offset="0x05E0"/>
+               </instance>
+            </module>
+            <module id="rst_integration_v8" name="RSTCTRL">
+               <instance name="RSTCTRL">
+                  <register-group address-space="data"
+                                  name="RSTCTRL"
+                                  name-in-module="RSTCTRL"
+                                  offset="0x0040"/>
+                  <signals>
+                     <signal function="OTHER" group="RESET" pad="PF6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_16b_rtc_avr_v2" name="RTC">
+               <instance name="RTC">
+                  <register-group address-space="data"
+                                  name="RTC"
+                                  name-in-module="RTC"
+                                  offset="0x0140"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="SIGROW">
+               <instance name="SIGROW">
+                  <register-group address-space="data"
+                                  name="SIGROW"
+                                  name-in-module="SIGROW"
+                                  offset="0x1080"/>
+               </instance>
+            </module>
+            <module id="clk_sleep_ctrl_avr_v3" name="SLPCTRL">
+               <instance name="SLPCTRL">
+                  <register-group address-space="data"
+                                  name="SLPCTRL"
+                                  name-in-module="SLPCTRL"
+                                  offset="0x0050"/>
+               </instance>
+            </module>
+            <module id="spi_8bit_v2" name="SPI">
+               <instance name="SPI0">
+                  <register-group address-space="data"
+                                  name="SPI0"
+                                  name-in-module="SPI"
+                                  offset="0x0940"/>
+                  <signals>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="MISO"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="MOSI"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="SCK"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0"
+                             group="SS"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="MISO"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="MOSI"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="SCK"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="SPI0_ALT4"
+                             group="SS"
+                             pad="PD7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdu" name="SYSCFG">
+               <instance name="SYSCFG">
+                  <register-group address-space="data"
+                                  name="SYSCFG"
+                                  name-in-module="SYSCFG"
+                                  offset="0x0F00"/>
+               </instance>
+            </module>
+            <module id="tmr_16b_pwm_v1" name="TCA">
+               <instance name="TCA0">
+                  <register-group address-space="data"
+                                  name="TCA0"
+                                  name-in-module="TCA"
+                                  offset="0x0A00"/>
+                  <signals>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="3"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="4"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0"
+                             group="WO"
+                             index="5"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT2"
+                             group="WO"
+                             index="3"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="0"
+                             pad="PD0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="3"
+                             pad="PD3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="4"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT3"
+                             group="WO"
+                             index="5"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="0"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="1"
+                             pad="PF1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="2"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="3"
+                             pad="PF3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="4"
+                             pad="PF4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="TCA0_ALT5"
+                             group="WO"
+                             index="5"
+                             pad="PF5"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_16b_capture_v1" name="TCB">
+               <instance name="TCB0">
+                  <register-group address-space="data"
+                                  name="TCB0"
+                                  name-in-module="TCB"
+                                  offset="0x0B00"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB0"
+                             function="TCB0"
+                             group="WO"
+                             index="0"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TCBROUTEA.TCB0"
+                             function="TCB0_ALT1"
+                             group="WO"
+                             index="0"
+                             pad="PF4"/>
+                  </signals>
+               </instance>
+               <instance name="TCB1">
+                  <register-group address-space="data"
+                                  name="TCB1"
+                                  name-in-module="TCB"
+                                  offset="0x0B10"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB1"
+                             function="TCB1"
+                             group="WO"
+                             index="0"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TCBROUTEA.TCB1"
+                             function="TCB1_ALT1"
+                             group="WO"
+                             index="0"
+                             pad="PF5"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="i2c_8bit_avr_v3" name="TWI">
+               <instance name="TWI0">
+                  <register-group address-space="data"
+                                  name="TWI0"
+                                  name-in-module="TWI"
+                                  offset="0x0900"/>
+                  <signals>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0"
+                             group="SCL"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0"
+                             group="SDA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT1"
+                             group="SCL"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT1"
+                             group="SDA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT3"
+                             group="SCL"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="I2C0_ALT3"
+                             group="SDA"
+                             pad="PA0"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="uart_autobd_v4" name="USART">
+               <instance name="USART0">
+                  <register-group address-space="data"
+                                  name="USART0"
+                                  name-in-module="USART"
+                                  offset="0x0800"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="RXD"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="TXD"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="XCK"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0"
+                             group="XDIR"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="RXD"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="TXD"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="XCK"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT1"
+                             group="XDIR"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT2"
+                             group="RXD"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT2"
+                             group="TXD"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="RXD"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="TXD"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="XCK"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="USART0_ALT3"
+                             group="XDIR"
+                             pad="PD7"/>
+                  </signals>
+               </instance>
+               <instance name="USART1">
+                  <register-group address-space="data"
+                                  name="USART1"
+                                  name-in-module="USART"
+                                  offset="0x0820"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="USART1_ALT2"
+                             group="RXD"
+                             pad="PD7"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="USART1_ALT2"
+                             group="TXD"
+                             pad="PD6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="usb_fscore_avr_v1" name="USB">
+               <instance name="USB0">
+                  <register-group address-space="data"
+                                  name="USB0"
+                                  name-in-module="USB"
+                                  offset="0xC00"/>
+                  <signals>
+                     <signal function="DEFAULT" group="DM" pad="DM"/>
+                     <signal function="DEFAULT" group="DP" pad="DP"/>
+                  </signals>
+                  <parameters>
+                     <param name="USB_MAX_ENDPOINTS" value="16"/>
+                  </parameters>
+               </instance>
+            </module>
+            <module id="avrdu" name="USERROW">
+               <instance name="USERROW">
+                  <register-group address-space="data"
+                                  name="USERROW"
+                                  name-in-module="USERROW"
+                                  offset="0x1200"/>
+               </instance>
+            </module>
+            <module id="gpio_ports_avr_v3_vport" name="VPORT">
+               <instance name="VPORTA">
+                  <register-group address-space="data"
+                                  name="VPORTA"
+                                  name-in-module="VPORT"
+                                  offset="0x0000"/>
+               </instance>
+               <instance name="VPORTC">
+                  <register-group address-space="data"
+                                  name="VPORTC"
+                                  name-in-module="VPORT"
+                                  offset="0x0008"/>
+               </instance>
+               <instance name="VPORTD">
+                  <register-group address-space="data"
+                                  name="VPORTD"
+                                  name-in-module="VPORT"
+                                  offset="0x000C"/>
+               </instance>
+               <instance name="VPORTF">
+                  <register-group address-space="data"
+                                  name="VPORTF"
+                                  name-in-module="VPORT"
+                                  offset="0x0014"/>
+               </instance>
+            </module>
+            <module id="avrdu" name="VREF">
+               <instance name="VREF">
+                  <register-group address-space="data"
+                                  name="VREF"
+                                  name-in-module="VREF"
+                                  offset="0x00B0"/>
+               </instance>
+            </module>
+            <module id="wdt_windowed_v2" name="WDT">
+               <instance name="WDT">
+                  <register-group address-space="data"
+                                  name="WDT"
+                                  name-in-module="WDT"
+                                  offset="0x0100"/>
+               </instance>
+            </module>
+         </peripherals>
+         <interrupts>
+            <interrupt index="1" module-instance="CRCSCAN" name="NMI"/>
+            <interrupt index="2" module-instance="BOD" name="VLM"/>
+            <interrupt index="3" module-instance="CLKCTRL" name="CFD"/>
+            <interrupt index="4" module-instance="RTC" name="CNT"/>
+            <interrupt index="5" module-instance="RTC" name="PIT"/>
+            <interrupt index="6" module-instance="CCL" name="CCL"/>
+            <interrupt index="7" module-instance="USB0" name="BUSEVENT"/>
+            <interrupt index="8" module-instance="USB0" name="TRNCOMPL"/>
+            <interrupt index="9" module-instance="PORTA" name="PORT"/>
+            <interrupt index="10" module-instance="TCA0" name="LUNF"/>
+            <interrupt index="10" module-instance="TCA0" name="OVF"/>
+            <interrupt index="11" module-instance="TCA0" name="HUNF"/>
+            <interrupt index="12" module-instance="TCA0" name="CMP0"/>
+            <interrupt index="12" module-instance="TCA0" name="LCMP0"/>
+            <interrupt index="13" module-instance="TCA0" name="CMP1"/>
+            <interrupt index="13" module-instance="TCA0" name="LCMP1"/>
+            <interrupt index="14" module-instance="TCA0" name="CMP2"/>
+            <interrupt index="14" module-instance="TCA0" name="LCMP2"/>
+            <interrupt index="15" module-instance="TCB0" name="INT"/>
+            <interrupt index="16" module-instance="TWI0" name="TWIS"/>
+            <interrupt index="17" module-instance="TWI0" name="TWIM"/>
+            <interrupt index="18" module-instance="SPI0" name="INT"/>
+            <interrupt index="19" module-instance="USART0" name="RXC"/>
+            <interrupt index="20" module-instance="USART0" name="DRE"/>
+            <interrupt index="21" module-instance="USART0" name="TXC"/>
+            <interrupt index="22" module-instance="PORTD" name="PORT"/>
+            <interrupt index="23" module-instance="PORTC" name="PORT"/>
+            <interrupt index="24" module-instance="PORTF" name="PORT"/>
+            <interrupt index="25" module-instance="NVMCTRL" name="NVMREADY"/>
+            <interrupt index="26" module-instance="USART1" name="RXC"/>
+            <interrupt index="27" module-instance="USART1" name="DRE"/>
+            <interrupt index="28" module-instance="USART1" name="TXC"/>
+            <interrupt index="29" module-instance="TCB1" name="INT"/>
+            <interrupt index="30" module-instance="AC0" name="AC"/>
+            <interrupt index="31" module-instance="ADC0" name="ERROR"/>
+            <interrupt index="32" module-instance="ADC0" name="RESRDY"/>
+            <interrupt index="33" module-instance="ADC0" name="SAMPRDY"/>
+         </interrupts>
+         <interfaces>
+            <interface name="UPDI" type="updi"/>
+         </interfaces>
+         <property-groups>
+            <property-group name="OCD_FEATURES">
+               <property name="BREAK_PIN" value="PF6"/>
+               <property name="BREAK_PIN_ALT" value="PF2"/>
+            </property-group>
+            <property-group name="PROGRAMMING_INFO">
+               <property name="FUSE_ENABLED_VALUE" value="1"/>
+            </property-group>
+            <property-group name="UPDI_INTERFACE">
+               <property name="HV_IMPLEMENTATION" value="2"/>
+               <property name="PROGMEM_OFFSET" value="0x00800000"/>
+            </property-group>
+            <property-group name="SIGNATURES">
+               <property name="SIGNATURE0" value="0x1E"/>
+               <property name="SIGNATURE1" value="0x96"/>
+               <property name="SIGNATURE2" value="0x21"/>
+            </property-group>
+         </property-groups>
+      </device>
+   </devices>
+   <modules>
+      <module caption="Analog Comparator" id="cmp_control_v8" name="AC">
+         <register-group caption="Analog Comparator" name="AC" size="0x8">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Hysteresis Mode"
+                         mask="0x06"
+                         name="HYSMODE"
+                         rw="RW"
+                         values="AC_HYSMODE"/>
+               <bitfield caption="Power profile"
+                         mask="0x18"
+                         name="POWER"
+                         rw="RW"
+                         values="AC_POWER"/>
+               <bitfield caption="Output Pad Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTDBY"
+                         rw="RW"/>
+            </register>
+            <register caption="Mux Control A"
+                      initval="0x00"
+                      name="MUXCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Negative Input MUX Selection"
+                         mask="0x07"
+                         name="MUXNEG"
+                         rw="RW"
+                         values="AC_MUXNEG"/>
+               <bitfield caption="Positive Input MUX Selection"
+                         mask="0x38"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="AC_MUXPOS"/>
+               <bitfield caption="AC Output Initial Value"
+                         mask="0x40"
+                         name="INITVAL"
+                         rw="RW"
+                         values="AC_INITVAL"/>
+               <bitfield caption="Invert AC Output" mask="0x80" name="INVERT" rw="RW"/>
+            </register>
+            <register caption="DAC Voltage Reference"
+                      initval="0xFF"
+                      name="DACREF"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="DACREF" mask="0xFF" name="DACREF" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <mode name="NORMAL" qualifier="WINSEL" value="0x0"/>
+               <mode name="WINDOW" qualifier="WINSEL" value="0x1 0x2"/>
+               <bitfield caption="Interrupt Enable" mask="0x01" name="CMP" rw="RW"/>
+               <bitfield caption="Interrupt Mode"
+                         mask="0x30"
+                         modes="NORMAL"
+                         name="INTMODE"
+                         rw="RW"
+                         values="AC_NORMAL_INTMODE"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Comparator Interrupt Flag"
+                         mask="0x01"
+                         name="CMPIF"
+                         rw="RW"/>
+               <bitfield caption="Analog Comparator State"
+                         mask="0x10"
+                         name="CMPSTATE"
+                         rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="Hysteresis Mode select" name="AC_HYSMODE">
+            <value caption="No hysteresis" name="NONE" value="0x00"/>
+            <value caption="Small hysteresis" name="SMALL" value="0x01"/>
+            <value caption="Medium hysteresis" name="MEDIUM" value="0x02"/>
+            <value caption="Large hysteresis" name="LARGE" value="0x03"/>
+         </value-group>
+         <value-group caption="Power profile select" name="AC_POWER">
+            <value caption="Power profile 0, lowest consumption and highest response time."
+                   name="PROFILE0"
+                   value="0x00"/>
+            <value caption="Power profile 1" name="PROFILE1" value="0x01"/>
+            <value caption="Power profile 2" name="PROFILE2" value="0x02"/>
+            <value caption="Power profile 3" name="PROFILE3" value="0x03"/>
+         </value-group>
+         <value-group caption="Interrupt Mode select" name="AC_NORMAL_INTMODE">
+            <value caption="Positive and negative inputs crosses"
+                   name="BOTHEDGE"
+                   value="0x0"/>
+            <value caption="Positive input goes below negative input"
+                   name="NEGEDGE"
+                   value="0x2"/>
+            <value caption="Positive input goes above negative input"
+                   name="POSEDGE"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="AC Output Initial Value select" name="AC_INITVAL">
+            <value caption="Output initialized to 0" name="LOW" value="0x0"/>
+            <value caption="Output initialized to 1" name="HIGH" value="0x1"/>
+         </value-group>
+         <value-group caption="Negative Input MUX Selection" name="AC_MUXNEG">
+            <value caption="Negative Pin 0" name="AINN0" value="0x00"/>
+            <value caption="Negative Pin 1" name="AINN1" value="0x01"/>
+            <value caption="Negative Pin 2" name="AINN2" value="0x02"/>
+            <value caption="DAC Reference" name="DACREF" value="0x04"/>
+         </value-group>
+         <value-group caption="Positive Input MUX Selection" name="AC_MUXPOS">
+            <value caption="Positive Pin 0" name="AINP0" value="0x00"/>
+            <value caption="Positive Pin 3" name="AINP3" value="0x03"/>
+            <value caption="Positive Pin 4" name="AINP4" value="0x04"/>
+         </value-group>
+      </module>
+      <module caption="Analog to Digital Converter"
+              id="adc_10b_ctrl_avr_v1"
+              name="ADC">
+         <register-group caption="Analog to Digital Converter" name="ADC" size="0x40">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="ADC Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Conversion mode" mask="0x20" name="LOWLAT" rw="RW"/>
+               <bitfield caption="Run standby mode" mask="0x80" name="RUNSTBY" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Pre-scaler"
+                         mask="0x0F"
+                         name="PRESC"
+                         rw="RW"
+                         values="ADC_PRESC"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference Selection"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="ADC_REFSEL"/>
+            </register>
+            <register caption="Control E"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Window Comparator Mode"
+                         mask="0x07"
+                         name="WINCM"
+                         rw="RW"
+                         values="ADC_WINCM"/>
+               <bitfield caption="Window Mode Source" mask="0x08" name="WINSRC" rw="RW"/>
+            </register>
+            <register caption="Control F"
+                      initval="0x00"
+                      name="CTRLE"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sample Duration" mask="0xFF" name="SAMPDUR" rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLF"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sampling Number"
+                         mask="0x07"
+                         name="SAMPNUM"
+                         rw="RW"
+                         values="ADC_SAMPNUM"/>
+               <bitfield caption="Left Adjust" mask="0x10" name="LEFTADJ" rw="RW"/>
+               <bitfield caption="Free Running" mask="0x20" name="FREERUN" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Result Ready Interrupt Enable"
+                         mask="0x01"
+                         name="RESRDY"
+                         rw="RW"/>
+               <bitfield caption="Sample Ready Interrupt Enable"
+                         mask="0x02"
+                         name="SAMPRDY"
+                         rw="RW"/>
+               <bitfield caption="Window Comparator Interrupt Enable"
+                         mask="0x04"
+                         name="WCMP"
+                         rw="RW"/>
+               <bitfield caption="Result Overwrite Interrupt Enable"
+                         mask="0x08"
+                         name="RESOVR"
+                         rw="RW"/>
+               <bitfield caption="Sample Overwrite Interrupt Enable"
+                         mask="0x10"
+                         name="SAMPOVR"
+                         rw="RW"/>
+               <bitfield caption="Trigger Overrun Interrupt Enable"
+                         mask="0x20"
+                         name="TRIGOVR"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Result Ready Flag" mask="0x01" name="RESRDY" rw="RW"/>
+               <bitfield caption="Sample Ready Flag" mask="0x02" name="SAMPRDY" rw="RW"/>
+               <bitfield caption="Window Comparator Flag"
+                         mask="0x04"
+                         name="WCMP"
+                         rw="RW"/>
+               <bitfield caption="Result OverwriteFlag"
+                         mask="0x08"
+                         name="RESOVR"
+                         rw="RW"/>
+               <bitfield caption="Sample OverwriteFlag"
+                         mask="0x10"
+                         name="SAMPOVR"
+                         rw="RW"/>
+               <bitfield caption="Trigger OverrunFlag"
+                         mask="0x20"
+                         name="TRIGOVR"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="ADC Busy" mask="0x01" name="ADCBUSY" rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Command"
+                      initval="0x00"
+                      name="COMMAND"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Start Conversion"
+                         mask="0x07"
+                         name="START"
+                         rw="RW"
+                         values="ADC_START"/>
+               <bitfield caption="Mode"
+                         mask="0x70"
+                         name="MODE"
+                         rw="RW"
+                         values="ADC_MODE"/>
+            </register>
+            <register caption="Positive mux input"
+                      initval="0x00"
+                      name="MUXPOS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Channel Selection Bits"
+                         mask="0x7F"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="ADC_MUXPOS"/>
+            </register>
+            <register caption="ADC Accumulator Result"
+                      name="RESULT"
+                      offset="0x0C"
+                      rw="R"
+                      size="2">
+               <bitfield caption="ADC Result" mask="0xFFFF" name="RESULT" rw="R"/>
+            </register>
+            <register caption="ADC Sample"
+                      initval="0x0000"
+                      name="SAMPLE"
+                      offset="0x0E"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="ADC Sample" mask="0xFFFF" name="SAMPLE" rw="R"/>
+            </register>
+            <register caption="Window comparator low threshold"
+                      name="WINLT"
+                      offset="0x10"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Window Low Threshold"
+                         mask="0xFFFF"
+                         name="WINLT"
+                         rw="RW"/>
+            </register>
+            <register caption="Window comparator high threshold"
+                      name="WINHT"
+                      offset="0x12"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Window High Threshold"
+                         mask="0xFFFF"
+                         name="WINHT"
+                         rw="RW"/>
+            </register>
+            <register caption="Temporary Data"
+                      initval="0x00"
+                      name="TEMP"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Temporary" mask="0xFF" name="TEMP" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Mode select" name="ADC_MODE">
+            <value caption="Single 8-bit conv" name="SINGLE_8BIT" value="0x0"/>
+            <value caption="Single 10-bit conv" name="SINGLE_10BIT" value="0x1"/>
+            <value caption="Series of 10-bit conv" name="SERIES" value="0x2"/>
+            <value caption="Burst of 10-bit conv" name="BURST" value="0x3"/>
+            <value caption="Acc test mode for FuSa" name="ACCTEST" value="0x7"/>
+         </value-group>
+         <value-group caption="Start Conversion select" name="ADC_START">
+            <value caption="Stop/No ongoing conv" name="STOP" value="0x0"/>
+            <value caption="Start Immediately" name="IMMEDIATE" value="0x1"/>
+            <value caption="Start after a write to MUXPOS"
+                   name="MUXPOS_WRITE"
+                   value="0x2"/>
+            <value caption="Start upon event reception"
+                   name="EVENT_TTRIGGER"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="Clock Pre-scaler select" name="ADC_PRESC">
+            <value caption="CLK_PER divided by 2" name="DIV2" value="0x00"/>
+            <value caption="CLK_PER divided by 4" name="DIV4" value="0x01"/>
+            <value caption="CLK_PER divided by 6" name="DIV6" value="0x02"/>
+            <value caption="CLK_PER divided by 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER divided by 10" name="DIV10" value="0x04"/>
+            <value caption="CLK_PER divided by 12" name="DIV12" value="0x05"/>
+            <value caption="CLK_PER divided by 14" name="DIV14" value="0x06"/>
+            <value caption="CLK_PER divided by 16" name="DIV16" value="0x07"/>
+            <value caption="CLK_PER divided by 20" name="DIV20" value="0x08"/>
+            <value caption="CLK_PER divided by 24" name="DIV24" value="0x09"/>
+            <value caption="CLK_PER divided by 28" name="DIV28" value="0x0A"/>
+            <value caption="CLK_PER divided by 32" name="DIV32" value="0x0B"/>
+            <value caption="CLK_PER divided by 40" name="DIV40" value="0x0C"/>
+            <value caption="CLK_PER divided by 48" name="DIV48" value="0x0D"/>
+            <value caption="CLK_PER divided by 56" name="DIV56" value="0x0E"/>
+            <value caption="CLK_PER divided by 64" name="DIV64" value="0x0F"/>
+         </value-group>
+         <value-group caption="Reference Selection" name="ADC_REFSEL">
+            <value caption="VDD" name="VDD" value="0x00"/>
+            <value caption="VREFA" name="VREFA" value="0x02"/>
+            <value caption="1.024V" name="1V024" value="0x04"/>
+            <value caption="2.048V" name="2V048" value="0x05"/>
+            <value caption="4.096V" name="4V096" value="0x06"/>
+            <value caption="2.5V" name="2V500" value="0x7"/>
+         </value-group>
+         <value-group caption="Window Comparator Mode select" name="ADC_WINCM">
+            <value caption="No Window Comparison" name="NONE" value="0x00"/>
+            <value caption="Below Window" name="BELOW" value="0x01"/>
+            <value caption="Above Window" name="ABOVE" value="0x02"/>
+            <value caption="Inside Window" name="INSIDE" value="0x03"/>
+            <value caption="Outside Window" name="OUTSIDE" value="0x04"/>
+         </value-group>
+         <value-group caption="Sampling Number select" name="ADC_SAMPNUM">
+            <value caption="No accumulation" name="NONE" value="0x0"/>
+            <value caption="2 results accumulated" name="ACC2" value="0x1"/>
+            <value caption="4 results accumulated" name="ACC4" value="0x2"/>
+            <value caption="8 results accumulated" name="ACC8" value="0x3"/>
+            <value caption="16 results accumulated" name="ACC16" value="0x4"/>
+            <value caption="32 results accumulated" name="ACC32" value="0x5"/>
+            <value caption="64 results accumulated" name="ACC64" value="0x6"/>
+         </value-group>
+         <value-group caption="Analog Channel Selection Bits" name="ADC_MUXPOS">
+            <value caption="ADC input pin 0" name="AIN0" value="0x00"/>
+            <value caption="ADC input pin 1" name="AIN1" value="0x01"/>
+            <value caption="ADC input pin 2" name="AIN2" value="0x02"/>
+            <value caption="ADC input pin 3" name="AIN3" value="0x03"/>
+            <value caption="ADC input pin 4" name="AIN4" value="0x04"/>
+            <value caption="ADC input pin 5" name="AIN5" value="0x05"/>
+            <value caption="ADC input pin 6" name="AIN6" value="0x06"/>
+            <value caption="ADC input pin 7" name="AIN7" value="0x07"/>
+            <value caption="ADC input pin 16" name="AIN16" value="0x10"/>
+            <value caption="ADC input pin 17" name="AIN17" value="0x11"/>
+            <value caption="ADC input pin 18" name="AIN18" value="0x12"/>
+            <value caption="ADC input pin 19" name="AIN19" value="0x13"/>
+            <value caption="ADC input pin 20" name="AIN20" value="0x14"/>
+            <value caption="ADC input pin 21" name="AIN21" value="0x15"/>
+            <value caption="ADC input pin 22" name="AIN22" value="0x16"/>
+            <value caption="ADC input pin 23" name="AIN23" value="0x17"/>
+            <value caption="ADC input pin 24" name="AIN24" value="0x18"/>
+            <value caption="ADC input pin 25" name="AIN25" value="0x19"/>
+            <value caption="ADC input pin 26" name="AIN26" value="0x1A"/>
+            <value caption="ADC input pin 27" name="AIN27" value="0x1B"/>
+            <value caption="ADC input pin 31" name="AIN31" value="0x1F"/>
+            <value caption="Ground" name="GND" value="0x40"/>
+            <value caption="Temperature sensor" name="TEMPSENSE" value="0x42"/>
+            <value caption="VDD/10" name="VDDDIV10" value="0x44"/>
+            <value caption="AC0 DAC voltage" name="DACREF0" value="0x49"/>
+         </value-group>
+      </module>
+      <module caption="Bod interface" id="bor_lvd_ctrl_v1" name="BOD">
+         <register-group caption="Bod interface" name="BOD" size="0x10">
+            <register caption="Control A"
+                      initval="0x01"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Operation in sleep mode"
+                         mask="0x03"
+                         name="SLEEP"
+                         rw="RW"
+                         values="BOD_SLEEP"/>
+               <bitfield caption="Operation in active mode"
+                         mask="0x0C"
+                         name="ACTIVE"
+                         rw="R"
+                         values="BOD_ACTIVE"/>
+               <bitfield caption="Sample frequency"
+                         mask="0x10"
+                         name="SAMPFREQ"
+                         rw="R"
+                         values="BOD_SAMPFREQ"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Bod level"
+                         mask="0x07"
+                         name="LVL"
+                         rw="R"
+                         values="BOD_LVL"/>
+            </register>
+            <register caption="Voltage level monitor Control"
+                      initval="0x00"
+                      name="VLMCTRLA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="voltage level monitor level"
+                         mask="0x03"
+                         name="VLMLVL"
+                         rw="RW"
+                         values="BOD_VLMLVL"/>
+            </register>
+            <register caption="Voltage level monitor interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="voltage level monitor interrrupt enable"
+                         mask="0x01"
+                         name="VLMIE"
+                         rw="RW"/>
+               <bitfield caption="Configuration"
+                         mask="0x06"
+                         name="VLMCFG"
+                         rw="RW"
+                         values="BOD_VLMCFG"/>
+            </register>
+            <register caption="Voltage level monitor interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Voltage level monitor interrupt flag"
+                         mask="0x01"
+                         name="VLMIF"
+                         rw="RW"/>
+            </register>
+            <register caption="Voltage level monitor status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Voltage level monitor status"
+                         mask="0x01"
+                         name="VLMS"
+                         rw="R"
+                         values="BOD_VLMS"/>
+            </register>
+         </register-group>
+         <value-group caption="Operation in active mode select" name="BOD_ACTIVE">
+            <value caption="Disabled" name="DIS" value="0x00"/>
+            <value caption="Enabled" name="ENABLED" value="0x01"/>
+            <value caption="Sampled" name="SAMPLED" value="0x02"/>
+            <value caption="Enabled with wake-up halted until BOD is ready"
+                   name="ENWAKE"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Sample frequency select" name="BOD_SAMPFREQ">
+            <value caption="128Hz sampling frequency" name="128HZ" value="0x0"/>
+            <value caption="32Hz sampling frequency" name="32HZ" value="0x1"/>
+         </value-group>
+         <value-group caption="Operation in sleep mode select" name="BOD_SLEEP">
+            <value caption="Disabled" name="DIS" value="0x00"/>
+            <value caption="Enabled" name="ENABLED" value="0x01"/>
+            <value caption="Sampled" name="SAMPLED" value="0x02"/>
+         </value-group>
+         <value-group caption="Bod level select" name="BOD_LVL">
+            <value caption="1.9 V" name="BODLEVEL0" value="0x00"/>
+            <value caption="2.45 V" name="BODLEVEL1" value="0x01"/>
+            <value caption="2.7 V" name="BODLEVEL2" value="0x02"/>
+            <value caption="2.85 V" name="BODLEVEL3" value="0x03"/>
+         </value-group>
+         <value-group caption="Configuration select" name="BOD_VLMCFG">
+            <value caption="VDD falls below VLM threshold" name="FALLING" value="0x00"/>
+            <value caption="VDD rises above VLM threshold" name="RISING" value="0x01"/>
+            <value caption="VDD crosses VLM threshold" name="BOTH" value="0x02"/>
+         </value-group>
+         <value-group caption="Voltage level monitor status select" name="BOD_VLMS">
+            <value caption="The voltage is above the VLM threshold level"
+                   name="ABOVE"
+                   value="0x0"/>
+            <value caption="The voltage is below the VLM threshold level"
+                   name="BELOW"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="voltage level monitor level select" name="BOD_VLMLVL">
+            <value caption="VLM Disabled" name="OFF" value="0x0"/>
+            <value caption="VLM threshold 5% above BOD level"
+                   name="5ABOVE"
+                   value="0x1"/>
+            <value caption="VLM threshold 15% above BOD level"
+                   name="15ABOVE"
+                   value="0x2"/>
+            <value caption="VLM threshold 25% above BOD level"
+                   name="25ABOVE"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="Boot Row" id="avrdu" name="BOOTROW">
+         <register-group caption="Boot Row" name="BOOTROW" size="0x100">
+            <register caption="Boot row"
+                      count="0x100"
+                      name="BOOTROW"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Configurable Custom Logic" id="cla_ccl_v1" name="CCL">
+         <register-group caption="Configurable Custom Logic" name="CCL" size="0x40">
+            <register caption="Control Register A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Run in Standby" mask="0x40" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Sequential Control 0"
+                      initval="0x00"
+                      name="SEQCTRL0"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sequential Selection"
+                         mask="0x0F"
+                         name="SEQSEL"
+                         rw="RW"
+                         values="CCL_SEQSEL"/>
+            </register>
+            <register caption="Sequential Control 1"
+                      initval="0x00"
+                      name="SEQCTRL1"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sequential Selection"
+                         mask="0x0F"
+                         name="SEQSEL"
+                         rw="RW"
+                         values="CCL_SEQSEL"/>
+            </register>
+            <register caption="Interrupt Control 0"
+                      initval="0x00"
+                      name="INTCTRL0"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Mode for LUT0"
+                         mask="0x03"
+                         name="INTMODE0"
+                         rw="RW"
+                         values="CCL_INTMODE0"/>
+               <bitfield caption="Interrupt Mode for LUT1"
+                         mask="0x0C"
+                         name="INTMODE1"
+                         rw="RW"
+                         values="CCL_INTMODE1"/>
+               <bitfield caption="Interrupt Mode for LUT2"
+                         mask="0x30"
+                         name="INTMODE2"
+                         rw="RW"
+                         values="CCL_INTMODE2"/>
+               <bitfield caption="Interrupt Mode for LUT3"
+                         mask="0xC0"
+                         name="INTMODE3"
+                         rw="RW"
+                         values="CCL_INTMODE3"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Flag" mask="0x0F" name="INT" rw="RW"/>
+            </register>
+            <register caption="LUT 0 Control A"
+                      initval="0x00"
+                      name="LUT0CTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 0 Control B"
+                      initval="0x00"
+                      name="LUT0CTRLB"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 0 Control C"
+                      initval="0x00"
+                      name="LUT0CTRLC"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 0"
+                      initval="0x00"
+                      name="TRUTH0"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 1 Control A"
+                      initval="0x00"
+                      name="LUT1CTRLA"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 1 Control B"
+                      initval="0x00"
+                      name="LUT1CTRLB"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 1 Control C"
+                      initval="0x00"
+                      name="LUT1CTRLC"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 1"
+                      initval="0x00"
+                      name="TRUTH1"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 2 Control A"
+                      initval="0x00"
+                      name="LUT2CTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 2 Control B"
+                      initval="0x00"
+                      name="LUT2CTRLB"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 2 Control C"
+                      initval="0x00"
+                      name="LUT2CTRLC"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 2"
+                      initval="0x00"
+                      name="TRUTH2"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 3 Control A"
+                      initval="0x00"
+                      name="LUT3CTRLA"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 3 Control B"
+                      initval="0x00"
+                      name="LUT3CTRLB"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 3 Control C"
+                      initval="0x00"
+                      name="LUT3CTRLC"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 3"
+                      initval="0x00"
+                      name="TRUTH3"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Interrupt Mode for LUT0 select" name="CCL_INTMODE0">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT1 select" name="CCL_INTMODE1">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT2 select" name="CCL_INTMODE2">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT3 select" name="CCL_INTMODE3">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Clock Source Selection" name="CCL_CLKSRC">
+            <value caption="Peripheral Clock" name="CLKPER" value="0x0"/>
+            <value caption="Selection by INSEL2" name="IN2" value="0x1"/>
+            <value caption="Internal High-Frequency Oscillator"
+                   name="OSCHF"
+                   value="0x4"/>
+            <value caption="32.768 kHz oscillator" name="OSC32K" value="0x5"/>
+            <value caption="32.768 kHz oscillator divided by 32"
+                   name="OSC1K"
+                   value="0x6"/>
+         </value-group>
+         <value-group caption="Edge Detection Enable select" name="CCL_EDGEDET">
+            <value caption="Edge detector is disabled" name="DIS" value="0x0"/>
+            <value caption="Edge detector is enabled" name="EN" value="0x1"/>
+         </value-group>
+         <value-group caption="Filter Selection" name="CCL_FILTSEL">
+            <value caption="Filter disabled" name="DISABLE" value="0x0"/>
+            <value caption="Synchronizer enabled" name="SYNCH" value="0x1"/>
+            <value caption="Filter enabled" name="FILTER" value="0x2"/>
+         </value-group>
+         <value-group caption="LUT Input 0 Source Selection" name="CCL_INSEL0">
+            <value caption="Masked input" name="MASK" value="0x0"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x1"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x2"/>
+            <value caption="Event input source A" name="EVENTA" value="0x3"/>
+            <value caption="Event input source B" name="EVENTB" value="0x4"/>
+            <value caption="IO pin LUTn-IN0 input source" name="IN0" value="0x5"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x6"/>
+            <value caption="USART0 TXD input source" name="USART0" value="0x7"/>
+            <value caption="SPI0 MOSI input source" name="SPI0" value="0x8"/>
+            <value caption="TCA0 WO0 input source" name="TCA0" value="0x9"/>
+            <value caption="TCB0 WO input source" name="TCB0" value="0xA"/>
+         </value-group>
+         <value-group caption="LUT Input 1 Source Selection" name="CCL_INSEL1">
+            <value caption="Masked input" name="MASK" value="0x0"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x1"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x2"/>
+            <value caption="Event input source A" name="EVENTA" value="0x3"/>
+            <value caption="Event input source B" name="EVENTB" value="0x4"/>
+            <value caption="IO pin LUTn-IN1 input source" name="IN1" value="0x5"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x6"/>
+            <value caption="USART1 TXD input source" name="USART1" value="0x7"/>
+            <value caption="SPI0 MOSI input source" name="SPI0" value="0x8"/>
+            <value caption="TCA0 WO1 input source" name="TCA0" value="0x9"/>
+            <value caption="TCB1 WO input source" name="TCB1" value="0xA"/>
+         </value-group>
+         <value-group caption="LUT Input 2 Source Selection" name="CCL_INSEL2">
+            <value caption="Masked input" name="MASK" value="0x0"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x1"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x2"/>
+            <value caption="Event input source A" name="EVENTA" value="0x3"/>
+            <value caption="Event input source B" name="EVENTB" value="0x4"/>
+            <value caption="IO pin LUTn-IN2 input source" name="IN2" value="0x5"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x6"/>
+            <value caption="USART1 TXD input source" name="USART1" value="0x7"/>
+            <value caption="SPI0 SCK input source" name="SPI0" value="0x8"/>
+            <value caption="TCA0 WO2 input source" name="TCA0" value="0x9"/>
+            <value caption="TCB1 WO input source" name="TCB1" value="0xA"/>
+         </value-group>
+         <value-group caption="Sequential Selection" name="CCL_SEQSEL">
+            <value caption="Sequential logic disabled" name="DISABLE" value="0x00"/>
+            <value caption="D FlipFlop" name="DFF" value="0x01"/>
+            <value caption="JK FlipFlop" name="JK" value="0x02"/>
+            <value caption="D Latch" name="LATCH" value="0x03"/>
+            <value caption="RS Latch" name="RS" value="0x04"/>
+         </value-group>
+      </module>
+      <module caption="Clock controller" id="avrdu" name="CLKCTRL">
+         <register-group caption="Clock controller" name="CLKCTRL" size="0x40">
+            <register caption="MCLK Control A"
+                      initval="0x00"
+                      name="MCLKCTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock select"
+                         mask="0x07"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="CLKCTRL_CLKSEL"/>
+               <bitfield caption="System clock out" mask="0x80" name="CLKOUT" rw="RW"/>
+            </register>
+            <register caption="MCLK Control B"
+                      initval="0x00"
+                      name="MCLKCTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Prescaler enable" mask="0x01" name="PEN" rw="RW"/>
+               <bitfield caption="Prescaler division"
+                         mask="0x1E"
+                         name="PDIV"
+                         rw="RW"
+                         values="CLKCTRL_PDIV"/>
+            </register>
+            <register caption="MCLK Control C"
+                      initval="0x00"
+                      name="MCLKCTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Enable"
+                         mask="0x01"
+                         name="CFDEN"
+                         rw="RW"/>
+               <bitfield caption="Clock Failure Detect Test"
+                         mask="0x02"
+                         name="CFDTST"
+                         rw="W"/>
+               <bitfield caption="Clock Failure Detect Source"
+                         mask="0x0C"
+                         name="CFDSRC"
+                         rw="RW"
+                         values="CLKCTRL_CFDSRC"/>
+            </register>
+            <register caption="MCLK Interrupt Control"
+                      initval="0x00"
+                      name="MCLKINTCTRL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Interrupt Enable"
+                         mask="0x01"
+                         name="CFD"
+                         rw="RW"/>
+               <bitfield caption="Interrupt type"
+                         mask="0x80"
+                         name="INTTYPE"
+                         rw="RW"
+                         values="CLKCTRL_INTTYPE"/>
+            </register>
+            <register caption="MCLK Interrupt Flags"
+                      initval="0x00"
+                      name="MCLKINTFLAGS"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Interrupt Flag"
+                         mask="0x01"
+                         name="CFD"
+                         rw="RW"/>
+            </register>
+            <register caption="MCLK Status"
+                      initval="0x00"
+                      name="MCLKSTATUS"
+                      offset="0x05"
+                      rw="R"
+                      size="1">
+               <bitfield caption="System Oscillator changing"
+                         mask="0x01"
+                         name="SOSC"
+                         rw="R"/>
+               <bitfield caption="High frequency oscillator status"
+                         mask="0x02"
+                         name="OSCHFS"
+                         rw="R"/>
+               <bitfield caption="32KHz oscillator status"
+                         mask="0x04"
+                         name="OSC32KS"
+                         rw="R"/>
+               <bitfield caption="32.768 kHz Crystal Oscillator status"
+                         mask="0x08"
+                         name="XOSC32KS"
+                         rw="R"/>
+               <bitfield caption="External Clock status" mask="0x10" name="EXTS" rw="R"/>
+            </register>
+            <register caption="Timebase"
+                      initval="0x00"
+                      name="MCLKTIMEBASE"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Timebase" mask="0x1F" name="TIMEBASE" rw="RW"/>
+            </register>
+            <register caption="OSCHF Control A"
+                      initval="0x0C"
+                      name="OSCHFCTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Autotune"
+                         mask="0x03"
+                         name="AUTOTUNE"
+                         rw="RW"
+                         values="CLKCTRL_AUTOTUNE"/>
+               <bitfield caption="Frequency select"
+                         mask="0x3C"
+                         name="FRQSEL"
+                         rw="RW"
+                         values="CLKCTRL_FRQSEL"/>
+               <bitfield caption="Algorithm Selection"
+                         mask="0x40"
+                         name="ALGSEL"
+                         rw="RW"
+                         values="CLKCTRL_ALGSEL"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="OSCHF Tune"
+                      name="OSCHFTUNE"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Tune" mask="0x7F" name="TUNE" rw="RW"/>
+            </register>
+            <register caption="OSCHF Status"
+                      name="OSCHFSTATUS"
+                      offset="0x0A"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Autotune in Lock" mask="0x01" name="ATSYNC" rw="R"/>
+               <bitfield caption="Autotune Synchronized"
+                         mask="0x02"
+                         name="ATLOCK"
+                         rw="R"/>
+            </register>
+            <register caption="OSC32K Control A"
+                      initval="0x00"
+                      name="OSC32KCTRLA"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="XOSC32K Control A"
+                      initval="0x00"
+                      name="XOSC32KCTRLA"
+                      offset="0x1C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Low power mode" mask="0x02" name="LPMODE" rw="RW"/>
+               <bitfield caption="Select"
+                         mask="0x04"
+                         name="SEL"
+                         rw="RW"
+                         values="CLKCTRL_SEL"/>
+               <bitfield caption="Crystal startup time"
+                         mask="0x30"
+                         name="CSUT"
+                         rw="RW"
+                         values="CLKCTRL_CSUT"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="XOSCHF Control A"
+                      initval="0x00"
+                      name="XOSCHFCTRLA"
+                      offset="0x20"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="External Source Select"
+                         mask="0x02"
+                         name="SELHF"
+                         rw="RW"
+                         values="CLKCTRL_SELHF"/>
+               <bitfield caption="Frequency Range"
+                         mask="0x0C"
+                         name="FRQRANGE"
+                         rw="RW"
+                         values="CLKCTRL_FRQRANGE"/>
+               <bitfield caption="Start-up Time Select"
+                         mask="0x30"
+                         name="CSUTHF"
+                         rw="RW"
+                         values="CLKCTRL_CSUTHF"/>
+               <bitfield caption="Run Standby" mask="0x80" name="RUNSTBY" rw="RW"/>
+            </register>
+            <register caption="PLL Status"
+                      initval="0x00"
+                      name="USBPLLSTATUS"
+                      offset="0x25"
+                      rw="R"
+                      size="1">
+               <bitfield caption="PLL Stable" mask="0x01" name="PLLS" rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock select" name="CLKCTRL_CLKSEL">
+            <value caption="Internal high-frequency oscillator"
+                   name="OSCHF"
+                   value="0x0"/>
+            <value caption="Internal 32.768 kHz oscillator" name="OSC32K" value="0x1"/>
+            <value caption="32.768 kHz crystal oscillator" name="XOSC32K" value="0x2"/>
+            <value caption="External clock" name="EXTCLK" value="0x3"/>
+         </value-group>
+         <value-group caption="Prescaler division select" name="CLKCTRL_PDIV">
+            <value caption="Divide by 2" name="DIV2" value="0x00"/>
+            <value caption="Divide by 4" name="DIV4" value="0x01"/>
+            <value caption="Divide by 8" name="DIV8" value="0x02"/>
+            <value caption="Divide by 16" name="DIV16" value="0x03"/>
+            <value caption="Divide by 32" name="DIV32" value="0x04"/>
+            <value caption="Divide by 64" name="DIV64" value="0x05"/>
+            <value caption="Divide by 6" name="DIV6" value="0x08"/>
+            <value caption="Divide by 10" name="DIV10" value="0x09"/>
+            <value caption="Divide by 12" name="DIV12" value="0x0A"/>
+            <value caption="Divide by 24" name="DIV24" value="0x0B"/>
+            <value caption="Divide by 48" name="DIV48" value="0x0C"/>
+         </value-group>
+         <value-group caption="Clock Failure Detect Source select" name="CLKCTRL_CFDSRC">
+            <value caption="Main Clock" name="CLKMAIN" value="0x0"/>
+            <value caption="XOSCHF" name="XOSCHF" value="0x1"/>
+            <value caption="XOSC32K" name="XOSC32K" value="0x2"/>
+         </value-group>
+         <value-group caption="Interrupt type select" name="CLKCTRL_INTTYPE">
+            <value caption="Regular Interrupt" name="INT" value="0x0"/>
+            <value caption="NMI" name="NMI" value="0x1"/>
+         </value-group>
+         <value-group caption="Algorithm Selection" name="CLKCTRL_ALGSEL">
+            <value caption="Binary Search" name="BIN" value="0x0"/>
+            <value caption="Incremental Search" name="INCR" value="0x1"/>
+         </value-group>
+         <value-group caption="Autotune select" name="CLKCTRL_AUTOTUNE">
+            <value caption="Automatic tuning disabled" name="OFF" value="0x0"/>
+            <value caption="Automatic tuning against XOSC32K enabled"
+                   name="32K"
+                   value="0x1"/>
+            <value caption="Automatic tuning against USB SOF enabled"
+                   name="SOF"
+                   value="0x2"/>
+         </value-group>
+         <value-group caption="Frequency select" name="CLKCTRL_FRQSEL">
+            <value caption="1 MHz system clock" name="1M" value="0x0"/>
+            <value caption="2 MHz system clock" name="2M" value="0x1"/>
+            <value caption="3 MHz system clock" name="3M" value="0x2"/>
+            <value caption="4 MHz system clock (default)" name="4M" value="0x3"/>
+            <value caption="8 MHz system clock" name="8M" value="0x5"/>
+            <value caption="12 MHz system clock" name="12M" value="0x6"/>
+            <value caption="16 MHz system clock" name="16M" value="0x7"/>
+            <value caption="20 MHz system clock" name="20M" value="0x8"/>
+            <value caption="24 MHz system clock" name="24M" value="0x9"/>
+            <value caption="28 MHz system clock" name="28M" value="0xA"/>
+            <value caption="32 MHz system clock" name="32M" value="0xB"/>
+         </value-group>
+         <value-group caption="Start-up Time Select" name="CLKCTRL_CSUTHF">
+            <value caption="256 XOSCHF cycles" name="256" value="0x0"/>
+            <value caption="1K XOSCHF cycles" name="1K" value="0x1"/>
+            <value caption="4K XOSCHF cycles" name="4K" value="0x2"/>
+         </value-group>
+         <value-group caption="Frequency Range select" name="CLKCTRL_FRQRANGE">
+            <value caption="Max 8 MHz XTAL Frequency" name="8M" value="0x0"/>
+            <value caption="Max 16 MHz XTAL Frequency" name="16M" value="0x1"/>
+            <value caption="Max 24 MHz XTAL Frequency" name="24M" value="0x2"/>
+            <value caption="Max 32 MHz XTAL Frequency" name="32M" value="0x3"/>
+         </value-group>
+         <value-group caption="External Source Select" name="CLKCTRL_SELHF">
+            <value caption="External Crystal" name="XTAL" value="0x0"/>
+            <value caption="External clock on XTALHF1 pin" name="EXTCLK" value="0x1"/>
+         </value-group>
+         <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+            <value caption="1k cycles" name="1K" value="0x00"/>
+            <value caption="16k cycles" name="16K" value="0x01"/>
+            <value caption="32k cycles" name="32K" value="0x02"/>
+            <value caption="64k cycles" name="64K" value="0x03"/>
+         </value-group>
+         <value-group caption="Select" name="CLKCTRL_SEL">
+            <value caption="External crystal connected to the XTAL32K1 and XTAL32K2 pins"
+                   name="XTAL"
+                   value="0x0"/>
+            <value caption="External clock on the XTAL32K1 pin"
+                   name="EXTCLK"
+                   value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="CPU" id="cpu_avr_xt_v1" name="CPU">
+         <register-group caption="CPU" name="CPU" size="0x10">
+            <register caption="Configuration Change Protection"
+                      initval="0x00"
+                      name="CCP"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CCP signature"
+                         mask="0xFF"
+                         name="CCP"
+                         rw="RW"
+                         values="CPU_CCP"/>
+            </register>
+            <register caption="Extended Z-pointer Register"
+                      initval="0x00"
+                      name="RAMPZ"
+                      offset="0xB"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Stack Pointer"
+                      initval="0x7FFF"
+                      name="SP"
+                      offset="0xD"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Status Register"
+                      initval="0x00"
+                      name="SREG"
+                      offset="0xF"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Carry Flag" mask="0x01" name="C" rw="RW"/>
+               <bitfield caption="Zero Flag" mask="0x02" name="Z" rw="RW"/>
+               <bitfield caption="Negative Flag" mask="0x04" name="N" rw="RW"/>
+               <bitfield caption="Two's Complement Overflow Flag"
+                         mask="0x08"
+                         name="V"
+                         rw="RW"/>
+               <bitfield caption="N Exclusive Or V Flag" mask="0x10" name="S" rw="RW"/>
+               <bitfield caption="Half Carry Flag" mask="0x20" name="H" rw="RW"/>
+               <bitfield caption="Transfer Bit" mask="0x40" name="T" rw="RW"/>
+               <bitfield caption="Global Interrupt Enable Flag"
+                         mask="0x80"
+                         name="I"
+                         rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="CCP signature select" name="CPU_CCP">
+            <value caption="SPM Instruction Protection" name="SPM" value="0x9D"/>
+            <value caption="IO Register Protection" name="IOREG" value="0xD8"/>
+         </value-group>
+      </module>
+      <module caption="Interrupt Controller" id="int_8bit_v3" name="CPUINT">
+         <register-group caption="Interrupt Controller" name="CPUINT" size="0x4">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Round-robin Scheduling Enable"
+                         mask="0x01"
+                         name="LVL0RR"
+                         rw="RW"/>
+               <bitfield caption="Compact Vector Table" mask="0x20" name="CVT" rw="RW"/>
+               <bitfield caption="Interrupt Vector Select"
+                         mask="0x40"
+                         name="IVSEL"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x1"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Level 0 Interrupt Executing"
+                         mask="0x01"
+                         name="LVL0EX"
+                         rw="R"/>
+               <bitfield caption="Level 1 Interrupt Executing"
+                         mask="0x02"
+                         name="LVL1EX"
+                         rw="R"/>
+               <bitfield caption="Non-maskable Interrupt Executing"
+                         mask="0x80"
+                         name="NMIEX"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Level 0 Priority"
+                      initval="0x00"
+                      name="LVL0PRI"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Level Priority"
+                         mask="0xFF"
+                         name="LVL0PRI"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Level 1 Priority Vector"
+                      initval="0x00"
+                      name="LVL1VEC"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Vector with High Priority"
+                         mask="0xFF"
+                         name="LVL1VEC"
+                         rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="CRCSCAN" id="math_pdi_crc_v1" name="CRCSCAN">
+         <register-group caption="CRCSCAN" name="CRCSCAN" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable CRC scan" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Enable NMI Trigger" mask="0x02" name="NMIEN" rw="RW"/>
+               <bitfield caption="Reset CRC scan" mask="0x80" name="RESET" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CRC Source"
+                         mask="0x03"
+                         name="SRC"
+                         rw="RW"
+                         values="CRCSCAN_SRC"/>
+            </register>
+            <register caption="Status"
+                      initval="0x02"
+                      name="STATUS"
+                      offset="0x2"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CRC Busy" mask="0x01" name="BUSY" rw="R"/>
+               <bitfield caption="CRC Ok" mask="0x02" name="OK" rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="CRC Source select" name="CRCSCAN_SRC">
+            <value caption="CRC on entire flash" name="FLASH" value="0x0"/>
+            <value caption="CRC on boot and appl section of flash"
+                   name="APPLICATION"
+                   value="0x1"/>
+            <value caption="CRC on boot section of flash" name="BOOT" value="0x2"/>
+         </value-group>
+      </module>
+      <module caption="Event System" id="avrdu" name="EVSYS">
+         <register-group caption="Event System" name="EVSYS" size="0x40">
+            <register caption="Software Event A"
+                      initval="0x00"
+                      name="SWEVENTA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Software event on channel select"
+                         mask="0xFF"
+                         name="SWEVENTA"
+                         rw="W"
+                         values="EVSYS_SWEVENTA"/>
+            </register>
+            <register caption="Multiplexer Channel 0"
+                      initval="0x00"
+                      name="CHANNEL0"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 1"
+                      initval="0x00"
+                      name="CHANNEL1"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 2"
+                      initval="0x00"
+                      name="CHANNEL2"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 3"
+                      initval="0x00"
+                      name="CHANNEL3"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 4"
+                      initval="0x00"
+                      name="CHANNEL4"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="Multiplexer Channel 5"
+                      initval="0x00"
+                      name="CHANNEL5"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel generator select"
+                         mask="0xFF"
+                         name="CHANNEL"
+                         rw="RW"
+                         values="EVSYS_CHANNEL"/>
+            </register>
+            <register caption="CCL0 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT0A"
+                      offset="0x20"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL0 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT0B"
+                      offset="0x21"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL1 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT1A"
+                      offset="0x22"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL1 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT1B"
+                      offset="0x23"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL2 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT2A"
+                      offset="0x24"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL2 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT2B"
+                      offset="0x25"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL3 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT3A"
+                      offset="0x26"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="CCL3 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT3B"
+                      offset="0x27"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="ADC0"
+                      initval="0x00"
+                      name="USERADC0START"
+                      offset="0x28"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="EVOUTA"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTA"
+                      offset="0x29"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="EVOUTD"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTD"
+                      offset="0x2A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="EVOUTF"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTF"
+                      offset="0x2B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="USART0"
+                      initval="0x00"
+                      name="USERUSART0IRDA"
+                      offset="0x2C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="USART1"
+                      initval="0x00"
+                      name="USERUSART1IRDA"
+                      offset="0x2D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCA0 Event A"
+                      initval="0x00"
+                      name="USERTCA0CNTA"
+                      offset="0x2E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCA0 Event B"
+                      initval="0x00"
+                      name="USERTCA0CNTB"
+                      offset="0x2F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB0 Event A"
+                      initval="0x00"
+                      name="USERTCB0CAPT"
+                      offset="0x30"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB0 Event B"
+                      initval="0x00"
+                      name="USERTCB0COUNT"
+                      offset="0x31"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB1 Event A"
+                      initval="0x00"
+                      name="USERTCB1CAPT"
+                      offset="0x32"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="TCB1 Event B"
+                      initval="0x00"
+                      name="USERTCB1COUNT"
+                      offset="0x33"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+         </register-group>
+         <value-group caption="Channel generator select" name="EVSYS_CHANNEL">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH Character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="Real Time Counter Overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter Compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Real Time Counter Event Output 0"
+                   name="RTC_EVGEN0"
+                   value="0x8"/>
+            <value caption="Real Time Counter Event Output 1"
+                   name="RTC_EVGEN1"
+                   value="0x9"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 Out" name="AC0_OUT" value="0x20"/>
+            <value caption="ADC0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="ADC0 Sample Ready" name="ADC0_SAMPRDY" value="0x25"/>
+            <value caption="ADC0 Window Comparator" name="ADC0_WCMP" value="0x26"/>
+            <value caption="Port A Event 0" name="PORTA_EVGEN0" value="0x40"/>
+            <value caption="Port A Event 1" name="PORTA_EVGEN1" value="0x41"/>
+            <value caption="Port C Event 0" name="PORTC_EVGEN0" value="0x44"/>
+            <value caption="Port C Event 1" name="PORTC_EVGEN1" value="0x45"/>
+            <value caption="Port D Event 0" name="PORTD_EVGEN0" value="0x46"/>
+            <value caption="Port D Event 1" name="PORTD_EVGEN1" value="0x47"/>
+            <value caption="Port F Event 0" name="PORTF_EVGEN0" value="0x4A"/>
+            <value caption="Port F Event 1" name="PORTF_EVGEN1" value="0x4B"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="Timer/Counter A0 Overflow / Low Byte Timer Underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 High Byte Timer Underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 Compare 0 / Low Byte Compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 Compare 1 / Low Byte Compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 Compare 2 / Low Byte Compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 Capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 Overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 Capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 Overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="USB0 Setup Received" name="USB0_SETUP" value="0xC0"/>
+            <value caption="USB0 SOF Received" name="USB0_SOF" value="0xC1"/>
+            <value caption="USB0 CRC Error" name="USB0_CRC" value="0xC2"/>
+            <value caption="USB0 Underflow / Overflow" name="USB0_UNFOVF" value="0xC3"/>
+            <value caption="USB0 Data Byte Received" name="USB0_RX" value="0xC4"/>
+            <value caption="USB0 Data Byte Transmitted" name="USB0_TX" value="0xC5"/>
+         </value-group>
+         <value-group caption="Software event on channel select" name="EVSYS_SWEVENTA">
+            <value caption="Software event on channel 0" name="CH0" value="0x01"/>
+            <value caption="Software event on channel 1" name="CH1" value="0x02"/>
+            <value caption="Software event on channel 2" name="CH2" value="0x04"/>
+            <value caption="Software event on channel 3" name="CH3" value="0x08"/>
+            <value caption="Software event on channel 4" name="CH4" value="0x10"/>
+            <value caption="Software event on channel 5" name="CH5" value="0x20"/>
+            <value caption="Software event on channel 6" name="CH6" value="0x40"/>
+            <value caption="Software event on channel 7" name="CH7" value="0x80"/>
+         </value-group>
+         <value-group caption="User channel select" name="EVSYS_USER">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="Connect user to event channel 0"
+                   name="CHANNEL0"
+                   value="0x1"/>
+            <value caption="Connect user to event channel 1"
+                   name="CHANNEL1"
+                   value="0x2"/>
+            <value caption="Connect user to event channel 2"
+                   name="CHANNEL2"
+                   value="0x3"/>
+            <value caption="Connect user to event channel 3"
+                   name="CHANNEL3"
+                   value="0x4"/>
+            <value caption="Connect user to event channel 4"
+                   name="CHANNEL4"
+                   value="0x5"/>
+            <value caption="Connect user to event channel 5"
+                   name="CHANNEL5"
+                   value="0x6"/>
+         </value-group>
+      </module>
+      <module caption="Fuses" id="avrdu" name="FUSE">
+         <register-group caption="Fuses" name="FUSE" size="0x0B">
+            <register caption="Watchdog Configuration"
+                      initval="0x00"
+                      name="WDTCFG"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Watchdog Timeout Period"
+                         mask="0x0F"
+                         name="PERIOD"
+                         rw="RW"
+                         values="FUSE_PERIOD"/>
+               <bitfield caption="Watchdog Window Timeout Period"
+                         mask="0xF0"
+                         name="WINDOW"
+                         rw="RW"
+                         values="FUSE_WINDOW"/>
+            </register>
+            <register caption="BOD Configuration"
+                      initval="0x00"
+                      name="BODCFG"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="BOD Operation in Sleep Mode"
+                         mask="0x03"
+                         name="SLEEP"
+                         rw="RW"
+                         values="FUSE_SLEEP"/>
+               <bitfield caption="BOD Operation in Active Mode"
+                         mask="0x0C"
+                         name="ACTIVE"
+                         rw="RW"
+                         values="FUSE_ACTIVE"/>
+               <bitfield caption="BOD Sample Frequency"
+                         mask="0x10"
+                         name="SAMPFREQ"
+                         rw="RW"
+                         values="FUSE_SAMPFREQ"/>
+               <bitfield caption="BOD Level"
+                         mask="0xE0"
+                         name="LVL"
+                         rw="RW"
+                         values="FUSE_LVL"/>
+            </register>
+            <register caption="Oscillator Configuration"
+                      initval="0x00"
+                      name="OSCCFG"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Frequency Select"
+                         mask="0x07"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="FUSE_CLKSEL"/>
+            </register>
+            <register caption="System Configuration 0"
+                      initval="0xD0"
+                      name="SYSCFG0"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Save" mask="0x01" name="EESAVE" rw="RW"/>
+               <bitfield caption="Boot Row Save" mask="0x02" name="BROWSAVE" rw="RW"/>
+               <bitfield caption="Reset Pin Configuration"
+                         mask="0x08"
+                         name="RSTPINCFG"
+                         rw="RW"
+                         values="FUSE_RSTPINCFG"/>
+               <bitfield caption="UPDI Pin Configuration"
+                         mask="0x10"
+                         name="UPDIPINCFG"
+                         rw="RW"
+                         values="FUSE_UPDIPINCFG"/>
+               <bitfield caption="CRC Select"
+                         mask="0x20"
+                         name="CRCSEL"
+                         rw="RW"
+                         values="FUSE_CRCSEL"/>
+               <bitfield caption="CRC Source"
+                         mask="0xC0"
+                         name="CRCSRC"
+                         rw="RW"
+                         values="FUSE_CRCSRC"/>
+            </register>
+            <register caption="System Configuration 1"
+                      initval="0x08"
+                      name="SYSCFG1"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Startup Time"
+                         mask="0x07"
+                         name="SUT"
+                         rw="RW"
+                         values="FUSE_SUT"/>
+               <bitfield caption="USB Voltage Regulator Current Sink Enable"
+                         mask="0x08"
+                         name="USBSINK"
+                         rw="RW"
+                         values="FUSE_USBSINK"/>
+            </register>
+            <register caption="Code Section Size"
+                      initval="0x00"
+                      name="CODESIZE"
+                      offset="0x7"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Boot Section Size"
+                      initval="0x00"
+                      name="BOOTSIZE"
+                      offset="0x8"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Programming and Debugging Interface Configuration"
+                      initval="0x0003"
+                      name="PDICFG"
+                      offset="0xA"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Protection Level"
+                         mask="0x03"
+                         name="LEVEL"
+                         rw="RW"
+                         values="FUSE_LEVEL"/>
+               <bitfield caption="NVM Protection Activation Key"
+                         mask="0xFFF0"
+                         name="KEY"
+                         rw="RW"
+                         values="FUSE_KEY"/>
+            </register>
+         </register-group>
+         <value-group caption="BOD Operation in Active Mode select" name="FUSE_ACTIVE">
+            <value caption="BOD disabled" name="DISABLE" value="0x00"/>
+            <value caption="BOD enabled in continuous mode" name="ENABLE" value="0x01"/>
+            <value caption="BOD enabled in sampled mode" name="SAMPLE" value="0x02"/>
+            <value caption="BOD enabled in continuous mode. Execution is halted at wake-up until BOD is running."
+                   name="ENABLEWAIT"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="BOD Level select" name="FUSE_LVL">
+            <value caption="1.9V" name="BODLEVEL0" value="0x00"/>
+            <value caption="2.45V" name="BODLEVEL1" value="0x01"/>
+            <value caption="2.7V" name="BODLEVEL2" value="0x02"/>
+            <value caption="2.85V" name="BODLEVEL3" value="0x03"/>
+         </value-group>
+         <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
+            <value caption="Sample frequency is 128 Hz" name="128Hz" value="0x0"/>
+            <value caption="Sample frequency is 32 Hz" name="32Hz" value="0x1"/>
+         </value-group>
+         <value-group caption="BOD Operation in Sleep Mode select" name="FUSE_SLEEP">
+            <value caption="BOD disabled" name="DISABLE" value="0x00"/>
+            <value caption="BOD enabled in continuous mode" name="ENABLE" value="0x01"/>
+            <value caption="BOD enabled in sampled mode" name="SAMPLE" value="0x02"/>
+         </value-group>
+         <value-group caption="Frequency Select" name="FUSE_CLKSEL">
+            <value caption="1-32MHz internal oscillator" name="OSCHF" value="0x0"/>
+            <value caption="32.768kHz internal oscillator" name="OSC32K" value="0x1"/>
+         </value-group>
+         <value-group caption="NVM Protection Activation Key select" name="FUSE_KEY">
+            <value caption="Not Active" name="NOTACT" value="0x000"/>
+            <value caption="NVM Protection Active" name="NVMACT" value="0xB45"/>
+         </value-group>
+         <value-group caption="Protection Level select" name="FUSE_LEVEL">
+            <value caption="NVM Access through UPDI disabled"
+                   name="NVMACCDIS"
+                   value="0x1"/>
+            <value caption="UPDI and UPDI pins working normally"
+                   name="BASIC"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="CRC Select" name="FUSE_CRCSEL">
+            <value caption="Enable CRC16" name="CRC16" value="0x0"/>
+            <value caption="Enable CRC32" name="CRC32" value="0x1"/>
+         </value-group>
+         <value-group caption="CRC Source select" name="FUSE_CRCSRC">
+            <value caption="CRC of full Flash (boot, application code and application data)"
+                   name="FLASH"
+                   value="0x0"/>
+            <value caption="CRC of boot section" name="BOOT" value="0x1"/>
+            <value caption="CRC of application code and boot sections"
+                   name="BOOTAPP"
+                   value="0x2"/>
+            <value caption="No CRC" name="NOCRC" value="0x3"/>
+         </value-group>
+         <value-group caption="Reset Pin Configuration select" name="FUSE_RSTPINCFG">
+            <value caption="GPIO mode" name="GPIO" value="0x0"/>
+            <value caption="Reset mode" name="RST" value="0x1"/>
+         </value-group>
+         <value-group caption="UPDI Pin Configuration select" name="FUSE_UPDIPINCFG">
+            <value caption="GPIO Mode" name="GPIO" value="0x0"/>
+            <value caption="UPDI Mode" name="UPDI" value="0x1"/>
+         </value-group>
+         <value-group caption="Startup Time select" name="FUSE_SUT">
+            <value caption="0 ms" name="0MS" value="0x00"/>
+            <value caption="1 ms" name="1MS" value="0x01"/>
+            <value caption="2 ms" name="2MS" value="0x02"/>
+            <value caption="4 ms" name="4MS" value="0x03"/>
+            <value caption="8 ms" name="8MS" value="0x04"/>
+            <value caption="16 ms" name="16MS" value="0x05"/>
+            <value caption="32 ms" name="32MS" value="0x06"/>
+            <value caption="64 ms" name="64MS" value="0x07"/>
+         </value-group>
+         <value-group caption="USB Voltage Regulator Current Sink Enable select"
+                      name="FUSE_USBSINK">
+            <value caption="USB VREG can not sink current" name="DISABLE" value="0x0"/>
+            <value caption="USB VREG can sink current" name="ENABLE" value="0x1"/>
+         </value-group>
+         <value-group caption="Watchdog Timeout Period select" name="FUSE_PERIOD">
+            <value caption="Watch-Dog timer Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.0s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.0s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+         <value-group caption="Watchdog Window Timeout Period select" name="FUSE_WINDOW">
+            <value caption="Window mode off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.0s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.0s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+      </module>
+      <module caption="General Purpose Registers" id="avrdu" name="GPR">
+         <register-group caption="General Purpose Registers" name="GPR" size="0x4">
+            <register caption="General Purpose Register 0"
+                      name="GPR0"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 1"
+                      name="GPR1"
+                      offset="0x1"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 2"
+                      name="GPR2"
+                      offset="0x2"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 3"
+                      name="GPR3"
+                      offset="0x3"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Lockbits" id="avrdu" name="LOCK">
+         <register-group caption="Lockbits" name="LOCK" size="0x4">
+            <register caption="Lock Key Bits"
+                      initval="0x5CC5C55C"
+                      name="KEY"
+                      offset="0x0"
+                      rw="RW"
+                      size="4">
+               <bitfield caption="Lock Key"
+                         mask="0xFFFFFFFF"
+                         name="KEY"
+                         rw="RW"
+                         values="LOCK_KEY"/>
+            </register>
+         </register-group>
+         <value-group caption="Lock Key select" name="LOCK_KEY">
+            <value caption="No locks" name="NOLOCK" value="0x5CC5C55C"/>
+            <value caption="Read and write lock" name="RWLOCK" value="0xA33A3AA3"/>
+         </value-group>
+      </module>
+      <module caption="Non-volatile Memory Controller"
+              id="nvm_ctrl_avr_v4"
+              name="NVMCTRL">
+         <register-group caption="Non-volatile Memory Controller" name="NVMCTRL" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x7F"
+                         name="CMD"
+                         rw="RW"
+                         values="NVMCTRL_CMD"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x30"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Application Code Write Protect"
+                         mask="0x01"
+                         name="APPCODEWP"
+                         rw="RW"/>
+               <bitfield caption="Boot Read Protect" mask="0x02" name="BOOTRP" rw="RW"/>
+               <bitfield caption="Application Data Write Protect"
+                         mask="0x04"
+                         name="APPDATAWP"
+                         rw="RW"/>
+               <bitfield caption="EEPROM Write Protect" mask="0x08" name="EEWP" rw="RW"/>
+               <bitfield caption="Flash Mapping in Data space"
+                         mask="0x30"
+                         name="FLMAP"
+                         rw="RW"
+                         values="NVMCTRL_FLMAP"/>
+               <bitfield caption="Flash Mapping Lock"
+                         mask="0x80"
+                         name="FLMAPLOCK"
+                         rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User Row Write Protect"
+                         mask="0x01"
+                         name="UROWWP"
+                         rw="RW"/>
+               <bitfield caption="Boot Row Write Protect"
+                         mask="0x02"
+                         name="BOOTROWWP"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Ready" mask="0x01" name="EEREADY" rw="RW"/>
+               <bitfield caption="Flash Ready" mask="0x02" name="FLREADY" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Ready" mask="0x01" name="EEREADY" rw="RW"/>
+               <bitfield caption="Flash Ready" mask="0x02" name="FLREADY" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x06"
+                      rw="R"
+                      size="1">
+               <bitfield caption="EEPROM busy" mask="0x01" name="EEBUSY" rw="R"/>
+               <bitfield caption="Flash busy" mask="0x02" name="FLBUSY" rw="R"/>
+               <bitfield caption="Write error"
+                         mask="0x70"
+                         name="ERROR"
+                         rw="R"
+                         values="NVMCTRL_ERROR"/>
+            </register>
+            <register caption="Data"
+                      initval="0x00000000"
+                      name="DATA"
+                      offset="0x08"
+                      rw="RW"
+                      size="4"/>
+            <register caption="Address"
+                      name="ADDR"
+                      offset="0x0C"
+                      rw="RW"
+                      size="4"/>
+         </register-group>
+         <value-group caption="Command select" name="NVMCTRL_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="No Operation" name="NOOP" value="0x01"/>
+            <value caption="Flash Write" name="FLWR" value="0x02"/>
+            <value caption="Flash Page Erase" name="FLPER" value="0x08"/>
+            <value caption="Flash Multi-Page Erase 2 pages"
+                   name="FLMPER2"
+                   value="0x09"/>
+            <value caption="Flash Multi-Page Erase 4 pages"
+                   name="FLMPER4"
+                   value="0x0A"/>
+            <value caption="Flash Multi-Page Erase 8 pages"
+                   name="FLMPER8"
+                   value="0x0B"/>
+            <value caption="Flash Multi-Page Erase 16 pages"
+                   name="FLMPER16"
+                   value="0x0C"/>
+            <value caption="Flash Multi-Page Erase 32 pages"
+                   name="FLMPER32"
+                   value="0x0D"/>
+            <value caption="EEPROM Write" name="EEWR" value="0x12"/>
+            <value caption="EEPROM Erase and Write" name="EEERWR" value="0x13"/>
+            <value caption="EEPROM Byte Erase" name="EEBER" value="0x18"/>
+            <value caption="EEPROM Multi-Byte Erase 2 bytes"
+                   name="EEMBER2"
+                   value="0x19"/>
+            <value caption="EEPROM Multi-Byte Erase 4 bytes"
+                   name="EEMBER4"
+                   value="0x1A"/>
+            <value caption="EEPROM Multi-Byte Erase 8 bytes"
+                   name="EEMBER8"
+                   value="0x1B"/>
+            <value caption="EEPROM Multi-Byte Erase 16 bytes"
+                   name="EEMBER16"
+                   value="0x1C"/>
+            <value caption="EEPROM Multi-Byte Erase 32 bytes"
+                   name="EEMBER32"
+                   value="0x1D"/>
+            <value caption="Chip Erase Command" name="CHER" value="0x20"/>
+            <value caption="EEPROM Erase Command" name="EECHER" value="0x30"/>
+         </value-group>
+         <value-group caption="Flash Mapping in Data space select" name="NVMCTRL_FLMAP">
+            <value caption="Flash section 0" name="SECTION0" value="0x0"/>
+            <value caption="Flash section 1" name="SECTION1" value="0x1"/>
+            <value caption="Flash section 2" name="SECTION2" value="0x2"/>
+            <value caption="Flash section 3" name="SECTION3" value="0x3"/>
+         </value-group>
+         <value-group caption="Write error select" name="NVMCTRL_ERROR">
+            <value caption="No Error" name="NOERROR" value="0x0"/>
+            <value caption="Write command not selected or not valid"
+                   name="INVALIDCMD"
+                   value="0x1"/>
+            <value caption="Write to section not allowed"
+                   name="WRITEPROTECT"
+                   value="0x2"/>
+            <value caption="Selecting new write command while programming is ongoing"
+                   name="CMDCOLLISION"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="I/O Ports" id="gpio_ports_avr_v3" name="PORT">
+         <register-group caption="I/O Ports" name="PORT" size="0x20">
+            <register caption="Data Direction"
+                      initval="0x00"
+                      name="DIR"
+                      offset="0x00"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Set"
+                      initval="0x00"
+                      name="DIRSET"
+                      offset="0x01"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Clear"
+                      initval="0x00"
+                      name="DIRCLR"
+                      offset="0x02"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Toggle"
+                      initval="0x00"
+                      name="DIRTGL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value"
+                      initval="0x00"
+                      name="OUT"
+                      offset="0x04"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Set"
+                      initval="0x00"
+                      name="OUTSET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Clear"
+                      initval="0x00"
+                      name="OUTCLR"
+                      offset="0x06"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Toggle"
+                      initval="0x00"
+                      name="OUTTGL"
+                      offset="0x07"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Input Value"
+                      initval="0x00"
+                      name="IN"
+                      offset="0x08"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin Interrupt Flag" mask="0xFF" name="INT" rw="RW"/>
+            </register>
+            <register caption="Port Control"
+                      initval="0x00"
+                      name="PORTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Slew Rate Limit Enable" mask="0x01" name="SRL" rw="RW"/>
+            </register>
+            <register caption="Pin Control Config"
+                      initval="0x00"
+                      name="PINCONFIG"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin Control Update"
+                      initval="0x00"
+                      name="PINCTRLUPD"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Pin Control Set"
+                      initval="0x00"
+                      name="PINCTRLSET"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Pin Control Clear"
+                      initval="0x00"
+                      name="PINCTRLCLR"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Pin 0 Control"
+                      initval="0x00"
+                      name="PIN0CTRL"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 1 Control"
+                      initval="0x00"
+                      name="PIN1CTRL"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 2 Control"
+                      initval="0x00"
+                      name="PIN2CTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 3 Control"
+                      initval="0x00"
+                      name="PIN3CTRL"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 4 Control"
+                      initval="0x00"
+                      name="PIN4CTRL"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 5 Control"
+                      initval="0x00"
+                      name="PIN5CTRL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 6 Control"
+                      initval="0x00"
+                      name="PIN6CTRL"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 7 Control"
+                      initval="0x00"
+                      name="PIN7CTRL"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input Level Select"
+                         mask="0x40"
+                         name="INLVL"
+                         rw="RW"
+                         values="PORT_INLVL"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Event Generation Control A"
+                      initval="0x00"
+                      name="EVGENCTRLA"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Generator 0 Select"
+                         mask="0x07"
+                         name="EVGEN0SEL"
+                         rw="RW"
+                         values="PORT_EVGEN0SEL"/>
+               <bitfield caption="Event Generator 1 Select"
+                         mask="0x70"
+                         name="EVGEN1SEL"
+                         rw="RW"
+                         values="PORT_EVGEN1SEL"/>
+            </register>
+         </register-group>
+         <value-group caption="Event Generator 0 Select" name="PORT_EVGEN0SEL">
+            <value caption="Pin 0 used as event generator" name="PIN0" value="0x0"/>
+            <value caption="Pin 1 used as event generator" name="PIN1" value="0x1"/>
+            <value caption="Pin 2 used as event generator" name="PIN2" value="0x2"/>
+            <value caption="Pin 3 used as event generator" name="PIN3" value="0x3"/>
+            <value caption="Pin 4 used as event generator" name="PIN4" value="0x4"/>
+            <value caption="Pin 5 used as event generator" name="PIN5" value="0x5"/>
+            <value caption="Pin 6 used as event generator" name="PIN6" value="0x6"/>
+            <value caption="Pin 7 used as event generator" name="PIN7" value="0x7"/>
+         </value-group>
+         <value-group caption="Event Generator 1 Select" name="PORT_EVGEN1SEL">
+            <value caption="Pin 0 used as event generator" name="PIN0" value="0x0"/>
+            <value caption="Pin 1 used as event generator" name="PIN1" value="0x1"/>
+            <value caption="Pin 2 used as event generator" name="PIN2" value="0x2"/>
+            <value caption="Pin 3 used as event generator" name="PIN3" value="0x3"/>
+            <value caption="Pin 4 used as event generator" name="PIN4" value="0x4"/>
+            <value caption="Pin 5 used as event generator" name="PIN5" value="0x5"/>
+            <value caption="Pin 6 used as event generator" name="PIN6" value="0x6"/>
+            <value caption="Pin 7 used as event generator" name="PIN7" value="0x7"/>
+         </value-group>
+         <value-group caption="Input Level Select" name="PORT_INLVL">
+            <value caption="Schmitt-Trigger input level" name="ST" value="0x0"/>
+            <value caption="TTL Input level" name="TTL" value="0x1"/>
+         </value-group>
+         <value-group caption="Input/Sense Configuration select" name="PORT_ISC">
+            <value caption="Interrupt disabled but input buffer enabled"
+                   name="INTDISABLE"
+                   value="0x0"/>
+            <value caption="Sense Both Edges" name="BOTHEDGES" value="0x1"/>
+            <value caption="Sense Rising Edge" name="RISING" value="0x2"/>
+            <value caption="Sense Falling Edge" name="FALLING" value="0x3"/>
+            <value caption="Digital Input Buffer disabled"
+                   name="INPUT_DISABLE"
+                   value="0x4"/>
+            <value caption="Sense low Level" name="LEVEL" value="0x5"/>
+         </value-group>
+      </module>
+      <module caption="Port Multiplexer" id="avrdu" name="PORTMUX">
+         <register-group caption="Port Multiplexer" name="PORTMUX" size="0x10">
+            <register caption="EVSYS route A"
+                      initval="0x00"
+                      name="EVSYSROUTEA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Output A"
+                         mask="0x01"
+                         name="EVOUTA"
+                         rw="RW"
+                         values="PORTMUX_EVOUTA"/>
+               <bitfield caption="Event Output D"
+                         mask="0x08"
+                         name="EVOUTD"
+                         rw="RW"
+                         values="PORTMUX_EVOUTD"/>
+               <bitfield caption="Event Output F"
+                         mask="0x20"
+                         name="EVOUTF"
+                         rw="RW"
+                         values="PORTMUX_EVOUTF"/>
+            </register>
+            <register caption="CCL route A"
+                      initval="0x00"
+                      name="CCLROUTEA"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CCL Look-Up Table 0 Signals"
+                         mask="0x01"
+                         name="LUT0"
+                         rw="RW"
+                         values="PORTMUX_LUT0"/>
+               <bitfield caption="CCL Look-Up Table 1 Signals"
+                         mask="0x02"
+                         name="LUT1"
+                         rw="RW"
+                         values="PORTMUX_LUT1"/>
+               <bitfield caption="CCL Look-Up Table 2 Signals"
+                         mask="0x04"
+                         name="LUT2"
+                         rw="RW"
+                         values="PORTMUX_LUT2"/>
+               <bitfield caption="CCL Look-Up Table 3 Signals"
+                         mask="0x08"
+                         name="LUT3"
+                         rw="RW"
+                         values="PORTMUX_LUT3"/>
+            </register>
+            <register caption="USART route A"
+                      initval="0x00"
+                      name="USARTROUTEA"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="USART0 Signals"
+                         mask="0x07"
+                         name="USART0"
+                         rw="RW"
+                         values="PORTMUX_USART0"/>
+               <bitfield caption="USART1 Signals"
+                         mask="0x18"
+                         name="USART1"
+                         rw="RW"
+                         values="PORTMUX_USART1"/>
+            </register>
+            <register caption="SPI route A"
+                      initval="0x00"
+                      name="SPIROUTEA"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SPI0 Signals"
+                         mask="0x07"
+                         name="SPI0"
+                         rw="RW"
+                         values="PORTMUX_SPI0"/>
+            </register>
+            <register caption="TWI route A"
+                      initval="0x00"
+                      name="TWIROUTEA"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TWI0 Signals"
+                         mask="0x03"
+                         name="TWI0"
+                         rw="RW"
+                         values="PORTMUX_TWI0"/>
+            </register>
+            <register caption="TCA route A"
+                      initval="0x00"
+                      name="TCAROUTEA"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCA0 Signals"
+                         mask="0x07"
+                         name="TCA0"
+                         rw="RW"
+                         values="PORTMUX_TCA0"/>
+            </register>
+            <register caption="TCB route A"
+                      initval="0x00"
+                      name="TCBROUTEA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCB0 Output"
+                         mask="0x01"
+                         name="TCB0"
+                         rw="RW"
+                         values="PORTMUX_TCB0"/>
+               <bitfield caption="TCB1 Output"
+                         mask="0x02"
+                         name="TCB1"
+                         rw="RW"
+                         values="PORTMUX_TCB1"/>
+            </register>
+         </register-group>
+         <value-group caption="CCL Look-Up Table 0 Signals select" name="PORTMUX_LUT0">
+            <value caption="In: PA0, PA1, PA2, Out: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="In: PA0, PA1, PA2, Out: PA6" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 1 Signals select" name="PORTMUX_LUT1">
+            <value caption="In: -, -, -, Out: PC3" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 2 Signals select" name="PORTMUX_LUT2">
+            <value caption="In: PD0, PD1, PD2, Out: PD3" name="DEFAULT" value="0x0"/>
+            <value caption="In: PD0, PD1, PD2, Out: PD6" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 3 Signals select" name="PORTMUX_LUT3">
+            <value caption="In: PF0, PF1, PF2, Out: PF3" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="Event Output A select" name="PORTMUX_EVOUTA">
+            <value caption="EVOUTA: PA2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTA: PA7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Output D select" name="PORTMUX_EVOUTD">
+            <value caption="EVOUTD: PD2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTD: PD7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Output F select" name="PORTMUX_EVOUTF">
+            <value caption="EVOUTF: PF2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTF: PF7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="SPI0 Signals select" name="PORTMUX_SPI0">
+            <value caption="MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7"
+                   name="ALT4"
+                   value="0x4"/>
+            <value caption="Not connected to any pins, SS set to 1"
+                   name="NONE"
+                   value="0x7"/>
+         </value-group>
+         <value-group caption="TCA0 Signals select" name="PORTMUX_TCA0">
+            <value caption="WOn: PA0, PA1, PA2, PA3, PA4, PA5"
+                   name="PORTA"
+                   value="0x0"/>
+            <value caption="WOn: -, -, -, PC3, -, -" name="PORTC" value="0x2"/>
+            <value caption="WOn: PD0, PD1, PD2, PD3, PD4, PD5"
+                   name="PORTD"
+                   value="0x3"/>
+            <value caption="WOn: PF0, PF1, PF2, PF3, PF4, PF5"
+                   name="PORTF"
+                   value="0x5"/>
+         </value-group>
+         <value-group caption="TCB0 Output select" name="PORTMUX_TCB0">
+            <value caption="WO: PA2" name="DEFAULT" value="0x0"/>
+            <value caption="WO: PF4" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="TCB1 Output select" name="PORTMUX_TCB1">
+            <value caption="WO: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="WO: PF5" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="TWI0 Signals select" name="PORTMUX_TWI0">
+            <value caption="SDA: PA2, SCL: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="SDA: PA0, SCL: PA1" name="ALT3" value="0x3"/>
+         </value-group>
+         <value-group caption="USART0 Signals select" name="PORTMUX_USART0">
+            <value caption="TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7"
+                   name="ALT1"
+                   value="0x1"/>
+            <value caption="TxD: PA2, RxD: PA3, XCK: -, XDIR: -"
+                   name="ALT2"
+                   value="0x2"/>
+            <value caption="TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7"
+                   name="ALT3"
+                   value="0x3"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x5"/>
+         </value-group>
+         <value-group caption="USART1 Signals select" name="PORTMUX_USART1">
+            <value caption="Not connected to any pins" name="DEFAULT" value="0x0"/>
+            <value caption="TxD: PD6, RxD: PD7, XCK: -, XDIR: -"
+                   name="ALT2"
+                   value="0x2"/>
+         </value-group>
+      </module>
+      <module caption="Reset controller" id="rst_integration_v8" name="RSTCTRL">
+         <register-group caption="Reset controller" name="RSTCTRL" size="0x4">
+            <register caption="Reset Flags"
+                      initval="0x00"
+                      name="RSTFR"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Power on Reset flag" mask="0x01" name="PORF" rw="RW"/>
+               <bitfield caption="Brown out detector Reset flag"
+                         mask="0x02"
+                         name="BORF"
+                         rw="RW"/>
+               <bitfield caption="External Reset flag" mask="0x04" name="EXTRF" rw="RW"/>
+               <bitfield caption="Watch dog Reset flag" mask="0x08" name="WDRF" rw="RW"/>
+               <bitfield caption="Software Reset flag" mask="0x10" name="SWRF" rw="RW"/>
+               <bitfield caption="UPDI Reset flag" mask="0x20" name="UPDIRF" rw="RW"/>
+            </register>
+            <register caption="Software Reset"
+                      initval="0x00"
+                      name="SWRR"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Software reset enable"
+                         mask="0x01"
+                         name="SWRST"
+                         rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Real-Time Counter" id="tmr_16b_rtc_avr_v2" name="RTC">
+         <register-group caption="Real-Time Counter" name="RTC" size="0x20">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="RTCEN" rw="RW"/>
+               <bitfield caption="Correction enable" mask="0x04" name="CORREN" rw="RW"/>
+               <bitfield caption="Prescaling Factor"
+                         mask="0x78"
+                         name="PRESCALER"
+                         rw="RW"
+                         values="RTC_PRESCALER"/>
+               <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x01"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CTRLA Synchronization Busy Flag"
+                         mask="0x01"
+                         name="CTRLABUSY"
+                         rw="R"/>
+               <bitfield caption="Count Synchronization Busy Flag"
+                         mask="0x02"
+                         name="CNTBUSY"
+                         rw="R"/>
+               <bitfield caption="Period Synchronization Busy Flag"
+                         mask="0x04"
+                         name="PERBUSY"
+                         rw="R"/>
+               <bitfield caption="Comparator Synchronization Busy Flag"
+                         mask="0x08"
+                         name="CMPBUSY"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt enable"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Compare Match Interrupt enable"
+                         mask="0x02"
+                         name="CMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Flag"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Compare Match Interrupt"
+                         mask="0x02"
+                         name="CMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Temporary"
+                      name="TEMP"
+                      offset="0x04"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Debug control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in debug" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Calibration"
+                      initval="0x00"
+                      name="CALIB"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Error Correction Value"
+                         mask="0x7F"
+                         name="ERROR"
+                         rw="RW"/>
+               <bitfield caption="Error Correction Sign Bit"
+                         mask="0x80"
+                         name="SIGN"
+                         rw="RW"/>
+            </register>
+            <register caption="Clock Select"
+                      initval="0x00"
+                      name="CLKSEL"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Select"
+                         mask="0x03"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="RTC_CLKSEL"/>
+            </register>
+            <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
+            <register caption="Period"
+                      initval="0xFFFF"
+                      name="PER"
+                      offset="0x0A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
+            <register caption="PIT Control A"
+                      initval="0x00"
+                      name="PITCTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="PITEN" rw="RW"/>
+               <bitfield caption="Period"
+                         mask="0x78"
+                         name="PERIOD"
+                         rw="RW"
+                         values="RTC_PERIOD"/>
+            </register>
+            <register caption="PIT Status"
+                      initval="0x00"
+                      name="PITSTATUS"
+                      offset="0x11"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CTRLA Synchronization Busy Flag"
+                         mask="0x01"
+                         name="CTRLBUSY"
+                         rw="R"/>
+            </register>
+            <register caption="PIT Interrupt Control"
+                      initval="0x00"
+                      name="PITINTCTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Periodic Interrupt" mask="0x01" name="PI" rw="RW"/>
+            </register>
+            <register caption="PIT Interrupt Flags"
+                      initval="0x00"
+                      name="PITINTFLAGS"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Periodic Interrupt" mask="0x01" name="PI" rw="RW"/>
+            </register>
+            <register caption="PIT Debug control"
+                      initval="0x00"
+                      name="PITDBGCTRL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in debug" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="PIT Event Generation Control A"
+                      initval="0x00"
+                      name="PITEVGENCTRLA"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Generation 0 Select"
+                         mask="0x0F"
+                         name="EVGEN0SEL"
+                         rw="RW"
+                         values="RTC_EVGEN0SEL"/>
+               <bitfield caption="Event Generation 1 Select"
+                         mask="0xF0"
+                         name="EVGEN1SEL"
+                         rw="RW"
+                         values="RTC_EVGEN1SEL"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock Select" name="RTC_CLKSEL">
+            <value caption="Internal 32.768 kHz Oscillator Divided by 32"
+                   name="OSC32K"
+                   value="0x0"/>
+            <value caption="32.768 kHz Crystal Oscillator" name="OSC1K" value="0x1"/>
+            <value caption="Internal 32.768 kHz Oscillator" name="XOSC32K" value="0x2"/>
+            <value caption="External Clock" name="EXTCLK" value="0x3"/>
+         </value-group>
+         <value-group caption="Prescaling Factor select" name="RTC_PRESCALER">
+            <value caption="RTC Clock / 1" name="DIV1" value="0x00"/>
+            <value caption="RTC Clock / 2" name="DIV2" value="0x01"/>
+            <value caption="RTC Clock / 4" name="DIV4" value="0x02"/>
+            <value caption="RTC Clock / 8" name="DIV8" value="0x03"/>
+            <value caption="RTC Clock / 16" name="DIV16" value="0x04"/>
+            <value caption="RTC Clock / 32" name="DIV32" value="0x05"/>
+            <value caption="RTC Clock / 64" name="DIV64" value="0x06"/>
+            <value caption="RTC Clock / 128" name="DIV128" value="0x07"/>
+            <value caption="RTC Clock / 256" name="DIV256" value="0x08"/>
+            <value caption="RTC Clock / 512" name="DIV512" value="0x09"/>
+            <value caption="RTC Clock / 1024" name="DIV1024" value="0x0A"/>
+            <value caption="RTC Clock / 2048" name="DIV2048" value="0x0B"/>
+            <value caption="RTC Clock / 4096" name="DIV4096" value="0x0C"/>
+            <value caption="RTC Clock / 8192" name="DIV8192" value="0x0D"/>
+            <value caption="RTC Clock / 16384" name="DIV16384" value="0x0E"/>
+            <value caption="RTC Clock / 32768" name="DIV32768" value="0x0F"/>
+         </value-group>
+         <value-group caption="Period select" name="RTC_PERIOD">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="RTC Clock Cycles 4" name="CYC4" value="0x01"/>
+            <value caption="RTC Clock Cycles 8" name="CYC8" value="0x02"/>
+            <value caption="RTC Clock Cycles 16" name="CYC16" value="0x03"/>
+            <value caption="RTC Clock Cycles 32" name="CYC32" value="0x04"/>
+            <value caption="RTC Clock Cycles 64" name="CYC64" value="0x05"/>
+            <value caption="RTC Clock Cycles 128" name="CYC128" value="0x06"/>
+            <value caption="RTC Clock Cycles 256" name="CYC256" value="0x07"/>
+            <value caption="RTC Clock Cycles 512" name="CYC512" value="0x08"/>
+            <value caption="RTC Clock Cycles 1024" name="CYC1024" value="0x09"/>
+            <value caption="RTC Clock Cycles 2048" name="CYC2048" value="0x0A"/>
+            <value caption="RTC Clock Cycles 4096" name="CYC4096" value="0x0B"/>
+            <value caption="RTC Clock Cycles 8192" name="CYC8192" value="0x0C"/>
+            <value caption="RTC Clock Cycles 16384" name="CYC16384" value="0x0D"/>
+            <value caption="RTC Clock Cycles 32768" name="CYC32768" value="0x0E"/>
+         </value-group>
+         <value-group caption="Event Generation 0 Select" name="RTC_EVGEN0SEL">
+            <value caption="No Event Generated" name="OFF" value="0x0"/>
+            <value caption="CLK_RTC divided by 4" name="DIV4" value="0x1"/>
+            <value caption="CLK_RTC divided by 8" name="DIV8" value="0x2"/>
+            <value caption="CLK_RTC divided by 16" name="DIV16" value="0x3"/>
+            <value caption="CLK_RTC divided by 32" name="DIV32" value="0x4"/>
+            <value caption="CLK_RTC divided by 64" name="DIV64" value="0x5"/>
+            <value caption="CLK_RTC divided by 128" name="DIV128" value="0x6"/>
+            <value caption="CLK_RTC divided by 256" name="DIV256" value="0x7"/>
+            <value caption="CLK_RTC divided by 512" name="DIV512" value="0x8"/>
+            <value caption="CLK_RTC divided by 1024" name="DIV1024" value="0x9"/>
+            <value caption="CLK_RTC divided by 2048" name="DIV2048" value="0xA"/>
+            <value caption="CLK_RTC divided by 4096" name="DIV4096" value="0xB"/>
+            <value caption="CLK_RTC divided by 8192" name="DIV8192" value="0xC"/>
+            <value caption="CLK_RTC divided by 16384" name="DIV16384" value="0xD"/>
+            <value caption="CLK_RTC divided by 32768" name="DIV32768" value="0xE"/>
+         </value-group>
+         <value-group caption="Event Generation 1 Select" name="RTC_EVGEN1SEL">
+            <value caption="No Event Generated" name="OFF" value="0x0"/>
+            <value caption="CLK_RTC divided by 4" name="DIV4" value="0x1"/>
+            <value caption="CLK_RTC divided by 8" name="DIV8" value="0x2"/>
+            <value caption="CLK_RTC divided by 16" name="DIV16" value="0x3"/>
+            <value caption="CLK_RTC divided by 32" name="DIV32" value="0x4"/>
+            <value caption="CLK_RTC divided by 64" name="DIV64" value="0x5"/>
+            <value caption="CLK_RTC divided by 128" name="DIV128" value="0x6"/>
+            <value caption="CLK_RTC divided by 256" name="DIV256" value="0x7"/>
+            <value caption="CLK_RTC divided by 512" name="DIV512" value="0x8"/>
+            <value caption="CLK_RTC divided by 1024" name="DIV1024" value="0x9"/>
+            <value caption="CLK_RTC divided by 2048" name="DIV2048" value="0xA"/>
+            <value caption="CLK_RTC divided by 4096" name="DIV4096" value="0xB"/>
+            <value caption="CLK_RTC divided by 8192" name="DIV8192" value="0xC"/>
+            <value caption="CLK_RTC divided by 16384" name="DIV16384" value="0xD"/>
+            <value caption="CLK_RTC divided by 32768" name="DIV32768" value="0xE"/>
+         </value-group>
+      </module>
+      <module caption="Signature row" id="avrdu" name="SIGROW">
+         <register-group caption="Signature row" name="SIGROW" size="0x40">
+            <register caption="Device ID Byte 0"
+                      name="DEVICEID0"
+                      offset="0x00"
+                      rw="R"
+                      size="1"/>
+            <register caption="Device ID Byte 1"
+                      name="DEVICEID1"
+                      offset="0x01"
+                      rw="R"
+                      size="1"/>
+            <register caption="Device ID Byte 2"
+                      name="DEVICEID2"
+                      offset="0x02"
+                      rw="R"
+                      size="1"/>
+            <register caption="Temperature Calibration 0"
+                      name="TEMPSENSE0"
+                      offset="0x04"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Temperature Calibration 0"
+                         mask="0xFFFF"
+                         name="TEMPSENSE0"
+                         rw="R"/>
+            </register>
+            <register caption="Temperature Calibration 1"
+                      name="TEMPSENSE1"
+                      offset="0x06"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Temperature Calibration 1"
+                         mask="0xFFFF"
+                         name="TEMPSENSE1"
+                         rw="R"/>
+            </register>
+            <register caption="LOTNUM0"
+                      name="SERNUM0"
+                      offset="0x10"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM1"
+                      name="SERNUM1"
+                      offset="0x11"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM2"
+                      name="SERNUM2"
+                      offset="0x12"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM3"
+                      name="SERNUM3"
+                      offset="0x13"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM4"
+                      name="SERNUM4"
+                      offset="0x14"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM5"
+                      name="SERNUM5"
+                      offset="0x15"
+                      rw="R"
+                      size="1"/>
+            <register caption="RANDOM"
+                      name="SERNUM6"
+                      offset="0x16"
+                      rw="R"
+                      size="1"/>
+            <register caption="SCRIBE"
+                      name="SERNUM7"
+                      offset="0x17"
+                      rw="R"
+                      size="1"/>
+            <register caption="XPOS0"
+                      name="SERNUM8"
+                      offset="0x18"
+                      rw="R"
+                      size="1"/>
+            <register caption="XPOS1"
+                      name="SERNUM9"
+                      offset="0x19"
+                      rw="R"
+                      size="1"/>
+            <register caption="YPOS0"
+                      name="SERNUM10"
+                      offset="0x1A"
+                      rw="R"
+                      size="1"/>
+            <register caption="YPOS1"
+                      name="SERNUM11"
+                      offset="0x1B"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES0"
+                      name="SERNUM12"
+                      offset="0x1C"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES1"
+                      name="SERNUM13"
+                      offset="0x1D"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES2"
+                      name="SERNUM14"
+                      offset="0x1E"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES3"
+                      name="SERNUM15"
+                      offset="0x1F"
+                      rw="R"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Sleep Controller"
+              id="clk_sleep_ctrl_avr_v3"
+              name="SLPCTRL">
+         <register-group caption="Sleep Controller" name="SLPCTRL" size="0x2">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sleep enable" mask="0x01" name="SEN" rw="RW"/>
+               <bitfield caption="Sleep mode"
+                         mask="0x06"
+                         name="SMODE"
+                         rw="RW"
+                         values="SLPCTRL_SMODE"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="VREGCTRL"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Performance Mode"
+                         mask="0x07"
+                         name="PMODE"
+                         rw="RW"
+                         values="SLPCTRL_PMODE"/>
+               <bitfield caption="High Temperature Low Leakage Enable"
+                         mask="0x10"
+                         name="HTLLEN"
+                         rw="RW"
+                         values="SLPCTRL_HTLLEN"/>
+            </register>
+         </register-group>
+         <value-group caption="Sleep mode select" name="SLPCTRL_SMODE">
+            <value caption="Idle mode" name="IDLE" value="0x00"/>
+            <value caption="Standby Mode" name="STDBY" value="0x01"/>
+            <value caption="Power-down Mode" name="PDOWN" value="0x02"/>
+         </value-group>
+         <value-group caption="High Temperature Low Leakage Enable select"
+                      name="SLPCTRL_HTLLEN">
+            <value caption="Disabled" name="OFF" value="0x0"/>
+            <value caption="Enabled" name="ON" value="0x1"/>
+         </value-group>
+         <value-group caption="Performance Mode select" name="SLPCTRL_PMODE">
+            <value caption="" name="AUTO" value="0x0"/>
+            <value caption="" name="FULL" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="Serial Peripheral Interface" id="spi_8bit_v2" name="SPI">
+         <register-group caption="Serial Peripheral Interface" name="SPI" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable Module" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Prescaler"
+                         mask="0x06"
+                         name="PRESC"
+                         rw="RW"
+                         values="SPI_PRESC"/>
+               <bitfield caption="Enable Double Speed" mask="0x10" name="CLK2X" rw="RW"/>
+               <bitfield caption="Host Operation Enable"
+                         mask="0x20"
+                         name="MASTER"
+                         rw="RW"/>
+               <bitfield caption="Data Order Setting" mask="0x40" name="DORD" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SPI Mode"
+                         mask="0x03"
+                         name="MODE"
+                         rw="RW"
+                         values="SPI_MODE"/>
+               <bitfield caption="SPI Select Disable" mask="0x04" name="SSD" rw="RW"/>
+               <bitfield caption="Buffer Mode Wait for Receive"
+                         mask="0x40"
+                         name="BUFWR"
+                         rw="RW"/>
+               <bitfield caption="Buffer Mode Enable" mask="0x80" name="BUFEN" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Enable" mask="0x01" name="IE" rw="RW"/>
+               <bitfield caption="SPI Select Trigger Interrupt Enable"
+                         mask="0x10"
+                         name="SSIE"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Enable"
+                         mask="0x20"
+                         name="DREIE"
+                         rw="RW"/>
+               <bitfield caption="Transfer Complete Interrupt Enable"
+                         mask="0x40"
+                         name="TXCIE"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Enable"
+                         mask="0x80"
+                         name="RXCIE"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="SPI.CTRLB.BUFEN" value="0"/>
+               <mode name="BUFFERED" qualifier="SPI.CTRLB.BUFEN" value="1"/>
+               <bitfield caption="Buffer Overflow"
+                         mask="0x01"
+                         modes="BUFFERED"
+                         name="BUFOVF"
+                         rw="RW"/>
+               <bitfield caption="SPI Select Trigger Interrupt Flag"
+                         mask="0x10"
+                         modes="BUFFERED"
+                         name="SSIF"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Flag"
+                         mask="0x20"
+                         modes="BUFFERED"
+                         name="DREIF"
+                         rw="RW"/>
+               <bitfield caption="Transfer Complete Interrupt Flag"
+                         mask="0x40"
+                         modes="BUFFERED"
+                         name="TXCIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         modes="BUFFERED"
+                         name="RXCIF"
+                         rw="RW"/>
+               <bitfield caption="Write Collision"
+                         mask="0x40"
+                         modes="DEFAULT"
+                         name="WRCOL"
+                         rw="RW"/>
+               <bitfield caption="Interrupt Flag"
+                         mask="0x80"
+                         modes="DEFAULT"
+                         name="IF"
+                         rw="RW"/>
+            </register>
+            <register caption="Data" name="DATA" offset="0x4" rw="RW" size="1"/>
+         </register-group>
+         <value-group caption="Prescaler select" name="SPI_PRESC">
+            <value caption="CLK_PER / 4" name="DIV4" value="0x00"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x01"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x02"/>
+            <value caption="CLK_PER / 128" name="DIV128" value="0x03"/>
+         </value-group>
+         <value-group caption="SPI Mode select" name="SPI_MODE">
+            <value caption="SPI Mode 0" name="0" value="0x00"/>
+            <value caption="SPI Mode 1" name="1" value="0x01"/>
+            <value caption="SPI Mode 2" name="2" value="0x02"/>
+            <value caption="SPI Mode 3" name="3" value="0x03"/>
+         </value-group>
+      </module>
+      <module caption="System Configuration Registers" id="avrdu" name="SYSCFG">
+         <register-group caption="System Configuration Registers" name="SYSCFG" size="0x20">
+            <register caption="Revision ID"
+                      name="REVID"
+                      offset="0x01"
+                      rw="RW"
+                      size="1"/>
+            <register caption="USB Voltage System Control"
+                      initval="0x00"
+                      name="VUSBCTRL"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="USB Voltage Regulator"
+                         mask="0x01"
+                         name="USBVREG"
+                         rw="RW"
+                         values="SYSCFG_USBVREG"/>
+            </register>
+         </register-group>
+         <value-group caption="USB Voltage Regulator select" name="SYSCFG_USBVREG">
+            <value caption="USBVREG is disabled" name="DISABLE" value="0x0"/>
+            <value caption="USBVREG is enabled" name="ENABLE" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="16-bit Timer/Counter Type A"
+              id="tmr_16b_pwm_v1"
+              name="TCA">
+         <register-group caption="16-bit Timer/Counter Type A" name="TCA" size="0x40">
+            <mode caption="Single Mode"
+                  name="SINGLE"
+                  qualifier="TCA.SINGLE.CTRLD.SPLITM"
+                  value="0"/>
+            <mode caption="Split Mode"
+                  name="SPLIT"
+                  qualifier="TCA.SPLIT.CTRLD.SPLITM"
+                  value="1"/>
+            <register caption="Control A"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Module Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Selection"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCA_SINGLE_CLKSEL"/>
+               <bitfield caption="Run in Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Waveform generation mode"
+                         mask="0x07"
+                         name="WGMODE"
+                         rw="RW"
+                         values="TCA_SINGLE_WGMODE"/>
+               <bitfield caption="Auto Lock Update" mask="0x08" name="ALUPD" rw="RW"/>
+               <bitfield caption="Compare 0 Enable" mask="0x10" name="CMP0EN" rw="RW"/>
+               <bitfield caption="Compare 1 Enable" mask="0x20" name="CMP1EN" rw="RW"/>
+               <bitfield caption="Compare 2 Enable" mask="0x40" name="CMP2EN" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Compare 0 Waveform Output Value"
+                         mask="0x01"
+                         name="CMP0OV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Waveform Output Value"
+                         mask="0x02"
+                         name="CMP1OV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Waveform Output Value"
+                         mask="0x04"
+                         name="CMP2OV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Split Mode Enable" mask="0x01" name="SPLITM" rw="RW"/>
+            </register>
+            <register caption="Control E Clear"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLECLR"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Direction" mask="0x01" name="DIR" rw="RW"/>
+               <bitfield caption="Lock Update" mask="0x02" name="LUPD" rw="RW"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SINGLE_CMD"/>
+            </register>
+            <register caption="Control E Set"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLESET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Direction"
+                         mask="0x01"
+                         name="DIR"
+                         rw="RW"
+                         values="TCA_SINGLE_DIR"/>
+               <bitfield caption="Lock Update" mask="0x02" name="LUPD" rw="RW"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SINGLE_CMD"/>
+            </register>
+            <register caption="Control F Clear"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLFCLR"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period Buffer Valid" mask="0x01" name="PERBV" rw="RW"/>
+               <bitfield caption="Compare 0 Buffer Valid"
+                         mask="0x02"
+                         name="CMP0BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Buffer Valid"
+                         mask="0x04"
+                         name="CMP1BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Buffer Valid"
+                         mask="0x08"
+                         name="CMP2BV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control F Set"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLFSET"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period Buffer Valid" mask="0x01" name="PERBV" rw="RW"/>
+               <bitfield caption="Compare 0 Buffer Valid"
+                         mask="0x02"
+                         name="CMP0BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Buffer Valid"
+                         mask="0x04"
+                         name="CMP1BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Buffer Valid"
+                         mask="0x08"
+                         name="CMP2BV"
+                         rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="EVCTRL"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Count on Event Input A"
+                         mask="0x01"
+                         name="CNTAEI"
+                         rw="RW"/>
+               <bitfield caption="Event Action A"
+                         mask="0x0E"
+                         name="EVACTA"
+                         rw="RW"
+                         values="TCA_SINGLE_EVACTA"/>
+               <bitfield caption="Count on Event Input B"
+                         mask="0x10"
+                         name="CNTBEI"
+                         rw="RW"/>
+               <bitfield caption="Event Action B"
+                         mask="0xE0"
+                         name="EVACTB"
+                         rw="RW"
+                         values="TCA_SINGLE_EVACTB"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="INTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt" mask="0x01" name="OVF" rw="RW"/>
+               <bitfield caption="Compare 0 Interrupt" mask="0x10" name="CMP0" rw="RW"/>
+               <bitfield caption="Compare 1 Interrupt" mask="0x20" name="CMP1" rw="RW"/>
+               <bitfield caption="Compare 2 Interrupt" mask="0x40" name="CMP2" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="INTFLAGS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt" mask="0x01" name="OVF" rw="RW"/>
+               <bitfield caption="Compare 0 Interrupt" mask="0x10" name="CMP0" rw="RW"/>
+               <bitfield caption="Compare 1 Interrupt" mask="0x20" name="CMP1" rw="RW"/>
+               <bitfield caption="Compare 2 Interrupt" mask="0x40" name="CMP2" rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary data for 16-bit Access"
+                      modes="SINGLE"
+                      name="TEMP"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Count"
+                      modes="SINGLE"
+                      name="CNT"
+                      offset="0x20"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Period"
+                      modes="SINGLE"
+                      name="PER"
+                      offset="0x26"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 0"
+                      modes="SINGLE"
+                      name="CMP0"
+                      offset="0x28"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 1"
+                      modes="SINGLE"
+                      name="CMP1"
+                      offset="0x2A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 2"
+                      modes="SINGLE"
+                      name="CMP2"
+                      offset="0x2C"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Period Buffer"
+                      modes="SINGLE"
+                      name="PERBUF"
+                      offset="0x36"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 0 Buffer"
+                      modes="SINGLE"
+                      name="CMP0BUF"
+                      offset="0x38"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 1 Buffer"
+                      modes="SINGLE"
+                      name="CMP1BUF"
+                      offset="0x3A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 2 Buffer"
+                      modes="SINGLE"
+                      name="CMP2BUF"
+                      offset="0x3C"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Control A"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Module Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Selection"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCA_SPLIT_CLKSEL"/>
+               <bitfield caption="Run in Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Compare 0 Enable"
+                         mask="0x01"
+                         name="LCMP0EN"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Enable"
+                         mask="0x02"
+                         name="LCMP1EN"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Enable"
+                         mask="0x04"
+                         name="LCMP2EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 0 Enable"
+                         mask="0x10"
+                         name="HCMP0EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 1 Enable"
+                         mask="0x20"
+                         name="HCMP1EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 2 Enable"
+                         mask="0x40"
+                         name="HCMP2EN"
+                         rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Compare 0 Output Value"
+                         mask="0x01"
+                         name="LCMP0OV"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Output Value"
+                         mask="0x02"
+                         name="LCMP1OV"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Output Value"
+                         mask="0x04"
+                         name="LCMP2OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 0 Output Value"
+                         mask="0x10"
+                         name="HCMP0OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 1 Output Value"
+                         mask="0x20"
+                         name="HCMP1OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 2 Output Value"
+                         mask="0x40"
+                         name="HCMP2OV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Split Mode Enable" mask="0x01" name="SPLITM" rw="RW"/>
+            </register>
+            <register caption="Control E Clear"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLECLR"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command Enable"
+                         mask="0x03"
+                         name="CMDEN"
+                         rw="RW"
+                         values="TCA_SPLIT_CMDEN"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SPLIT_CMD"/>
+            </register>
+            <register caption="Control E Set"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLESET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command Enable"
+                         mask="0x03"
+                         name="CMDEN"
+                         rw="RW"
+                         values="TCA_SPLIT_CMDEN"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SPLIT_CMD"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="INTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Underflow Interrupt Enable"
+                         mask="0x01"
+                         name="LUNF"
+                         rw="RW"/>
+               <bitfield caption="High Underflow Interrupt Enable"
+                         mask="0x02"
+                         name="HUNF"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 0 Interrupt Enable"
+                         mask="0x10"
+                         name="LCMP0"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Interrupt Enable"
+                         mask="0x20"
+                         name="LCMP1"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Interrupt Enable"
+                         mask="0x40"
+                         name="LCMP2"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="INTFLAGS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Underflow Interrupt Flag"
+                         mask="0x01"
+                         name="LUNF"
+                         rw="RW"/>
+               <bitfield caption="High Underflow Interrupt Flag"
+                         mask="0x02"
+                         name="HUNF"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Interrupt Flag"
+                         mask="0x10"
+                         name="LCMP0"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Interrupt Flag"
+                         mask="0x20"
+                         name="LCMP1"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 0 Interrupt Flag"
+                         mask="0x40"
+                         name="LCMP2"
+                         rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Low Count"
+                      modes="SPLIT"
+                      name="LCNT"
+                      offset="0x20"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Count"
+                      modes="SPLIT"
+                      name="HCNT"
+                      offset="0x21"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Period"
+                      modes="SPLIT"
+                      name="LPER"
+                      offset="0x26"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Period"
+                      modes="SPLIT"
+                      name="HPER"
+                      offset="0x27"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP0"
+                      offset="0x28"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP0"
+                      offset="0x29"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP1"
+                      offset="0x2A"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP1"
+                      offset="0x2B"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP2"
+                      offset="0x2C"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP2"
+                      offset="0x2D"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+         <value-group caption="Clock Selection" name="TCA_SINGLE_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER / 2" name="DIV2" value="0x01"/>
+            <value caption="CLK_PER / 4" name="DIV4" value="0x02"/>
+            <value caption="CLK_PER / 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x05"/>
+            <value caption="CLK_PER / 256" name="DIV256" value="0x06"/>
+            <value caption="CLK_PER / 1024" name="DIV1024" value="0x07"/>
+         </value-group>
+         <value-group caption="Waveform generation mode select" name="TCA_SINGLE_WGMODE">
+            <value caption="Normal Mode" name="NORMAL" value="0x00"/>
+            <value caption="Frequency Generation Mode" name="FRQ" value="0x01"/>
+            <value caption="Single Slope PWM" name="SINGLESLOPE" value="0x03"/>
+            <value caption="Dual Slope PWM, overflow on TOP" name="DSTOP" value="0x05"/>
+            <value caption="Dual Slope PWM, overflow on TOP and BOTTOM"
+                   name="DSBOTH"
+                   value="0x06"/>
+            <value caption="Dual Slope PWM, overflow on BOTTOM"
+                   name="DSBOTTOM"
+                   value="0x07"/>
+         </value-group>
+         <value-group caption="Command select" name="TCA_SINGLE_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="Force Update" name="UPDATE" value="0x01"/>
+            <value caption="Force Restart" name="RESTART" value="0x02"/>
+            <value caption="Force Hard Reset" name="RESET" value="0x03"/>
+         </value-group>
+         <value-group caption="Direction select" name="TCA_SINGLE_DIR">
+            <value caption="Count up" name="UP" value="0x0"/>
+            <value caption="Count down" name="DOWN" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Action A select" name="TCA_SINGLE_EVACTA">
+            <value caption="Count on positive edge event"
+                   name="CNT_POSEDGE"
+                   value="0x00"/>
+            <value caption="Count on any edge event" name="CNT_ANYEDGE" value="0x01"/>
+            <value caption="Count on prescaled clock while event line is 1."
+                   name="CNT_HIGHLVL"
+                   value="0x02"/>
+            <value caption="Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1."
+                   name="UPDOWN"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Event Action B select" name="TCA_SINGLE_EVACTB">
+            <value caption="No Action" name="NONE" value="0x00"/>
+            <value caption="Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1."
+                   name="UPDOWN"
+                   value="0x03"/>
+            <value caption="Restart counter at positive edge event"
+                   name="RESTART_POSEDGE"
+                   value="0x04"/>
+            <value caption="Restart counter on any edge event"
+                   name="RESTART_ANYEDGE"
+                   value="0x05"/>
+            <value caption="Restart counter while event line is 1."
+                   name="RESTART_HIGHLVL"
+                   value="0x06"/>
+         </value-group>
+         <value-group caption="Clock Selection" name="TCA_SPLIT_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER / 2" name="DIV2" value="0x01"/>
+            <value caption="CLK_PER / 4" name="DIV4" value="0x02"/>
+            <value caption="CLK_PER / 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x05"/>
+            <value caption="CLK_PER / 256" name="DIV256" value="0x06"/>
+            <value caption="CLK_PER / 1024" name="DIV1024" value="0x07"/>
+         </value-group>
+         <value-group caption="Command select" name="TCA_SPLIT_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="Force Update" name="UPDATE" value="0x01"/>
+            <value caption="Force Restart" name="RESTART" value="0x02"/>
+            <value caption="Force Hard Reset" name="RESET" value="0x03"/>
+         </value-group>
+         <value-group caption="Command Enable select" name="TCA_SPLIT_CMDEN">
+            <value caption="None" name="NONE" value="0x0"/>
+            <value caption="Both low byte and high byte counter"
+                   name="BOTH"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="16-bit Timer Type B" id="tmr_16b_capture_v1" name="TCB">
+         <register-group caption="16-bit Timer Type B" name="TCB" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Select"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCB_CLKSEL"/>
+               <bitfield caption="Synchronize Update" mask="0x10" name="SYNCUPD" rw="RW"/>
+               <bitfield caption="Cascade two timers" mask="0x20" name="CASCADE" rw="RW"/>
+               <bitfield caption="Run Standby" mask="0x40" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control Register B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Timer Mode"
+                         mask="0x07"
+                         name="CNTMODE"
+                         rw="RW"
+                         values="TCB_CNTMODE"/>
+               <bitfield caption="Pin Output Enable" mask="0x10" name="CCMPEN" rw="RW"/>
+               <bitfield caption="Pin Initial State" mask="0x20" name="CCMPINIT" rw="RW"/>
+               <bitfield caption="Asynchronous Enable" mask="0x40" name="ASYNC" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Input Enable" mask="0x01" name="CAPTEI" rw="RW"/>
+               <bitfield caption="Event Edge" mask="0x10" name="EDGE" rw="RW"/>
+               <bitfield caption="Input Capture Noise Cancellation Filter"
+                         mask="0x40"
+                         name="FILTER"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Capture or Timeout" mask="0x01" name="CAPT" rw="RW"/>
+               <bitfield caption="Overflow" mask="0x02" name="OVF" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Capture or Timeout" mask="0x01" name="CAPT" rw="RW"/>
+               <bitfield caption="Overflow" mask="0x02" name="OVF" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x7"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Run" mask="0x01" name="RUN" rw="R"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary Value"
+                      name="TEMP"
+                      offset="0x9"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Count"
+                      initval="0x0000"
+                      name="CNT"
+                      offset="0xA"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare or Capture"
+                      name="CCMP"
+                      offset="0xC"
+                      rw="RW"
+                      size="2"/>
+         </register-group>
+         <value-group caption="Clock Select" name="TCB_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER/2" name="DIV2" value="0x01"/>
+            <value caption="Use CLK_TCA from TCA0" name="TCA0" value="0x02"/>
+            <value caption="Count on event edge" name="EVENT" value="0x07"/>
+         </value-group>
+         <value-group caption="Timer Mode select" name="TCB_CNTMODE">
+            <value caption="Periodic Interrupt" name="INT" value="0x00"/>
+            <value caption="Periodic Timeout" name="TIMEOUT" value="0x01"/>
+            <value caption="Input Capture Event" name="CAPT" value="0x02"/>
+            <value caption="Input Capture Frequency measurement"
+                   name="FRQ"
+                   value="0x03"/>
+            <value caption="Input Capture Pulse-Width measurement"
+                   name="PW"
+                   value="0x04"/>
+            <value caption="Input Capture Frequency and Pulse-Width measurement"
+                   name="FRQPW"
+                   value="0x05"/>
+            <value caption="Single Shot" name="SINGLE" value="0x06"/>
+            <value caption="8-bit PWM" name="PWM8" value="0x07"/>
+         </value-group>
+      </module>
+      <module caption="Two-Wire Interface" id="i2c_8bit_avr_v3" name="TWI">
+         <register-group caption="Two-Wire Interface" name="TWI" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Fast-mode Plus Enable"
+                         mask="0x02"
+                         name="FMPEN"
+                         rw="RW"
+                         values="TWI_FMPEN"/>
+               <bitfield caption="SDA Hold Time"
+                         mask="0x0C"
+                         name="SDAHOLD"
+                         rw="RW"
+                         values="TWI_SDAHOLD"/>
+               <bitfield caption="SDA Setup Time"
+                         mask="0x10"
+                         name="SDASETUP"
+                         rw="RW"
+                         values="TWI_SDASETUP"/>
+               <bitfield caption="Input voltage transition level"
+                         mask="0x40"
+                         name="INPUTLVL"
+                         rw="RW"
+                         values="TWI_INPUTLVL"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run"
+                         mask="0x01"
+                         name="DBGRUN"
+                         rw="RW"
+                         values="TWI_DBGRUN"/>
+            </register>
+            <register caption="Host Control A"
+                      initval="0x00"
+                      name="MCTRLA"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Smart Mode Enable" mask="0x02" name="SMEN" rw="RW"/>
+               <bitfield caption="Inactive Bus Time-Out"
+                         mask="0x0C"
+                         name="TIMEOUT"
+                         rw="RW"
+                         values="TWI_TIMEOUT"/>
+               <bitfield caption="Quick Command Enable" mask="0x10" name="QCEN" rw="RW"/>
+               <bitfield caption="Write Interrupt Enable"
+                         mask="0x40"
+                         name="WIEN"
+                         rw="RW"/>
+               <bitfield caption="Read Interrupt Enable" mask="0x80" name="RIEN" rw="RW"/>
+            </register>
+            <register caption="Host Control B"
+                      initval="0x00"
+                      name="MCTRLB"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x03"
+                         name="MCMD"
+                         rw="RW"
+                         values="TWI_MCMD"/>
+               <bitfield caption="Acknowledge Action"
+                         mask="0x04"
+                         name="ACKACT"
+                         rw="RW"
+                         values="TWI_ACKACT"/>
+               <bitfield caption="Flush" mask="0x08" name="FLUSH" rw="RW"/>
+            </register>
+            <register caption="Host STATUS"
+                      initval="0x00"
+                      name="MSTATUS"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Bus State"
+                         mask="0x03"
+                         name="BUSSTATE"
+                         rw="RW"
+                         values="TWI_BUSSTATE"/>
+               <bitfield caption="Bus Error" mask="0x04" name="BUSERR" rw="RW"/>
+               <bitfield caption="Arbitration Lost" mask="0x08" name="ARBLOST" rw="RW"/>
+               <bitfield caption="Received Acknowledge" mask="0x10" name="RXACK" rw="R"/>
+               <bitfield caption="Clock Hold" mask="0x20" name="CLKHOLD" rw="RW"/>
+               <bitfield caption="Write Interrupt Flag" mask="0x40" name="WIF" rw="RW"/>
+               <bitfield caption="Read Interrupt Flag" mask="0x80" name="RIF" rw="RW"/>
+            </register>
+            <register caption="Host Baud Rate"
+                      initval="0x00"
+                      name="MBAUD"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Baud Rate" mask="0xFF" name="BAUD" rw="RW"/>
+            </register>
+            <register caption="Host Address"
+                      initval="0x00"
+                      name="MADDR"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address" mask="0xFF" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="Host Data"
+                      initval="0x00"
+                      name="MDATA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Data" mask="0xFF" name="DATA" rw="RW"/>
+            </register>
+            <register caption="Client Control A"
+                      initval="0x00"
+                      name="SCTRLA"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Smart Mode Enable" mask="0x02" name="SMEN" rw="RW"/>
+               <bitfield caption="Address Recognition Mode"
+                         mask="0x04"
+                         name="PMEN"
+                         rw="RW"/>
+               <bitfield caption="Stop Interrupt Enable" mask="0x20" name="PIEN" rw="RW"/>
+               <bitfield caption="Address or Stop Interrupt Enable"
+                         mask="0x40"
+                         name="APIEN"
+                         rw="RW"/>
+               <bitfield caption="Data Interrupt Enable" mask="0x80" name="DIEN" rw="RW"/>
+            </register>
+            <register caption="Client Control B"
+                      initval="0x00"
+                      name="SCTRLB"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x03"
+                         name="SCMD"
+                         rw="RW"
+                         values="TWI_SCMD"/>
+               <bitfield caption="Acknowledge Action"
+                         mask="0x04"
+                         name="ACKACT"
+                         rw="RW"
+                         values="TWI_ACKACT"/>
+            </register>
+            <register caption="Client Status"
+                      initval="0x00"
+                      name="SSTATUS"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address or Stop"
+                         mask="0x01"
+                         name="AP"
+                         rw="R"
+                         values="TWI_AP"/>
+               <bitfield caption="Read/Write Direction" mask="0x02" name="DIR" rw="R"/>
+               <bitfield caption="Bus Error" mask="0x04" name="BUSERR" rw="RW"/>
+               <bitfield caption="Collision" mask="0x08" name="COLL" rw="RW"/>
+               <bitfield caption="Received Acknowledge" mask="0x10" name="RXACK" rw="R"/>
+               <bitfield caption="Clock Hold" mask="0x20" name="CLKHOLD" rw="R"/>
+               <bitfield caption="Address or Stop Interrupt Flag"
+                         mask="0x40"
+                         name="APIF"
+                         rw="R"/>
+               <bitfield caption="Data Interrupt Flag" mask="0x80" name="DIF" rw="R"/>
+            </register>
+            <register caption="Client Address"
+                      initval="0x00"
+                      name="SADDR"
+                      offset="0xC"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address" mask="0xFF" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="Client Data"
+                      initval="0x00"
+                      name="SDATA"
+                      offset="0xD"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Data" mask="0xFF" name="DATA" rw="RW"/>
+            </register>
+            <register caption="Client Address Mask"
+                      initval="0x00"
+                      name="SADDRMASK"
+                      offset="0xE"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address Mask Enable" mask="0x01" name="ADDREN" rw="RW"/>
+               <bitfield caption="Address Mask" mask="0xFE" name="ADDRMASK" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Fast-mode Plus Enable select" name="TWI_FMPEN">
+            <value caption="Operating in Standard-mode or Fast-mode"
+                   name="OFF"
+                   value="0x0"/>
+            <value caption="Operating in Fast-mode Plus" name="ON" value="0x1"/>
+         </value-group>
+         <value-group caption="Input voltage transition level select" name="TWI_INPUTLVL">
+            <value caption="I2C input voltage transition level" name="I2C" value="0x0"/>
+            <value caption="SMBus 3.0 input voltage transition level"
+                   name="SMBUS"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="SDA Hold Time select" name="TWI_SDAHOLD">
+            <value caption="No SDA Hold Delay" name="OFF" value="0x0"/>
+            <value caption="Short SDA hold time" name="50NS" value="0x1"/>
+            <value caption="Meets SMBUS 2.0 specification under typical conditions"
+                   name="300NS"
+                   value="0x2"/>
+            <value caption="Meets SMBUS 2.0 specificaiton across all corners"
+                   name="500NS"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="SDA Setup Time select" name="TWI_SDASETUP">
+            <value caption="SDA setup time is four clock cycles" name="4CYC" value="0"/>
+            <value caption="SDA setup time is eight clock cycle" name="8CYC" value="1"/>
+         </value-group>
+         <value-group caption="Debug Run select" name="TWI_DBGRUN">
+            <value caption="The peripheral is halted in Break Debug mode and ignores events"
+                   name="HALT"
+                   value="0"/>
+            <value caption="The peripheral will continue to run in Break Debug mode when the CPU is halted"
+                   name="RUN"
+                   value="1"/>
+         </value-group>
+         <value-group caption="Inactive Bus Time-Out select" name="TWI_TIMEOUT">
+            <value caption="Bus time-out disabled. I2C." name="DISABLED" value="0"/>
+            <value caption="50us - SMBus" name="50US" value="1"/>
+            <value caption="100us" name="100US" value="2"/>
+            <value caption="200us" name="200US" value="3"/>
+         </value-group>
+         <value-group caption="Acknowledge Action select" name="TWI_ACKACT">
+            <value caption="Send ACK" name="ACK" value="0x0"/>
+            <value caption="Send NACK" name="NACK" value="0x1"/>
+         </value-group>
+         <value-group caption="Command select" name="TWI_MCMD">
+            <value caption="No action" name="NOACT" value="0"/>
+            <value caption="Execute Acknowledge Action followed by repeated Start."
+                   name="REPSTART"
+                   value="1"/>
+            <value caption="Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR."
+                   name="RECVTRANS"
+                   value="2"/>
+            <value caption="Execute Acknowledge Action followed by issuing a Stop condition."
+                   name="STOP"
+                   value="3"/>
+         </value-group>
+         <value-group caption="Bus State select" name="TWI_BUSSTATE">
+            <value caption="Unknown bus state" name="UNKNOWN" value="0"/>
+            <value caption="Bus is idle" name="IDLE" value="1"/>
+            <value caption="This TWI controls the bus" name="OWNER" value="2"/>
+            <value caption="The bus is busy" name="BUSY" value="3"/>
+         </value-group>
+         <value-group caption="Command select" name="TWI_SCMD">
+            <value caption="No Action" name="NOACT" value="0"/>
+            <value caption="Complete transaction" name="COMPTRANS" value="2"/>
+            <value caption="Used in response to an interrupt"
+                   name="RESPONSE"
+                   value="3"/>
+         </value-group>
+         <value-group caption="Address or Stop select" name="TWI_AP">
+            <value caption="A Stop condition generated the interrupt on APIF flag"
+                   name="STOP"
+                   value="0"/>
+            <value caption="Address detection generated the interrupt on APIF flag"
+                   name="ADR"
+                   value="1"/>
+         </value-group>
+      </module>
+      <module caption="Universal Synchronous and Asynchronous Receiver and Transmitter"
+              id="uart_autobd_v4"
+              name="USART">
+         <register-group caption="Universal Synchronous and Asynchronous Receiver and Transmitter"
+                         name="USART"
+                         size="0x10">
+            <register caption="Receive Data Low Byte"
+                      initval="0x00"
+                      name="RXDATAL"
+                      offset="0x0"
+                      rw="R"
+                      size="1">
+               <bitfield caption="RX Data" mask="0xFF" name="DATA" rw="R"/>
+            </register>
+            <register caption="Receive Data High Byte"
+                      initval="0x00"
+                      name="RXDATAH"
+                      offset="0x1"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Receiver Data Register"
+                         mask="0x01"
+                         name="DATA8"
+                         rw="R"/>
+               <bitfield caption="Parity Error" mask="0x02" name="PERR" rw="R"/>
+               <bitfield caption="Frame Error" mask="0x04" name="FERR" rw="R"/>
+               <bitfield caption="Buffer Overflow" mask="0x40" name="BUFOVF" rw="R"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         name="RXCIF"
+                         rw="R"/>
+            </register>
+            <register caption="Transmit Data Low Byte"
+                      initval="0x00"
+                      name="TXDATAL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit Data Register"
+                         mask="0xFF"
+                         name="DATA"
+                         rw="RW"/>
+            </register>
+            <register caption="Transmit Data High Byte"
+                      initval="0x00"
+                      name="TXDATAH"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit Data Register (CHSIZE=9bit)"
+                         mask="0x01"
+                         name="DATA8"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x20"
+                      name="STATUS"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Wait For Break" mask="0x01" name="WFB" rw="RW"/>
+               <bitfield caption="Break Detected Flag" mask="0x02" name="BDF" rw="RW"/>
+               <bitfield caption="Inconsistent Sync Field Interrupt Flag"
+                         mask="0x08"
+                         name="ISFIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Start Interrupt"
+                         mask="0x10"
+                         name="RXSIF"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Flag"
+                         mask="0x20"
+                         name="DREIF"
+                         rw="R"/>
+               <bitfield caption="Transmit Interrupt Flag"
+                         mask="0x40"
+                         name="TXCIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         name="RXCIF"
+                         rw="R"/>
+            </register>
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="RS485 Mode internal transmitter"
+                         mask="0x01"
+                         name="RS485"
+                         rw="RW"
+                         values="USART_RS485"/>
+               <bitfield caption="Auto-baud Error Interrupt Enable"
+                         mask="0x04"
+                         name="ABEIE"
+                         rw="RW"/>
+               <bitfield caption="Loop-back Mode Enable" mask="0x08" name="LBME" rw="RW"/>
+               <bitfield caption="Receiver Start Frame Interrupt Enable"
+                         mask="0x10"
+                         name="RXSIE"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Enable"
+                         mask="0x20"
+                         name="DREIE"
+                         rw="RW"/>
+               <bitfield caption="Transmit Complete Interrupt Enable"
+                         mask="0x40"
+                         name="TXCIE"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Enable"
+                         mask="0x80"
+                         name="RXCIE"
+                         rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Multi-processor Communication Mode"
+                         mask="0x01"
+                         name="MPCM"
+                         rw="RW"/>
+               <bitfield caption="Receiver Mode"
+                         mask="0x06"
+                         name="RXMODE"
+                         rw="RW"
+                         values="USART_RXMODE"/>
+               <bitfield caption="Open Drain Mode Enable"
+                         mask="0x08"
+                         name="ODME"
+                         rw="RW"/>
+               <bitfield caption="Start Frame Detection Enable"
+                         mask="0x10"
+                         name="SFDEN"
+                         rw="RW"/>
+               <bitfield caption="Transmitter Enable" mask="0x40" name="TXEN" rw="RW"/>
+               <bitfield caption="Reciever enable" mask="0x80" name="RXEN" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x03"
+                      name="CTRLC"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <mode name="NORMAL" qualifier="USART.CTRLC.CMODE" value="0x00 0x01 0x02"/>
+               <mode name="MSPI" qualifier="USART.CTRLC.CMODE" value="0x03"/>
+               <bitfield caption="Communication Mode"
+                         mask="0xC0"
+                         name="CMODE"
+                         rw="RW"
+                         values="USART_CMODE"/>
+               <bitfield caption="SPI Host Mode, Clock Phase"
+                         mask="0x02"
+                         modes="MSPI"
+                         name="UCPHA"
+                         rw="RW"/>
+               <bitfield caption="SPI Host Mode, Data Order"
+                         mask="0x04"
+                         modes="MSPI"
+                         name="UDORD"
+                         rw="RW"/>
+               <bitfield caption="Character Size"
+                         mask="0x07"
+                         modes="NORMAL"
+                         name="CHSIZE"
+                         rw="RW"
+                         values="USART_NORMAL_CHSIZE"/>
+               <bitfield caption="Stop Bit Mode"
+                         mask="0x08"
+                         modes="NORMAL"
+                         name="SBMODE"
+                         rw="RW"
+                         values="USART_NORMAL_SBMODE"/>
+               <bitfield caption="Parity Mode"
+                         mask="0x30"
+                         modes="NORMAL"
+                         name="PMODE"
+                         rw="RW"
+                         values="USART_NORMAL_PMODE"/>
+            </register>
+            <register caption="Baud Rate"
+                      initval="0x0000"
+                      name="BAUD"
+                      offset="0x8"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Auto Baud Window"
+                         mask="0xC0"
+                         name="ABW"
+                         rw="RW"
+                         values="USART_ABW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0xC"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="IrDA Event Input Enable"
+                         mask="0x01"
+                         name="IREI"
+                         rw="RW"/>
+            </register>
+            <register caption="IRCOM Transmitter Pulse Length Control"
+                      initval="0x00"
+                      name="TXPLCTRL"
+                      offset="0xD"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit pulse length" mask="0xFF" name="TXPL" rw="RW"/>
+            </register>
+            <register caption="IRCOM Receiver Pulse Length Control"
+                      initval="0x00"
+                      name="RXPLCTRL"
+                      offset="0xE"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Receiver Pulse Lenght" mask="0x7F" name="RXPL" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="RS485 Mode internal transmitter select" name="USART_RS485">
+            <value caption="RS485 Mode disabled" name="DISABLE" value="0x0"/>
+            <value caption="RS485 Mode enabled" name="ENABLE" value="0x1"/>
+         </value-group>
+         <value-group caption="Receiver Mode select" name="USART_RXMODE">
+            <value caption="Normal mode" name="NORMAL" value="0x0"/>
+            <value caption="CLK2x mode" name="CLK2X" value="0x1"/>
+            <value caption="Generic autobaud mode" name="GENAUTO" value="0x2"/>
+            <value caption="LIN constrained autobaud mode" name="LINAUTO" value="0x3"/>
+         </value-group>
+         <value-group caption="Communication Mode select" name="USART_CMODE">
+            <value caption="Asynchronous Mode" name="ASYNCHRONOUS" value="0x00"/>
+            <value caption="Synchronous Mode" name="SYNCHRONOUS" value="0x01"/>
+            <value caption="Infrared Communication" name="IRCOM" value="0x02"/>
+            <value caption="SPI Host Mode" name="MSPI" value="0x03"/>
+         </value-group>
+         <value-group caption="Character Size select" name="USART_NORMAL_CHSIZE">
+            <value caption="Character size: 5 bit" name="5BIT" value="0x00"/>
+            <value caption="Character size: 6 bit" name="6BIT" value="0x01"/>
+            <value caption="Character size: 7 bit" name="7BIT" value="0x02"/>
+            <value caption="Character size: 8 bit" name="8BIT" value="0x03"/>
+            <value caption="Character size: 9 bit read low byte first"
+                   name="9BITL"
+                   value="0x06"/>
+            <value caption="Character size: 9 bit read high byte first"
+                   name="9BITH"
+                   value="0x07"/>
+         </value-group>
+         <value-group caption="Parity Mode select" name="USART_NORMAL_PMODE">
+            <value caption="No Parity" name="DISABLED" value="0x00"/>
+            <value caption="Even Parity" name="EVEN" value="0x02"/>
+            <value caption="Odd Parity" name="ODD" value="0x03"/>
+         </value-group>
+         <value-group caption="Stop Bit Mode select" name="USART_NORMAL_SBMODE">
+            <value caption="1 stop bit" name="1BIT" value="0x0"/>
+            <value caption="2 stop bits" name="2BIT" value="0x1"/>
+         </value-group>
+         <value-group caption="Auto Baud Window select" name="USART_ABW">
+            <value caption="18% tolerance" name="WDW0" value="0x0"/>
+            <value caption="15% tolerance" name="WDW1" value="0x1"/>
+            <value caption="21% tolerance" name="WDW2" value="0x2"/>
+            <value caption="25% tolerance" name="WDW3" value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="USB Device Controller" id="usb_fscore_avr_v1" name="USB">
+         <register-group caption="USB Device Controller EP" name="USB_EP" size="0x8">
+            <register caption="Endpoint Status"
+                      name="STATUS"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="USB.CTRL.TYPE" value="0x00 0x01 0x02"/>
+               <mode name="ISO" qualifier="USB.CTRL.TYPE" value="0x03"/>
+               <bitfield caption="Data Buffer NAK" mask="0x02" name="BUSNAK" rw="RW"/>
+               <bitfield caption="Transaction Complete"
+                         mask="0x20"
+                         name="TRNCOMPL"
+                         rw="RW"/>
+               <bitfield caption="Underflow/Overflow EP"
+                         mask="0x40"
+                         name="UNFOVF"
+                         rw="RW"/>
+               <bitfield caption="Data Toggle"
+                         mask="0x01"
+                         modes="DEFAULT"
+                         name="TOGGLE"
+                         rw="RW"
+                         values="USB_DEFAULT_TOGGLE"/>
+               <bitfield caption="EP Stalled"
+                         mask="0x08"
+                         modes="DEFAULT"
+                         name="STALLED"
+                         rw="RW"/>
+               <bitfield caption="EP Setup Complete"
+                         mask="0x10"
+                         modes="DEFAULT"
+                         name="EPSETUP"
+                         rw="RW"/>
+               <bitfield caption="CRC Error"
+                         mask="0x80"
+                         modes="ISO"
+                         name="CRC"
+                         rw="RW"/>
+            </register>
+            <register caption="Endpoint Control"
+                      name="CTRL"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="USB.CTRL.TYPE" value="0x00 0x01 0x02"/>
+               <mode name="ISO" qualifier="USB.CTRL.TYPE" value="0x03"/>
+               <bitfield caption="TRNCOMPL Interrupt Disable"
+                         mask="0x08"
+                         name="TCDSBL"
+                         rw="RW"/>
+               <bitfield caption="Multipacket transfer enable"
+                         mask="0x20"
+                         name="MULTIPKT"
+                         rw="RW"/>
+               <bitfield caption="Endpoint type"
+                         mask="0xC0"
+                         name="TYPE"
+                         rw="RW"
+                         values="USB_TYPE"/>
+               <bitfield caption="Data Size default"
+                         mask="0x03"
+                         modes="DEFAULT"
+                         name="BUFSIZE"
+                         rw="RW"
+                         values="USB_DEFAULT_BUFSIZE"/>
+               <bitfield caption="Endpoint will respond with STALL"
+                         mask="0x04"
+                         modes="DEFAULT"
+                         name="DOSTALL"
+                         rw="RW"/>
+               <bitfield caption="Automatic zero length packet"
+                         mask="0x10"
+                         modes="DEFAULT"
+                         name="AZLP"
+                         rw="RW"/>
+               <bitfield caption="Data Size isochronous"
+                         mask="0x07"
+                         modes="ISO"
+                         name="BUFSIZE"
+                         rw="RW"
+                         values="USB_ISO_BUFSIZE"/>
+            </register>
+            <register caption="Endpoint Byte Count"
+                      name="CNT"
+                      offset="0x02"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Endpoint Byte Count" mask="0xFFFF" name="CNT" rw="RW"/>
+            </register>
+            <register caption="Endpoint Data Pointer"
+                      name="DATAPTR"
+                      offset="0x04"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Endpoint data pointer"
+                         mask="0xFFFF"
+                         name="DATAPTR"
+                         rw="RW"/>
+            </register>
+            <register caption="Endpoint Multi-packet Byte Count"
+                      name="MCNT"
+                      offset="0x06"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Multi-packet byte count"
+                         mask="0xFFFF"
+                         name="MCNT"
+                         rw="RW"/>
+            </register>
+         </register-group>
+         <register-group caption="USB Device Controller EP_PAIR"
+                         name="USB_EP_PAIR"
+                         size="0x10">
+            <register-group caption="USB Device Controller OUT"
+                            name="OUT"
+                            name-in-module="USB_EP"
+                            offset="0x00"
+                            size="0x08"/>
+            <register-group caption="USB Device Controller IN"
+                            name="IN"
+                            name-in-module="USB_EP"
+                            offset="0x08"
+                            size="0x08"/>
+         </register-group>
+         <register-group caption="USB Device Controller EP_TABLE"
+                         name="USB_EP_TABLE"
+                         size="0x122">
+            <register caption="FIFO Pointer Table"
+                      count="0x20"
+                      name="FIFO"
+                      offset="0x00"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Endpoint Direction"
+                         mask="0x08"
+                         name="DIR"
+                         rw="R"
+                         values="USB_DIR"/>
+               <bitfield caption="Endpoint Number" mask="0xF0" name="EPNUM" rw="R"/>
+            </register>
+            <register-group caption="USB Device Controller EP"
+                            count="0x10"
+                            name="EP"
+                            name-in-module="USB_EP_PAIR"
+                            offset="0x20"
+                            size="0x100"/>
+            <register caption="FRAMENUM count"
+                      name="FRAMENUM"
+                      offset="0x120"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Frame Number" mask="0x7FF" name="FRAMENUM" rw="R"/>
+               <bitfield caption="Frame Error" mask="0x8000" name="FRAMEERR" rw="R"/>
+            </register>
+         </register-group>
+         <register-group caption="USB Device Controller STATUS" name="USB_STATUS" size="0x4">
+            <register caption="Endpoint n OUT Status Clear"
+                      initval="0x00"
+                      name="OUTCLR"
+                      offset="0x00"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+            <register caption="Endpoint n OUT Status Set"
+                      initval="0x00"
+                      name="OUTSET"
+                      offset="0x01"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+            <register caption="Endpoint n IN Status Clear"
+                      initval="0x00"
+                      name="INCLR"
+                      offset="0x02"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+            <register caption="Endpoint n IN Status Set"
+                      initval="0x00"
+                      name="INSET"
+                      offset="0x03"
+                      rw="W"
+                      size="1">
+               <bitfield caption="Read-Modify-Write Endpoint STATUS"
+                         mask="0xFF"
+                         name="RMWSTATUS"
+                         rw="W"/>
+            </register>
+         </register-group>
+         <register-group caption="USB Device Controller" name="USB" size="0x80">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Maximum Endpoint Address"
+                         mask="0x0F"
+                         name="MAXEP"
+                         rw="RW"/>
+               <bitfield caption="Store Frame Number Enable"
+                         mask="0x10"
+                         name="STFRNUM"
+                         rw="RW"/>
+               <bitfield caption="Transaction Complete FIFO Enable"
+                         mask="0x20"
+                         name="FIFOEN"
+                         rw="RW"/>
+               <bitfield caption="USB Enable" mask="0x80" name="ENABLE" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Attach" mask="0x01" name="ATTACH" rw="RW"/>
+               <bitfield caption="Respond with NAK on all Endpoints"
+                         mask="0x02"
+                         name="GNAK"
+                         rw="RW"/>
+               <bitfield caption="Set GNAK Automatically after SETUP"
+                         mask="0x04"
+                         name="GNAUTO"
+                         rw="RW"/>
+               <bitfield caption="Send Upstream Resume"
+                         mask="0x08"
+                         name="URESUME"
+                         rw="RW"/>
+            </register>
+            <register caption="Bus State"
+                      initval="0x00"
+                      name="BUSSTATE"
+                      offset="0x02"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Bus Reset" mask="0x01" name="BUSRST" rw="R"/>
+               <bitfield caption="Bus Suspended" mask="0x02" name="SUSPENDED" rw="R"/>
+               <bitfield caption="Downstram Resume" mask="0x04" name="DRESUME" rw="R"/>
+               <bitfield caption="Upstream Resume" mask="0x08" name="URESUME" rw="R"/>
+               <bitfield caption="Wait Time Resume" mask="0x10" name="WTRSM" rw="R"/>
+            </register>
+            <register caption="Address"
+                      initval="0x00"
+                      name="ADDR"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Device Address" mask="0x7F" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="FIFO Write Pointer"
+                      initval="0xFF"
+                      name="FIFOWP"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="FIFO Write Pointer" mask="0x1F" name="FIFOWP" rw="RW"/>
+            </register>
+            <register caption="FIFO Read Pointer"
+                      initval="0xFF"
+                      name="FIFORP"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="FIFO Read Pointer" mask="0x1F" name="FIFORP" rw="RW"/>
+            </register>
+            <register caption="Endpoint Configuration Table Pointer"
+                      initval="0x0000"
+                      name="EPPTR"
+                      offset="0x06"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Endpoint Configuration Table Pointer"
+                         mask="0xFFFF"
+                         name="EPPTR"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Control A"
+                      initval="0x00"
+                      name="INTCTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Enable"
+                         mask="0x02"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Underflow Interrupt Enable"
+                         mask="0x04"
+                         name="UNF"
+                         rw="RW"/>
+               <bitfield caption="STALL Interrupt Enable"
+                         mask="0x08"
+                         name="STALLED"
+                         rw="RW"/>
+               <bitfield caption="Reset Interrupt Enable"
+                         mask="0x10"
+                         name="RESET"
+                         rw="RW"/>
+               <bitfield caption="Resume Interrupt Enable"
+                         mask="0x20"
+                         name="RESUME"
+                         rw="RW"/>
+               <bitfield caption="Suspend Interrupt Enable"
+                         mask="0x40"
+                         name="SUSPEND"
+                         rw="RW"/>
+               <bitfield caption="Start Of Frame Interrupt Enable"
+                         mask="0x80"
+                         name="SOF"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control B"
+                      initval="0x00"
+                      name="INTCTRLB"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SETUP Transaction Complete Interrupt Enable"
+                         mask="0x01"
+                         name="SETUP"
+                         rw="RW"/>
+               <bitfield caption="GNAK Operation Done Interrupt Enable"
+                         mask="0x02"
+                         name="GNDONE"
+                         rw="RW"/>
+               <bitfield caption="Transaction Complete Interrupt Enable"
+                         mask="0x20"
+                         name="TRNCOMPL"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags A"
+                      initval="0x00"
+                      name="INTFLAGSA"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Flag"
+                         mask="0x02"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Underflow Interrupt Flag"
+                         mask="0x04"
+                         name="UNF"
+                         rw="RW"/>
+               <bitfield caption="STALL Interrupt Flag"
+                         mask="0x08"
+                         name="STALLED"
+                         rw="RW"/>
+               <bitfield caption="Reset Interrupt Flag" mask="0x10" name="RESET" rw="RW"/>
+               <bitfield caption="Resume Interrupt Flag"
+                         mask="0x20"
+                         name="RESUME"
+                         rw="RW"/>
+               <bitfield caption="Suspend Interrupt Flag"
+                         mask="0x40"
+                         name="SUSPEND"
+                         rw="RW"/>
+               <bitfield caption="Start Of Frame Interrupt Flag"
+                         mask="0x80"
+                         name="SOF"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags B"
+                      initval="0x00"
+                      name="INTFLAGSB"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SETUP Transaction Complete Interrupt Flag"
+                         mask="0x01"
+                         name="SETUP"
+                         rw="RW"/>
+               <bitfield caption="GNAK Operation Done Interrupt Flag"
+                         mask="0x02"
+                         name="GNDONE"
+                         rw="RW"/>
+               <bitfield caption="RMW Busy Flag" mask="0x04" name="RMWBUSY" rw="RW"/>
+               <bitfield caption="Transaction Complete Interrupt Flag"
+                         mask="0x20"
+                         name="TRNCOMPL"
+                         rw="RW"/>
+            </register>
+            <register-group caption="USB Device Controller STATUS"
+                            count="0x10"
+                            name="STATUS"
+                            name-in-module="USB_STATUS"
+                            offset="0x40"
+                            size="0x40"/>
+         </register-group>
+         <value-group caption="Data Size default select" name="USB_DEFAULT_BUFSIZE">
+            <value caption="8 bytes buffer size" name="BUF8" value="0x0"/>
+            <value caption="16 bytes buffer size" name="BUF16" value="0x1"/>
+            <value caption="32 bytes buffer size" name="BUF32" value="0x2"/>
+            <value caption="64 bytes buffer size" name="BUF64" value="0x3"/>
+         </value-group>
+         <value-group caption="Endpoint type select" name="USB_TYPE">
+            <value caption="Endpoint Disabled" name="DISABLE" value="0x0"/>
+            <value caption="Control" name="CONTROL" value="0x1"/>
+            <value caption="Bulk or Interrupt" name="BULKINT" value="0x2"/>
+            <value caption="Isochronous" name="ISO" value="0x3"/>
+         </value-group>
+         <value-group caption="Data Size isochronous select" name="USB_ISO_BUFSIZE">
+            <value caption="8 bytes buffer size" name="BUF8" value="0x0"/>
+            <value caption="16 bytes buffer size" name="BUF16" value="0x1"/>
+            <value caption="32 bytes buffer size" name="BUF32" value="0x2"/>
+            <value caption="64 bytes buffer size" name="BUF64" value="0x3"/>
+            <value caption="128 bytes buffer size" name="BUF128" value="0x4"/>
+            <value caption="256 bytes buffer size" name="BUF256" value="0x5"/>
+            <value caption="512 bytes buffer size" name="BUF512" value="0x6"/>
+            <value caption="1023 bytes buffer size" name="BUF1023" value="0x7"/>
+         </value-group>
+         <value-group caption="Endpoint Direction select" name="USB_DIR">
+            <value caption="OUT Endpoint" name="OUT" value="0x0"/>
+            <value caption="In Endpoint" name="IN" value="0x1"/>
+         </value-group>
+         <value-group caption="Data Toggle select" name="USB_DEFAULT_TOGGLE">
+            <value caption="DATA0 PID in next transaction" name="DATA0" value="0x0"/>
+            <value caption="DATA1 PID in next transaction" name="DATA1" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="User Row" id="avrdu" name="USERROW">
+         <register-group caption="User Row" name="USERROW" size="0x200">
+            <register caption="User Row"
+                      count="0x200"
+                      name="USERROW"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Virtual Ports" id="gpio_ports_avr_v3_vport" name="VPORT">
+         <register-group caption="Virtual Ports" name="VPORT" size="0x4">
+            <register caption="Data Direction"
+                      initval="0x00"
+                      name="DIR"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value"
+                      initval="0x00"
+                      name="OUT"
+                      offset="0x1"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Input Value"
+                      initval="0x00"
+                      name="IN"
+                      offset="0x2"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin Interrupt Flag" mask="0xFF" name="INT" rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Voltage reference" id="avrdu" name="VREF">
+         <register-group caption="Voltage reference" name="VREF" size="0x2">
+            <register caption="ADC0 Reference"
+                      initval="0x00"
+                      name="ACREF"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference select"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="VREF_REFSEL"/>
+               <bitfield caption="Always on" mask="0x80" name="ALWAYSON" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Reference select" name="VREF_REFSEL">
+            <value caption="Internal 1.024V reference" name="1V024" value="0x0"/>
+            <value caption="Internal 2.048V reference" name="2V048" value="0x1"/>
+            <value caption="Internal 4.096V reference" name="4V096" value="0x2"/>
+            <value caption="Internal 2.500V reference" name="2V500" value="0x3"/>
+            <value caption="VDD as reference" name="VDD" value="0x5"/>
+            <value caption="External reference on VREFA pin" name="VREFA" value="0x6"/>
+         </value-group>
+      </module>
+      <module caption="Watch-Dog Timer" id="wdt_windowed_v2" name="WDT">
+         <register-group caption="Watch-Dog Timer" name="WDT" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period"
+                         mask="0x0F"
+                         name="PERIOD"
+                         rw="RW"
+                         values="WDT_PERIOD"/>
+               <bitfield caption="Window"
+                         mask="0xF0"
+                         name="WINDOW"
+                         rw="RW"
+                         values="WDT_WINDOW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Syncronization busy"
+                         mask="0x01"
+                         name="SYNCBUSY"
+                         rw="R"/>
+               <bitfield caption="Lock enable" mask="0x80" name="LOCK" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Period select" name="WDT_PERIOD">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.1s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.2s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+         <value-group caption="Window select" name="WDT_WINDOW">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.1s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.2s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+      </module>
+   </modules>
+   <pinouts>
+      <pinout name="QFN32USB">
+         <pin pad="PA3" position="1"/>
+         <pin pad="PA4" position="2"/>
+         <pin pad="PA5" position="3"/>
+         <pin pad="PA6" position="4"/>
+         <pin pad="PA7" position="5"/>
+         <pin pad="VUSB" position="6"/>
+         <pin pad="DM" position="7"/>
+         <pin pad="DP" position="8"/>
+         <pin pad="PC3" position="9"/>
+         <pin pad="PD0" position="10"/>
+         <pin pad="PD1" position="11"/>
+         <pin pad="PD2" position="12"/>
+         <pin pad="PD3" position="13"/>
+         <pin pad="PD4" position="14"/>
+         <pin pad="PD5" position="15"/>
+         <pin pad="PD6" position="16"/>
+         <pin pad="PD7" position="17"/>
+         <pin pad="VDD1" position="18"/>
+         <pin pad="GND1" position="19"/>
+         <pin pad="PF0" position="20"/>
+         <pin pad="PF1" position="21"/>
+         <pin pad="PF2" position="22"/>
+         <pin pad="PF3" position="23"/>
+         <pin pad="PF4" position="24"/>
+         <pin pad="PF5" position="25"/>
+         <pin pad="PF6" position="26"/>
+         <pin pad="PF7" position="27"/>
+         <pin pad="VDD0" position="28"/>
+         <pin pad="GND0" position="29"/>
+         <pin pad="PA0" position="30"/>
+         <pin pad="PA1" position="31"/>
+         <pin pad="PA2" position="32"/>
+      </pinout>
+   </pinouts>
+</avr-tools-device-file>


### PR DESCRIPTION
Adds basic support for AVR64DU32 and AVR64DU28. I have only spot checked the generated doc, they look ok.

https://www.microchip.com/en-us/product/AVR64DU32