### PR TITLE
Update to svd2rust 0.33.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: svd2rust
-          version: 0.28.0
+          version: 0.33.1
       - name: Install cargo-form
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: rust-tools-003
+          key: rust-tools-004
       - name: Install svd2rust
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ svd/%.svd.patched: svd/%.svd .deps/%.d
 src/devices/%/mod.full.rs: svd/%.svd.patched
 	@mkdir -p $(@D)
 	@echo -e "\tSVD2RUST\t$*"
-	@cd $(@D); svd2rust --generic_mod --make_mod --target none -i $(realpath $<)
+	@cd $(@D); svd2rust --ident-formats-theme legacy --generic_mod --make_mod --target none -i $(realpath $<)
 	@mv $(@D)/mod.rs $@
 	@mv $(@D)/generic.rs $(@D)/../../generic.rs
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The version on `crates.io` is pre-built.  The following is only necessary when t
 You need to have [atdf2svd][] (= 0.4.0), [svd2rust][] (= 0.28), [form][] (>= 0.8), [rustfmt][](for the *nightly* toolchain) and [svdtools][] (>= 0.1.9) installed:
 ```bash
 cargo install atdf2svd --version 0.4.0
-cargo install svd2rust --version 0.28.0
+cargo install svd2rust --version 0.33.1
 cargo install form
 rustup component add --toolchain nightly rustfmt
 pip3 install --user svdtools


### PR DESCRIPTION
This improves the generated API in various ways.

The most major change seems to be from [0.31.0](https://github.com/rust-embedded/svd2rust/releases/tag/v0.31.0) where registers are now accessed using methods instead of fields.  This will require rather large downstream changes.

Upstream svd2rust also switched to a different case style for identifiers in [0.32.0](https://github.com/rust-embedded/svd2rust/releases/tag/v0.32.0).  For now, this is disabled using `--ident-formats legacy` but we should consider following their suggestion at some point in the future.