### PR TITLE
ci: Bump nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,12 @@ jobs:
       - name: Install Nightly Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2023-08-08
+          toolchain: nightly-2024-03-22
           components: rustfmt
 
       # Actual test run
       - name: Generate chip description sources
-        run: make RUSTUP_TOOLCHAIN=nightly-2023-08-08
+        run: make RUSTUP_TOOLCHAIN=nightly-2024-03-22
       - name: Test-compile the crate
         run: cargo check --all-features
 
@@ -84,7 +84,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2023-12-28
+          toolchain: nightly-2024-03-22
           components: rust-src,rustfmt
       - name: Install AVR gcc, binutils, and libc
         run: sudo apt-get install -y avr-libc binutils-avr gcc-avr

--- a/examples/atmega328p/Cargo.toml
+++ b/examples/atmega328p/Cargo.toml
@@ -24,6 +24,12 @@ version = "0.5.3"
 # path = "../.."
 features = ["atmega328p", "rt"]
 
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"
+
 # Configure the build for minimal size - AVRs have very little program memory
 [profile.dev]
 panic = "abort"

--- a/examples/atmega328p/rust-toolchain.toml
+++ b/examples/atmega328p/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-12-28"
+channel = "nightly-2024-03-22"
 components = ["rust-src"]
 profile = "minimal"


### PR DESCRIPTION
Use the same version that is now used by avr-hal.