### PR TITLE
Use locked svd2rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,25 +34,16 @@ jobs:
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: rust-tools-005
+          key: rust-tools-006
       - name: Install svd2rust
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        uses: actions-rs/install@v0.1
-        with:
-          crate: svd2rust
-          version: 0.28.0
+        run: cargo install svd2rust --version 0.28.0 --locked
       - name: Install cargo-form
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        uses: actions-rs/install@v0.1
-        with:
-          crate: form
-          version: 0.8.0
+        run: cargo install form --version 0.8.0 --locked
       - name: Install atdf2svd
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        uses: actions-rs/install@v0.1
-        with:
-          crate: atdf2svd
-          version: 0.4.0
+        run: cargo install atdf2svd --version 0.4.0 --locked
       - name: Copy tools to cache directory
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ The version on `crates.io` is pre-built.  The following is only necessary when t
 
 You need to have [atdf2svd][] (= 0.4.0), [svd2rust][] (= 0.28), [form][] (>= 0.8), [rustfmt][](for the *nightly* toolchain) and [svdtools][] (>= 0.1.9) installed:
 ```bash
-cargo install atdf2svd --version 0.4.0
-cargo install svd2rust --version 0.28.0
+cargo install atdf2svd --version 0.4.0 --locked
+cargo install svd2rust --version 0.28.0 --locked
 cargo install form
 rustup component add --toolchain nightly rustfmt
 pip3 install --user svdtools


### PR DESCRIPTION
Due to a [regression caused by proc-macro2][1], we have to use a locked version of svd2rust to successfully build the code in this crate.

[1]: rust-embedded/svd2rust#863