### PR TITLE
Refactored attiny-xmega patch files

### DIFF
--- a/patch/attiny202.yaml
+++ b/patch/attiny202.yaml
@@ -1,4 +1,5 @@
 _svd: ../svd/attiny202.svd
 
 _include:
-  - common/attiny-0-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/0-series.yaml

--- a/patch/attiny212.yaml
+++ b/patch/attiny212.yaml
@@ -1,5 +1,5 @@
 _svd: ../svd/attiny212.svd
 
 _include:
-  - common/attiny-0-series.yaml
-  - common/attiny-1-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/1-series.yaml

--- a/patch/attiny214.yaml
+++ b/patch/attiny214.yaml
@@ -1,5 +1,5 @@
 _svd: ../svd/attiny214.svd
 
 _include:
-  - common/attiny-0-series.yaml
-  - common/attiny-1-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/1-series.yaml

--- a/patch/attiny402.yaml
+++ b/patch/attiny402.yaml
@@ -1,4 +1,5 @@
 _svd: ../svd/attiny402.svd
 
 _include:
-  - common/attiny-0-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/0-series.yaml

--- a/patch/attiny404.yaml
+++ b/patch/attiny404.yaml
@@ -1,4 +1,5 @@
 _svd: ../svd/attiny404.svd
 
 _include:
-  - common/attiny-0-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/0-series.yaml

--- a/patch/attiny412.yaml
+++ b/patch/attiny412.yaml
@@ -1,5 +1,5 @@
 _svd: ../svd/attiny412.svd
 
 _include:
-  - common/attiny-0-series.yaml
-  - common/attiny-1-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/1-series.yaml

--- a/patch/attiny414.yaml
+++ b/patch/attiny414.yaml
@@ -1,5 +1,5 @@
 _svd: ../svd/attiny414.svd
 
 _include:
-  - common/attiny-0-series.yaml
-  - common/attiny-1-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/1-series.yaml

--- a/patch/attiny416.yaml
+++ b/patch/attiny416.yaml
@@ -1,5 +1,5 @@
 _svd: ../svd/attiny416.svd
 
 _include:
-  - common/attiny-0-series.yaml
-  - common/attiny-1-series.yaml
+  - common/attiny-xmega/common.yaml
+  - common/attiny-xmega/1-series.yaml

--- a/patch/common/attiny-xmega/0-series.yaml
+++ b/patch/common/attiny-xmega/0-series.yaml
@@ -1,0 +1,4 @@
+# Nothing needed beyond common config
+# This is probably good for at least ATtiny202/204/402/404/406, but may not be valid for ATtiny80* and ATtiny160*
+
+{}

--- a/patch/common/attiny-xmega/1-series.yaml
+++ b/patch/common/attiny-xmega/1-series.yaml
@@ -1,0 +1,4 @@
+# Nothing needed beyond common config
+# This is probably good for at least ATtiny212/214/412/414/416, but may not be valid for ATtiny81* and ATtiny161*
+
+{}

--- a/patch/common/attiny-xmega/common.yaml
+++ b/patch/common/attiny-xmega/common.yaml
@@ -1,5 +1,5 @@
-# This is probably good for at least ATtiny202/204/402/404/406, but may not be valid for ATtiny80* and ATtiny160*
-# This is also good for ATtiny212/214/412/414/416, but may not be valid for ATtiny81* and ATtiny161*
+# This is probably good for ATtiny20x, ATtiny40x, ATtiny21x, ATtiny41x
+# It may not be enough for Attiny8xx, ATtiny16xx, or ATtinyx2x
 
 TCB0:
   CTRLB:


### PR DESCRIPTION
A light refactor of the patch files. Since the ATtiny xmega series have a lot in common, it makes more sense to structure their patch files as "common + 0 series" or "common + 1 series" than "0 series" or "0 series + 1 series"