### PR TITLE
remove form dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,10 @@ jobs:
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: rust-tools-20250106-001
+          key: rust-tools-20250112-001
       - name: Install svd2rust
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: cargo install svd2rust --version 0.28.0 --locked
-      - name: Install cargo-form
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: cargo install form --version 0.8.0 --locked
       - name: Install atdf2svd
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: cargo install atdf2svd --version 0.5.0 --locked
@@ -44,7 +41,6 @@ jobs:
         run: |
           mkdir ~/cargo-bin
           cp ~/.cargo/bin/svd2rust ~/cargo-bin
-          cp ~/.cargo/bin/form ~/cargo-bin
           cp ~/.cargo/bin/atdf2svd ~/cargo-bin
           cp ~/.cargo/bin/svdtools ~/cargo-bin
       - name: Put new cargo binary directory into path

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 
 svd/
 .deps/
-src/devices/*/*
+src/devices/*.rs
+!src/devices/mod.rs
 src/generic.rs
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ chips: $(CHIPS)
 deps: $(DEPS)
 vector: macros/src/vector.rs
 
-$(foreach chip, $(CHIPS), $(eval $(chip): src/devices/$(chip)/mod.rs))
+$(foreach chip, $(CHIPS), $(eval $(chip): src/devices/$(chip).rs))
 
 .SECONDARY:
 svd/%.svd: vendor/%.atdf
@@ -30,21 +30,14 @@ svd/%.svd.patched: svd/%.svd .deps/%.d patch/%.yaml
 		cp $< $@; \
 	fi
 
-src/devices/%/mod.full.rs: svd/%.svd.patched
-	@mkdir -p $(@D)
+src/devices/%.rs: svd/%.svd.patched
+	@mkdir -p $(@D)/$*
 	@echo -e "\tSVD2RUST\t$*"
-	@cd $(@D); svd2rust --generic_mod --make_mod --target none -i $(realpath $<)
-	@mv $(@D)/mod.rs $@
-	@mv $(@D)/generic.rs $(@D)/../../generic.rs
-
-src/devices/%/mod.rs: src/devices/%/mod.full.rs
-	@echo -e "\tFORM\t\t$*"
-	@RUST_LOG=WARN form -i $< -o $(@D) >/dev/null
-	@rm $<
-	@mv $(@D)/lib.rs $@
+	@cd $(@D)/$*; svd2rust --generic_mod --make_mod --target none -i $(realpath $<)
+	@mv $(@D)/$*/mod.rs $@
+	@mv $(@D)/$*/generic.rs $(@D)/../generic.rs
+	@rmdir $(@D)/$*
 	@RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustfmt $@
-	@# Remove the `extern crate` lines
-	@sed -i'' -e "/^extern crate/d" $@
 	@# Remove DEVICE_PERIPHERALS declaration and replace it with a reference
 	@# to the global version
 	@patch --no-backup-if-mismatch --quiet $@ patch/modrs.patch

--- a/README.md
+++ b/README.md
@@ -40,18 +40,16 @@ Via the feature you can select which chip you want the register specifications f
 ## Build Instructions
 The version on `crates.io` is pre-built.  The following is only necessary when trying to build this crate from source.
 
-You need to have [atdf2svd][] (= 0.5.0), [svd2rust][] (= 0.28), [form][] (>= 0.8), [rustfmt][](for the *nightly* toolchain) and [svdtools][] (= 0.4.0) installed:
+You need to have [atdf2svd][] (= 0.5.0), [svd2rust][] (= 0.28), [rustfmt][](for the *nightly* toolchain) and [svdtools][] (= 0.4.0) installed:
 ```bash
 cargo install atdf2svd --version 0.5.0 --locked
 cargo install svd2rust --version 0.28.0 --locked
-cargo install form
 rustup component add --toolchain nightly rustfmt
 cargo install svdtools --version 0.4.0 --locked
 ```
 
 [atdf2svd]: https://github.com/Rahix/atdf2svd
 [svd2rust]: https://github.com/rust-embedded/svd2rust
-[form]: https://github.com/djmcgill/form
 [rustfmt]: https://github.com/rust-lang/rustfmt
 [svdtools]: https://github.com/stm32-rs/svdtools
 


### PR DESCRIPTION
This is another stepping stone toward #157. I did not see any difference in build time on my machine when running `cargo check --all-features`.

It probably needs the same CI changes to build the example as #176, but I didn't want to duplicate them here.  This change can be rebased once that one lands.