### PR TITLE
build: Update error messages

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -195,7 +195,13 @@ impl InputFinder {
             }
         }
 
-        cargo_directives.push(format!("cargo::rerun-if-changed={}", path.display()));
+        cargo_directives.push(format!(
+            "cargo::rerun-if-changed={}",
+            path.to_str().ok_or(anyhow::anyhow!(
+                "file with non UTF-8 name in `{}`",
+                path.display()
+            ))?
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
Change the context messages for errors so they are more in line with the way `anyhow` intends context messages to be used.  This means the message will read properly top-down and users will hopefully be less confused when trying to understand what went wrong.

Cc: @LuigiPiucco 