### PR TITLE
Upgrade rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Nightly Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-03-03
+          toolchain: nightly-2025-04-27
           components: rustfmt,rust-src
 
       # Actual test run
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-03-03
+          toolchain: nightly-2025-04-27
           rustflags: ""
           components: rust-src,rustfmt
       - name: Install AVR gcc, binutils, and libc

--- a/examples/atmega328p/rust-toolchain.toml
+++ b/examples/atmega328p/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-03-03"
+channel = "nightly-2025-04-27"
 components = ["rust-src"]
 profile = "minimal"


### PR DESCRIPTION
See [1] for details.

Some floating point intrinsics were added in this newer version which helps on systems where these intrinsics are not provided by avr-gcc.

[1]: https://github.com/Rahix/avr-hal/pull/651