### PR TITLE
build: Apply atdf2svd port_rename_snake_case patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ optional = true
 [build-dependencies]
 svd2rust = "=0.36.1"
 svdtools = "=0.4.6"
-atdf2svd = "=0.5.0"
+atdf2svd = { git = "https://github.com/Rahix/atdf2svd", rev = "1073549b2315ba28748af7bac3301c54db8e1d49" }
 prettyplease = "=0.2.32"
 svd-rs = "=0.14.12"
 yaml-rust2 = "=0.10.1"

--- a/build.rs
+++ b/build.rs
@@ -109,10 +109,15 @@ impl InputFinder {
                 continue;
             }
 
+            // Apply the port_rename_snake_case patch so svd2rust generates port names like
+            // `PortA`, `PortB` instead of `Porta`, `Portb`.
+            let atdf2svd_patches =
+                HashSet::from_iter(["port_rename_snake_case"].iter().map(ToString::to_string));
+
             let atdf_file = File::open(&atdf_path)
                 .map_err(io_error_in_path(&atdf_path))
                 .context("could not open ATDF file")?;
-            let atdf = atdf2svd::atdf::parse(atdf_file, &mut HashSet::new())
+            let atdf = atdf2svd::atdf::parse(atdf_file, &atdf2svd_patches)
                 .map_err(atdf_error(&atdf_path))?;
             let patch_path = patches_dir.join(&mcu_name).with_extension("yaml");
             let patch = if patch_path


### PR DESCRIPTION
Now that new svd2rust has started renaming peripherals to CamelCase automatically, port names have become really ugly. They are now called `Porta`, `Portb`, `Portc`, etc. It would be preferential, to call them `PortA`, `PortB`, `PortC`.

Implement this by enabling the `port_rename_snake_case` patch from atdf2svd [^1].

[^1]: Rahix/atdf2svd#80

Fixes #193.

Cc: @LuigiPiucco 