### PR TITLE
Enable critical-section by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,9 @@ avr64du32 = ["device-selected"]
 avr64du28 = ["device-selected"]
 rt = ["avr-device-macros"]
 
-critical-section-impl = ["critical-section/restore-state-u8"]
+critical-section = ["critical-section/restore-state-u8"]
+
+default = ["critical-section"]
 
 # Unfortunately, we can only build documentation for a subset of the supported
 # MCUs on docs.rs.  If you think a very popular chip is missing from the list,

--- a/examples/atmega328p/Cargo.toml
+++ b/examples/atmega328p/Cargo.toml
@@ -20,7 +20,7 @@ embedded-hal = "0.2.3"
 [dependencies.avr-device]
 version = "0.7"
 path = "../.."
-features = ["atmega328p", "rt", "critical-section-impl"]
+features = ["atmega328p", "rt"]
 
 # Configure the build for minimal size - AVRs have very little program memory
 [profile.dev]

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -235,7 +235,7 @@ where
     }
 }
 
-#[cfg(feature = "critical-section-impl")]
+#[cfg(feature = "critical-section")]
 mod cs {
     use critical_section::RawRestoreState;
 


### PR DESCRIPTION
The new svd2rust code needs `critical-section` for implementing the `Peripherals::take()` function.  This means almost all uses of `avr-device` will need it as well.

Rename the `critical-section-impl` feature to just `critical-section` and make it a part of the crate's default features.

Cc: @LuigiPiucco @tones111 
Ref: #157