### PR TITLE
Drop unused vcell dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ docsrs = ["rt", "ufmt", "atmega328p", "atmega32u4", "atmega2560", "attiny85", "a
 
 [dependencies]
 bare-metal = "1.0.0"
-vcell = "0.1.2"
 cfg-if = "1.0.0"
 ufmt = { version = "0.2.0", optional = true }
 critical-section = { version = "1.1.1", optional = true }


### PR DESCRIPTION
Since the very first commit of this project, we have strung along the `vcell` dependency without ever using it.  Time to get rid of it...