### PR TITLE
Disable atdf2svd CLI dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ optional = true
 [build-dependencies]
 svd2rust = "=0.36.1"
 svdtools = "=0.4.6"
-atdf2svd = "=0.5.0"
+atdf2svd = "=0.5.1"
 prettyplease = "=0.2.32"
 svd-rs = "=0.14.12"
 yaml-rust2 = "=0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ optional = true
 [build-dependencies]
 svd2rust = "=0.36.1"
 svdtools = "=0.4.6"
-atdf2svd = "=0.5.1"
+atdf2svd = { version = "=0.5.1", default-features = false }
 prettyplease = "=0.2.32"
 svd-rs = "=0.14.12"
 yaml-rust2 = "=0.10.1"


### PR DESCRIPTION
Disable default features of atdf2svd to disable the `cli` feature which pulls in all the dependencies for the CLI of the tool.  This helps with reducing the amount of dependencies we carry at build-time.

Link: https://github.com/Rahix/atdf2svd/pull/81