### PR TITLE
Add nop functions to burn more than one cycle

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -3,12 +3,116 @@
 #[cfg(target_arch = "avr")]
 use core::arch::asm;
 
-/// No Operation
+/// No Operation - Burn one CPU cycle
+///
+/// This emits exactly one NOP instruction and therefore burns at least one CPU cycle at runtime.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
 #[inline(always)]
 pub fn nop() {
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "avr")] {
-            unsafe { asm!("nop") }
+            unsafe {
+                asm!(
+                    "nop",
+                    options(preserves_flags)
+                )
+            }
+        } else {
+            unimplemented!()
+        }
+    }
+}
+
+/// No Operation - Burn two CPU cycles
+///
+/// This emits a minimum amount of instructions to burn at least two CPU cycles at runtime.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
+#[inline(always)]
+pub fn nop2() {
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe {
+                asm!(
+                    "rjmp 1f",
+                    "1:",
+                    options(preserves_flags)
+                )
+            }
+        } else {
+            unimplemented!()
+        }
+    }
+}
+
+/// No Operation - Burn three CPU cycles
+///
+/// This emits a minimum amount of instructions to burn at least three CPU cycles at runtime.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
+#[inline(always)]
+pub fn nop3() {
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe {
+                asm!(
+                    "rjmp 1f",
+                    "1: nop",
+                    options(preserves_flags)
+                )
+            }
+        } else {
+            unimplemented!()
+        }
+    }
+}
+
+/// No Operation - Burn four CPU cycles
+///
+/// This emits a minimum amount of instructions to burn at least four CPU cycles at runtime.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
+#[inline(always)]
+pub fn nop4() {
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe {
+                asm!(
+                    "rjmp 1f",
+                    "1: rjmp 2f",
+                    "2:",
+                    options(preserves_flags)
+                )
+            }
+        } else {
+            unimplemented!()
+        }
+    }
+}
+
+/// No Operation - Burn five CPU cycles
+///
+/// This emits a minimum amount of instructions to burn at least five CPU cycles at runtime.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
+#[inline(always)]
+pub fn nop5() {
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "avr")] {
+            unsafe {
+                asm!(
+                    "rjmp 1f",
+                    "1: rjmp 2f",
+                    "2: nop",
+                    options(preserves_flags)
+                )
+            }
         } else {
             unimplemented!()
         }
@@ -16,11 +120,21 @@ pub fn nop() {
 }
 
 /// Sleep / Wait For Interrupt
+///
+/// Emit a SLEEP instruction.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
 #[inline(always)]
 pub fn sleep() {
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "avr")] {
-            unsafe { asm!("sleep") }
+            unsafe {
+                asm!(
+                    "sleep",
+                    options(preserves_flags)
+                )
+            }
         } else {
             unimplemented!()
         }
@@ -28,11 +142,21 @@ pub fn sleep() {
 }
 
 /// Watchdog Reset
+///
+/// Emit a WDR instruction.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
 #[inline(always)]
 pub fn wdr() {
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "avr")] {
-            unsafe { asm!("wdr") }
+            unsafe {
+                asm!(
+                    "wdr",
+                    options(preserves_flags)
+                )
+            }
         } else {
             unimplemented!()
         }
@@ -99,6 +223,9 @@ pub fn get_stack_size() -> usize {
 /// - The real-time delay depends on the CPU clock frequency. If you want to
 ///   conveniently specify a delay value in real-time units like microseconds,
 ///   then use the `delay` module in the HAL crate for your platform.
+///
+/// This function is an optimization fence.
+/// That means memory accesses will not be re-ordered by the compiler across this function call.
 #[inline(always)]
 pub fn delay_cycles(cycles: u32) {
     cfg_if::cfg_if! {


### PR DESCRIPTION
This PR adds a couple of more nop-like functions that burn more than one cycle.

The advantage of using these functions instead of using `delay_cycles` is that it's much more precise for a low amount of cycles.

The use case is that it's sometimes needed to sleep an extremely small amount of time. For example when bit banging fast busses or similar.
In such situations it's often not really suitable to delay a cycle more than necessary. For example if these situations happen many times in a row and therefore errors accumulate.

The same behavior could be achieved by calling the original nop() more than once in a row.
But the disadvantage is that this wastes more program memory space than necessary.

It's up to the user to protect this with IRQ-disable to avoid waiting more than necessary.

The nop functions are provided up to 5. From then on it starts to make sense to use `delay_cycles` instead.
Also these nop functions could be chained.

This PR also adds `options(preserves_flags)` to all asm blocks in this file. I think this makes sense as it doesn't change the memory or ordering behavior and avoids possibly unnecessary recomputations of flags.