### PR TITLE
Remove wrong patch on atmega4809

### DIFF
--- a/patch/atmega4809.yaml
+++ b/patch/atmega4809.yaml
@@ -1,2 +1,0 @@
-_include:
-  - "common/mega0/port.yaml"


### PR DESCRIPTION
It seems that the patch has been included to atmega4809 in bulk with other mcu.

The mega0 patch removes 4 pins in PORTC, however the atmega4809 has 8 pins in PORTC that are all documeted in the datasheet, that work, and that are correctly described in `vendor/atmega4809.atdf `. Moreover, other parts of the patch do not change the atdf.

So it is reasonable to just drop the patch (and it works for me :)

See https://ww1.microchip.com/downloads/en/DeviceDoc/ATmega4808-4809-Data-Sheet-DS40002173A.pdf for datasheet