### PR TITLE
build: allow symlinks in required path validation (rules_rust compatibility)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -154,11 +154,6 @@ impl InputFinder {
                 "required path `{}` is missing",
                 path.display()
             ));
-        } else if path.is_symlink() {
-            return Err(anyhow::anyhow!(
-                "required path `{}` being a symlink is invalid",
-                path.display()
-            ));
         }
 
         if path.is_dir() {


### PR DESCRIPTION
Bazel's [rules_rust](https://github.com/bazelbuild/rules_rust) can fetch Cargo packages as dependencies, but in order to provide hermetic and reproducible builds, it creates symlinks for source files in sandboxed builds. The previous check in build.rs rejected these, causing builds to fail when using this crate with Bazel.

This change removes the symlink restriction so that symlinked paths are treated the same as regular files/dirs, enabling avr-device to work as a dependency in Bazel Rust repositories.
