### PR TITLE
[FEAT]: add avr128db32 device support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ attiny3217 = ["device-selected"]
 avr64du32 = ["device-selected"]
 avr64du28 = ["device-selected"]
 avr128db28 = ["device-selected"]
+avr128db32 = ["device-selected"]
 avr128db48 = ["device-selected"]
 rt = ["avr-device-macros"]
 

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -411,6 +411,12 @@ pub mod avr128db28 {
     include!(concat!(env!("OUT_DIR"), "/pac/avr128db28.rs"));
 }
 
+/// [AVR128DB32](https://www.microchip.com/wwwproducts/en/AVR128DB32)
+#[cfg(feature = "avr128db32")]
+pub mod avr128db32 {
+    include!(concat!(env!("OUT_DIR"), "/pac/avr128db32.rs"));
+}
+
 /// [AVR128DB48](https://www.microchip.com/wwwproducts/en/AVR128DB48)
 #[cfg(feature = "avr128db48")]
 pub mod avr128db48 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 #![cfg_attr(feature = "avr64du32", doc = "**avr64du32**,")]
 #![cfg_attr(feature = "avr64du28", doc = "**avr64du28**,")]
 #![cfg_attr(feature = "avr128db28", doc = "**avr128db28**,")]
+#![cfg_attr(feature = "avr128db32", doc = "**avr128db32**,")]
 #![cfg_attr(feature = "avr128db48", doc = "**avr128db48**,")]
 //! and a few things which apply to AVR microcontrollers generally.
 //!
@@ -143,6 +144,7 @@
 //! `avr64du32`,
 //! `avr64du28`,
 //! `avr128db28`,
+//! `avr128db32`,
 //! `avr128db48`,
 //!
 //! # How to use this crate?
@@ -332,6 +334,7 @@ compile_error!(
     * avr64du32
     * avr64du28
     * avr128db28
+    * avr128db32
     * avr128db48
     "
 );
@@ -477,5 +480,7 @@ pub use crate::devices::avr64du28;
 pub use crate::devices::avr64du32;
 #[cfg(feature = "avr128db28")]
 pub use crate::devices::avr128db28;
+#[cfg(feature = "avr128db32")]
+pub use crate::devices::avr128db32;
 #[cfg(feature = "avr128db48")]
 pub use crate::devices::avr128db48;

--- a/vendor/avr128db32.atdf
+++ b/vendor/avr128db32.atdf
@@ -1,0 +1,7605 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<avr-tools-device-file xmlns:NumHelper="NumHelper"
+                       xmlns:xalan="http://xml.apache.org/xalan"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       schema-version="4.5"
+                       xsi:noNamespaceSchemaLocation="schema/atdf.xsd">
+   <variants>
+      <variant ordercode="AVR128DB32-VQFN/TQFP"
+               package="QFP32"
+               pinout="QFP32"
+               speedmax="32000000"
+               tempmax="125"
+               tempmin="-40"
+               vccmax="5.5"
+               vccmin="1.8"/>
+   </variants>
+   <devices>
+      <device architecture="AVR8X" family="AVR" name="AVR128DB32">
+         <address-spaces>
+            <address-space endianness="little"
+                           id="data"
+                           name="data"
+                           size="0x10000"
+                           start="0x0000">
+               <memory-segment exec="0"
+                               name="IO"
+                               rw="RW"
+                               size="0x103F"
+                               start="0x00"
+                               type="io"/>
+               <memory-segment exec="0"
+                               name="LOCKBITS"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x04"
+                               start="0x1040"
+                               type="lockbits"/>
+               <memory-segment exec="0"
+                               name="FUSES"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x10"
+                               start="0x1050"
+                               type="fuses"/>
+               <memory-segment exec="0"
+                               name="USER_SIGNATURES"
+                               pagesize="0x20"
+                               rw="RW"
+                               size="0x20"
+                               start="0x1080"
+                               type="user_signatures"/>
+               <memory-segment exec="0"
+                               name="SIGNATURES"
+                               pagesize="0x80"
+                               rw="R"
+                               size="0x03"
+                               start="0x1100"
+                               type="signatures"/>
+               <memory-segment exec="0"
+                               name="PROD_SIGNATURES"
+                               pagesize="0x80"
+                               rw="R"
+                               size="0x7D"
+                               start="0x1103"
+                               type="signatures"/>
+               <memory-segment exec="0"
+                               name="EEPROM"
+                               pagesize="0x1"
+                               rw="RW"
+                               size="0x200"
+                               start="0x1400"
+                               type="eeprom"/>
+               <memory-segment exec="0"
+                               name="INTERNAL_SRAM"
+                               rw="RW"
+                               size="0x4000"
+                               start="0x4000"
+                               type="ram"/>
+               <memory-segment exec="0"
+                               name="MAPPED_PROGMEM"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x8000"
+                               start="0x8000"
+                               type="other"/>
+            </address-space>
+            <address-space endianness="little"
+                           id="prog"
+                           name="prog"
+                           size="0x20000"
+                           start="0x0000">
+               <memory-segment exec="1"
+                               name="PROGMEM"
+                               pagesize="0x200"
+                               rw="RW"
+                               size="0x20000"
+                               start="0x00"
+                               type="flash"/>
+            </address-space>
+         </address-spaces>
+         <peripherals>
+            <module id="cmp_control_v8" name="AC">
+               <instance name="AC0">
+                  <register-group address-space="data"
+                                  name="AC0"
+                                  name-in-module="AC"
+                                  offset="0x0680"/>
+                  <signals>
+                     <signal field="AC0.MUXCTRL.MUXNEG"
+                             function="AINN0"
+                             group="AINN"
+                             pad="PD3"/>
+                     <signal field="AC0.MUXCTRL.MUXNEG"
+                             function="AINN2"
+                             group="AINN"
+                             pad="PD7"/>
+                     <signal field="AC0.MUXCTRL.MUXPOS"
+                             function="AINP0"
+                             group="AINP"
+                             pad="PD2"/>
+                     <signal field="AC0.MUXCTRL.MUXPOS"
+                             function="AINP3"
+                             group="AINP"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.ACROUTEA.AC0"
+                             function="DEFAULT"
+                             group="OUT"
+                             pad="PA7"/>
+                  </signals>
+               </instance>
+               <instance name="AC1">
+                  <register-group address-space="data"
+                                  name="AC1"
+                                  name-in-module="AC"
+                                  offset="0x0688"/>
+                  <signals>
+                     <signal field="AC1.MUXCTRL.MUXNEG"
+                             function="AINN0"
+                             group="AINN"
+                             pad="PD5"/>
+                     <signal field="AC1.MUXCTRL.MUXNEG"
+                             function="AINN2"
+                             group="AINN"
+                             pad="PD7"/>
+                     <signal field="AC1.MUXCTRL.MUXPOS"
+                             function="AINP0"
+                             group="AINP"
+                             pad="PD2"/>
+                     <signal field="AC1.MUXCTRL.MUXPOS"
+                             function="AINP1"
+                             group="AINP"
+                             pad="PD3"/>
+                     <signal field="AC1.MUXCTRL.MUXPOS"
+                             function="AINP2"
+                             group="AINP"
+                             pad="PD4"/>
+                     <signal field="AC1.MUXCTRL.MUXPOS"
+                             function="AINP3"
+                             group="AINP"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.ACROUTEA.AC1"
+                             function="DEFAULT"
+                             group="OUT"
+                             pad="PA7"/>
+                  </signals>
+               </instance>
+               <instance name="AC2">
+                  <register-group address-space="data"
+                                  name="AC2"
+                                  name-in-module="AC"
+                                  offset="0x0690"/>
+                  <signals>
+                     <signal field="AC2.MUXCTRL.MUXNEG"
+                             function="AINN0"
+                             group="AINN"
+                             pad="PD7"/>
+                     <signal field="AC2.MUXCTRL.MUXNEG"
+                             function="AINN2"
+                             group="AINN"
+                             pad="PD7"/>
+                     <signal field="AC2.MUXCTRL.MUXPOS"
+                             function="AINP0"
+                             group="AINP"
+                             pad="PD2"/>
+                     <signal field="AC2.MUXCTRL.MUXPOS"
+                             function="AINP1"
+                             group="AINP"
+                             pad="PD4"/>
+                     <signal field="AC2.MUXCTRL.MUXPOS"
+                             function="AINP3"
+                             group="AINP"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.ACROUTEA.AC2"
+                             function="DEFAULT"
+                             group="OUT"
+                             pad="PA7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="adc_12b_diff_ctrl_v1" name="ADC">
+               <instance name="ADC0">
+                  <register-group address-space="data"
+                                  name="ADC0"
+                                  name-in-module="ADC"
+                                  offset="0x0600"/>
+                  <signals>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN1"
+                             group="AINN"
+                             pad="PD1"/>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN2"
+                             group="AINN"
+                             pad="PD2"/>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN3"
+                             group="AINN"
+                             pad="PD3"/>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN4"
+                             group="AINN"
+                             pad="PD4"/>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN5"
+                             group="AINN"
+                             pad="PD5"/>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN6"
+                             group="AINN"
+                             pad="PD6"/>
+                     <signal field="ADC0.MUXNEG.MUXNEG"
+                             function="AIN7"
+                             group="AINN"
+                             pad="PD7"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN1"
+                             group="AINP"
+                             pad="PD1"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN2"
+                             group="AINP"
+                             pad="PD2"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN3"
+                             group="AINP"
+                             pad="PD3"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN4"
+                             group="AINP"
+                             pad="PD4"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN5"
+                             group="AINP"
+                             pad="PD5"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN6"
+                             group="AINP"
+                             pad="PD6"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN7"
+                             group="AINP"
+                             pad="PD7"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN16"
+                             group="AINP"
+                             pad="PF0"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN17"
+                             group="AINP"
+                             pad="PF1"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN18"
+                             group="AINP"
+                             pad="PF2"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN19"
+                             group="AINP"
+                             pad="PF3"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN20"
+                             group="AINP"
+                             pad="PF4"/>
+                     <signal field="ADC0.MUXPOS.MUXPOS"
+                             function="AIN21"
+                             group="AINP"
+                             pad="PF5"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="bor_lvd_ctrl_v1" name="BOD">
+               <instance name="BOD">
+                  <register-group address-space="data"
+                                  name="BOD"
+                                  name-in-module="BOD"
+                                  offset="0x00A0"/>
+               </instance>
+            </module>
+            <module id="cla_ccl_v1" name="CCL">
+               <instance name="CCL">
+                  <register-group address-space="data"
+                                  name="CCL"
+                                  name-in-module="CCL"
+                                  offset="0x01C0"/>
+                  <signals>
+                     <signal field="CCL.LUT0CTRLB.INSEL0"
+                             function="IN0"
+                             group="LUT0_IN0"
+                             pad="PA0"/>
+                     <signal field="CCL.LUT0CTRLB.INSEL1"
+                             function="IN1"
+                             group="LUT0_IN1"
+                             pad="PA1"/>
+                     <signal field="CCL.LUT0CTRLC.INSEL2"
+                             function="IN2"
+                             group="LUT0_IN2"
+                             pad="PA2"/>
+                     <signal field="CCL.LUT1CTRLB.INSEL0"
+                             function="IN0"
+                             group="LUT1_IN0"
+                             pad="PC0"/>
+                     <signal field="CCL.LUT1CTRLB.INSEL1"
+                             function="IN1"
+                             group="LUT1_IN1"
+                             pad="PC1"/>
+                     <signal field="CCL.LUT1CTRLC.INSEL2"
+                             function="IN2"
+                             group="LUT1_IN2"
+                             pad="PC2"/>
+                     <signal field="CCL.LUT2CTRLB.INSEL1"
+                             function="IN1"
+                             group="LUT2_IN1"
+                             pad="PD1"/>
+                     <signal field="CCL.LUT2CTRLC.INSEL2"
+                             function="IN2"
+                             group="LUT2_IN2"
+                             pad="PD2"/>
+                     <signal field="CCL.LUT3CTRLB.INSEL0"
+                             function="IN0"
+                             group="LUT3_IN0"
+                             pad="PF0"/>
+                     <signal field="CCL.LUT3CTRLB.INSEL1"
+                             function="IN1"
+                             group="LUT3_IN1"
+                             pad="PF1"/>
+                     <signal field="CCL.LUT3CTRLC.INSEL2"
+                             function="IN2"
+                             group="LUT3_IN2"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="ALT1"
+                             group="LUT0_OUT"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT0"
+                             function="DEFAULT"
+                             group="LUT0_OUT"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT1"
+                             function="DEFAULT"
+                             group="LUT1_OUT"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="ALT1"
+                             group="LUT2_OUT"
+                             pad="PD6"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT2"
+                             function="DEFAULT"
+                             group="LUT2_OUT"
+                             pad="PD3"/>
+                     <signal field="PORTMUX.CCLROUTEA.LUT3"
+                             function="DEFAULT"
+                             group="LUT3_OUT"
+                             pad="PF3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdb" name="CLKCTRL">
+               <instance name="CLKCTRL">
+                  <register-group address-space="data"
+                                  name="CLKCTRL"
+                                  name-in-module="CLKCTRL"
+                                  offset="0x0060"/>
+                  <signals>
+                     <signal function="DEFAULT" group="CLKOUT" pad="PA7"/>
+                     <signal function="DEFAULT" group="EXTCLK" pad="PA0"/>
+                     <signal function="DEFAULT" group="XTAL32K1" pad="PF0"/>
+                     <signal function="DEFAULT" group="XTAL32K2" pad="PF1"/>
+                     <signal function="DEFAULT" group="XTALHF1" pad="PA0"/>
+                     <signal function="DEFAULT" group="XTALHF2" pad="PA1"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="cpu_avr_xt_v1" name="CPU">
+               <instance name="CPU">
+                  <register-group address-space="data"
+                                  name="CPU"
+                                  name-in-module="CPU"
+                                  offset="0x0030"/>
+                  <parameters>
+                     <param name="CORE_VERSION" value="V4S"/>
+                  </parameters>
+               </instance>
+            </module>
+            <module id="int_8bit_v3" name="CPUINT">
+               <instance name="CPUINT">
+                  <register-group address-space="data"
+                                  name="CPUINT"
+                                  name-in-module="CPUINT"
+                                  offset="0x0110"/>
+               </instance>
+            </module>
+            <module id="math_pdi_crc_v1" name="CRCSCAN">
+               <instance name="CRCSCAN">
+                  <register-group address-space="data"
+                                  name="CRCSCAN"
+                                  name-in-module="CRCSCAN"
+                                  offset="0x0120"/>
+               </instance>
+            </module>
+            <module id="dac_nbit_ctrl_v5" name="DAC">
+               <instance name="DAC0">
+                  <register-group address-space="data"
+                                  name="DAC0"
+                                  name-in-module="DAC"
+                                  offset="0x06A0"/>
+                  <signals>
+                     <signal function="DEFAULT" group="OUT" pad="PD6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdb" name="EVSYS">
+               <instance name="EVSYS">
+                  <register-group address-space="data"
+                                  name="EVSYS"
+                                  name-in-module="EVSYS"
+                                  offset="0x0200"/>
+                  <signals>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTA"
+                             function="ALT1"
+                             group="EVOUTA"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTA"
+                             function="DEFAULT"
+                             group="EVOUTA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTC"
+                             function="DEFAULT"
+                             group="EVOUTC"
+                             pad="PC2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTD"
+                             function="ALT1"
+                             group="EVOUTD"
+                             pad="PD7"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTD"
+                             function="DEFAULT"
+                             group="EVOUTD"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.EVSYSROUTEA.EVOUTF"
+                             function="DEFAULT"
+                             group="EVOUTF"
+                             pad="PF2"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdb" name="FUSE">
+               <instance name="FUSE">
+                  <register-group address-space="data"
+                                  name="FUSE"
+                                  name-in-module="FUSE"
+                                  offset="0x1050"/>
+               </instance>
+            </module>
+            <module id="avrdb" name="GPR">
+               <instance name="GPR">
+                  <register-group address-space="data"
+                                  name="GPR"
+                                  name-in-module="GPR"
+                                  offset="0x001C"/>
+               </instance>
+            </module>
+            <module id="avrdb" name="LOCK">
+               <instance name="LOCK">
+                  <register-group address-space="data"
+                                  name="LOCK"
+                                  name-in-module="LOCK"
+                                  offset="0x1040"/>
+               </instance>
+            </module>
+            <module id="io_multiv_ctrl_avr_v1" name="MVIO">
+               <instance name="MVIO">
+                  <register-group address-space="data"
+                                  name="MVIO"
+                                  name-in-module="MVIO"
+                                  offset="0x00C0"/>
+               </instance>
+            </module>
+            <module id="nvm_ctrl_avr_v1" name="NVMCTRL">
+               <instance name="NVMCTRL">
+                  <register-group address-space="data"
+                                  name="NVMCTRL"
+                                  name-in-module="NVMCTRL"
+                                  offset="0x1000"/>
+               </instance>
+            </module>
+            <module id="amp_opamp_ctrl_avr_v1" name="OPAMP">
+               <instance name="OPAMP">
+                  <register-group address-space="data"
+                                  name="OPAMP"
+                                  name-in-module="OPAMP"
+                                  offset="0x0700"/>
+                  <signals>
+                     <signal function="DEFAULT" group="OP0INN" pad="PD3"/>
+                     <signal function="DEFAULT" group="OP0INP" pad="PD1"/>
+                     <signal function="DEFAULT" group="OP0OUT" pad="PD2"/>
+                     <signal function="DEFAULT" group="OP1INN" pad="PD7"/>
+                     <signal function="DEFAULT" group="OP1INP" pad="PD4"/>
+                     <signal function="DEFAULT" group="OP1OUT" pad="PD5"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="gpio_ports_avr_v2_port" name="PORT">
+               <instance name="PORTA">
+                  <register-group address-space="data"
+                                  name="PORTA"
+                                  name-in-module="PORT"
+                                  offset="0x0400"/>
+                  <signals>
+                     <signal function="DEFAULT" group="PIN0" pad="PA0"/>
+                     <signal function="DEFAULT" group="PIN1" pad="PA1"/>
+                     <signal function="DEFAULT" group="PIN2" pad="PA2"/>
+                     <signal function="DEFAULT" group="PIN3" pad="PA3"/>
+                     <signal function="DEFAULT" group="PIN4" pad="PA4"/>
+                     <signal function="DEFAULT" group="PIN5" pad="PA5"/>
+                     <signal function="DEFAULT" group="PIN6" pad="PA6"/>
+                     <signal function="DEFAULT" group="PIN7" pad="PA7"/>
+                  </signals>
+               </instance>
+               <instance name="PORTC">
+                  <register-group address-space="data"
+                                  name="PORTC"
+                                  name-in-module="PORT"
+                                  offset="0x0440"/>
+                  <signals>
+                     <signal function="DEFAULT" group="PIN0" pad="PC0"/>
+                     <signal function="DEFAULT" group="PIN1" pad="PC1"/>
+                     <signal function="DEFAULT" group="PIN2" pad="PC2"/>
+                     <signal function="DEFAULT" group="PIN3" pad="PC3"/>
+                  </signals>
+               </instance>
+               <instance name="PORTD">
+                  <register-group address-space="data"
+                                  name="PORTD"
+                                  name-in-module="PORT"
+                                  offset="0x0460"/>
+                  <signals>
+                     <signal function="DEFAULT" group="PIN1" pad="PD1"/>
+                     <signal function="DEFAULT" group="PIN2" pad="PD2"/>
+                     <signal function="DEFAULT" group="PIN3" pad="PD3"/>
+                     <signal function="DEFAULT" group="PIN4" pad="PD4"/>
+                     <signal function="DEFAULT" group="PIN5" pad="PD5"/>
+                     <signal function="DEFAULT" group="PIN6" pad="PD6"/>
+                     <signal function="DEFAULT" group="PIN7" pad="PD7"/>
+                  </signals>
+               </instance>
+               <instance name="PORTF">
+                  <register-group address-space="data"
+                                  name="PORTF"
+                                  name-in-module="PORT"
+                                  offset="0x04A0"/>
+                  <signals>
+                     <signal function="DEFAULT" group="PIN0" pad="PF0"/>
+                     <signal function="DEFAULT" group="PIN1" pad="PF1"/>
+                     <signal function="DEFAULT" group="PIN2" pad="PF2"/>
+                     <signal function="DEFAULT" group="PIN3" pad="PF3"/>
+                     <signal function="DEFAULT" group="PIN4" pad="PF4"/>
+                     <signal function="DEFAULT" group="PIN5" pad="PF5"/>
+                     <signal function="DEFAULT" group="PIN6" pad="PF6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdb" name="PORTMUX">
+               <instance name="PORTMUX">
+                  <register-group address-space="data"
+                                  name="PORTMUX"
+                                  name-in-module="PORTMUX"
+                                  offset="0x05E0"/>
+               </instance>
+            </module>
+            <module id="rst_integration_v8" name="RSTCTRL">
+               <instance name="RSTCTRL">
+                  <register-group address-space="data"
+                                  name="RSTCTRL"
+                                  name-in-module="RSTCTRL"
+                                  offset="0x0040"/>
+                  <signals>
+                     <signal function="DEFAULT" group="RESET" pad="PF6"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_16b_rtc_v1" name="RTC">
+               <instance name="RTC">
+                  <register-group address-space="data"
+                                  name="RTC"
+                                  name-in-module="RTC"
+                                  offset="0x0140"/>
+               </instance>
+            </module>
+            <module id="avrdb" name="SIGROW">
+               <instance name="SIGROW">
+                  <register-group address-space="data"
+                                  name="SIGROW"
+                                  name-in-module="SIGROW"
+                                  offset="0x1100"/>
+               </instance>
+            </module>
+            <module id="clk_sleep_ctrl_avr_v2" name="SLPCTRL">
+               <instance name="SLPCTRL">
+                  <register-group address-space="data"
+                                  name="SLPCTRL"
+                                  name-in-module="SLPCTRL"
+                                  offset="0x0050"/>
+               </instance>
+            </module>
+            <module id="spi_8bit_v2" name="SPI">
+               <instance name="SPI0">
+                  <register-group address-space="data"
+                                  name="SPI0"
+                                  name-in-module="SPI"
+                                  offset="0x0940"/>
+                  <signals>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="DEFAULT"
+                             group="MISO"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="DEFAULT"
+                             group="MOSI"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="DEFAULT"
+                             group="SCK"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI0"
+                             function="DEFAULT"
+                             group="SS"
+                             pad="PA7"/>
+                  </signals>
+               </instance>
+               <instance name="SPI1">
+                  <register-group address-space="data"
+                                  name="SPI1"
+                                  name-in-module="SPI"
+                                  offset="0x0960"/>
+                  <signals>
+                     <signal field="PORTMUX.SPIROUTEA.SPI1"
+                             function="DEFAULT"
+                             group="MISO"
+                             pad="PC1"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI1"
+                             function="DEFAULT"
+                             group="MOSI"
+                             pad="PC0"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI1"
+                             function="DEFAULT"
+                             group="SCK"
+                             pad="PC2"/>
+                     <signal field="PORTMUX.SPIROUTEA.SPI1"
+                             function="DEFAULT"
+                             group="SS"
+                             pad="PC3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdb" name="SYSCFG">
+               <instance name="SYSCFG">
+                  <register-group address-space="data"
+                                  name="SYSCFG"
+                                  name-in-module="SYSCFG"
+                                  offset="0x0F00"/>
+               </instance>
+            </module>
+            <module id="tmr_16b_pwm_v1" name="TCA">
+               <instance name="TCA0">
+                  <register-group address-space="data"
+                                  name="TCA0"
+                                  name-in-module="TCA"
+                                  offset="0x0A00"/>
+                  <signals>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTA"
+                             group="WO0"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTA"
+                             group="WO1"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTA"
+                             group="WO2"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTA"
+                             group="WO3"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTA"
+                             group="WO4"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTA"
+                             group="WO5"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTC"
+                             group="WO0"
+                             pad="PC0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTC"
+                             group="WO1"
+                             pad="PC1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTC"
+                             group="WO2"
+                             pad="PC2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTC"
+                             group="WO3"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTD"
+                             group="WO1"
+                             pad="PD1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTD"
+                             group="WO2"
+                             pad="PD2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTD"
+                             group="WO3"
+                             pad="PD3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTD"
+                             group="WO4"
+                             pad="PD4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTD"
+                             group="WO5"
+                             pad="PD5"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTF"
+                             group="WO0"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTF"
+                             group="WO1"
+                             pad="PF1"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTF"
+                             group="WO2"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTF"
+                             group="WO3"
+                             pad="PF3"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTF"
+                             group="WO4"
+                             pad="PF4"/>
+                     <signal field="PORTMUX.TCAROUTEA.TCA0"
+                             function="PORTF"
+                             group="WO5"
+                             pad="PF5"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_16b_capture_v1" name="TCB">
+               <instance name="TCB0">
+                  <register-group address-space="data"
+                                  name="TCB0"
+                                  name-in-module="TCB"
+                                  offset="0x0B00"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB0"
+                             function="ALT1"
+                             group="WO"
+                             pad="PF4"/>
+                     <signal field="PORTMUX.TCBROUTEA.TCB0"
+                             function="DEFAULT"
+                             group="WO"
+                             pad="PA2"/>
+                  </signals>
+               </instance>
+               <instance name="TCB1">
+                  <register-group address-space="data"
+                                  name="TCB1"
+                                  name-in-module="TCB"
+                                  offset="0x0B10"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB1"
+                             function="ALT1"
+                             group="WO"
+                             pad="PF5"/>
+                     <signal field="PORTMUX.TCBROUTEA.TCB1"
+                             function="DEFAULT"
+                             group="WO"
+                             pad="PA3"/>
+                  </signals>
+               </instance>
+               <instance name="TCB2">
+                  <register-group address-space="data"
+                                  name="TCB2"
+                                  name-in-module="TCB"
+                                  offset="0x0B20"/>
+                  <signals>
+                     <signal field="PORTMUX.TCBROUTEA.TCB2"
+                             function="DEFAULT"
+                             group="WO"
+                             pad="PC0"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="tmr_12b_psc_v1" name="TCD">
+               <instance name="TCD0">
+                  <register-group address-space="data"
+                                  name="TCD0"
+                                  name-in-module="TCD"
+                                  offset="0x0B80"/>
+                  <signals>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="ALT2"
+                             group="WOA"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="ALT2"
+                             group="WOB"
+                             pad="PF1"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="ALT2"
+                             group="WOC"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="ALT2"
+                             group="WOD"
+                             pad="PF3"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="DEFAULT"
+                             group="WOA"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="DEFAULT"
+                             group="WOB"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="DEFAULT"
+                             group="WOC"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.TCDROUTEA.TCD0"
+                             function="DEFAULT"
+                             group="WOD"
+                             pad="PA7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="i2c_8bit_v2" name="TWI">
+               <instance name="TWI0">
+                  <register-group address-space="data"
+                                  name="TWI0"
+                                  name-in-module="TWI"
+                                  offset="0x0900"/>
+                  <signals>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="ALT1"
+                             group="SCL"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="ALT1"
+                             group="SDA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="ALT2"
+                             group="SCL"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="ALT2"
+                             group="SDA"
+                             pad="PC2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="DEFAULT"
+                             group="SCL"
+                             pad="PA3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="DEFAULT"
+                             group="SCL_DUAL"
+                             pad="PC3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="DEFAULT"
+                             group="SDA"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI0"
+                             function="DEFAULT"
+                             group="SDA_DUAL"
+                             pad="PC2"/>
+                  </signals>
+               </instance>
+               <instance name="TWI1">
+                  <register-group address-space="data"
+                                  name="TWI1"
+                                  name-in-module="TWI"
+                                  offset="0x0920"/>
+                  <signals>
+                     <signal field="PORTMUX.TWIROUTEA.TWI1"
+                             function="ALT1"
+                             group="SCL"
+                             pad="PF3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI1"
+                             function="ALT1"
+                             group="SDA"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI1"
+                             function="DEFAULT"
+                             group="SCL"
+                             pad="PF3"/>
+                     <signal field="PORTMUX.TWIROUTEA.TWI1"
+                             function="DEFAULT"
+                             group="SDA"
+                             pad="PF2"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="uart_autobd_v4" name="USART">
+               <instance name="USART0">
+                  <register-group address-space="data"
+                                  name="USART0"
+                                  name-in-module="USART"
+                                  offset="0x0800"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="ALT1"
+                             group="RXD"
+                             pad="PA5"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="ALT1"
+                             group="TXD"
+                             pad="PA4"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="ALT1"
+                             group="XCK"
+                             pad="PA6"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="ALT1"
+                             group="XDIR"
+                             pad="PA7"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="DEFAULT"
+                             group="RXD"
+                             pad="PA1"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="DEFAULT"
+                             group="TXD"
+                             pad="PA0"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="DEFAULT"
+                             group="XCK"
+                             pad="PA2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART0"
+                             function="DEFAULT"
+                             group="XDIR"
+                             pad="PA3"/>
+                  </signals>
+               </instance>
+               <instance name="USART1">
+                  <register-group address-space="data"
+                                  name="USART1"
+                                  name-in-module="USART"
+                                  offset="0x0820"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="DEFAULT"
+                             group="RXD"
+                             pad="PC1"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="DEFAULT"
+                             group="TXD"
+                             pad="PC0"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="DEFAULT"
+                             group="XCK"
+                             pad="PC2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART1"
+                             function="DEFAULT"
+                             group="XDIR"
+                             pad="PC3"/>
+                  </signals>
+               </instance>
+               <instance name="USART2">
+                  <register-group address-space="data"
+                                  name="USART2"
+                                  name-in-module="USART"
+                                  offset="0x0840"/>
+                  <signals>
+                     <signal field="PORTMUX.USARTROUTEA.USART2"
+                             function="ALT1"
+                             group="RXD"
+                             pad="PF5"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART2"
+                             function="ALT1"
+                             group="TXD"
+                             pad="PF4"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART2"
+                             function="DEFAULT"
+                             group="RXD"
+                             pad="PF1"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART2"
+                             function="DEFAULT"
+                             group="TXD"
+                             pad="PF0"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART2"
+                             function="DEFAULT"
+                             group="XCK"
+                             pad="PF2"/>
+                     <signal field="PORTMUX.USARTROUTEA.USART2"
+                             function="DEFAULT"
+                             group="XDIR"
+                             pad="PF3"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="avrdb" name="USERROW">
+               <instance name="USERROW">
+                  <register-group address-space="data"
+                                  name="USERROW"
+                                  name-in-module="USERROW"
+                                  offset="0x1080"/>
+               </instance>
+            </module>
+            <module id="gpio_ports_avr_v2_vport" name="VPORT">
+               <instance name="VPORTA">
+                  <register-group address-space="data"
+                                  name="VPORTA"
+                                  name-in-module="VPORT"
+                                  offset="0x0000"/>
+               </instance>
+               <instance name="VPORTC">
+                  <register-group address-space="data"
+                                  name="VPORTC"
+                                  name-in-module="VPORT"
+                                  offset="0x0008"/>
+               </instance>
+               <instance name="VPORTD">
+                  <register-group address-space="data"
+                                  name="VPORTD"
+                                  name-in-module="VPORT"
+                                  offset="0x000C"/>
+               </instance>
+               <instance name="VPORTF">
+                  <register-group address-space="data"
+                                  name="VPORTF"
+                                  name-in-module="VPORT"
+                                  offset="0x0014"/>
+               </instance>
+            </module>
+            <module id="avrdb" name="VREF">
+               <instance name="VREF">
+                  <register-group address-space="data"
+                                  name="VREF"
+                                  name-in-module="VREF"
+                                  offset="0x00B0"/>
+                  <signals>
+                     <signal function="DEFAULT" group="VREFA" pad="PD7"/>
+                  </signals>
+               </instance>
+            </module>
+            <module id="wdt_windowed_v2" name="WDT">
+               <instance name="WDT">
+                  <register-group address-space="data"
+                                  name="WDT"
+                                  name-in-module="WDT"
+                                  offset="0x0100"/>
+               </instance>
+            </module>
+            <module id="cmp_zxover_ctrl_v3" name="ZCD">
+               <instance name="ZCD0">
+                  <register-group address-space="data"
+                                  name="ZCD0"
+                                  name-in-module="ZCD"
+                                  offset="0x06C0"/>
+                  <signals>
+                     <signal function="DEFAULT" group="ZCIN" pad="PD1"/>
+                     <signal field="PORTMUX.ZCDROUTEA.ZCD0"
+                             function="DEFAULT"
+                             group="OUT"
+                             pad="PA7"/>
+                  </signals>
+               </instance>
+            </module>
+         </peripherals>
+         <interrupts>
+            <interrupt index="1" module-instance="CRCSCAN" name="NMI"/>
+            <interrupt index="2" module-instance="BOD" name="VLM"/>
+            <interrupt index="3" module-instance="CLKCTRL" name="CFD"/>
+            <interrupt index="4" module-instance="MVIO" name="MVIO"/>
+            <interrupt index="5" module-instance="RTC" name="CNT"/>
+            <interrupt index="6" module-instance="RTC" name="PIT"/>
+            <interrupt index="7" module-instance="CCL" name="CCL"/>
+            <interrupt index="8" module-instance="PORTA" name="PORT"/>
+            <interrupt index="9" module-instance="TCA0" name="LUNF"/>
+            <interrupt index="9" module-instance="TCA0" name="OVF"/>
+            <interrupt index="10" module-instance="TCA0" name="HUNF"/>
+            <interrupt index="11" module-instance="TCA0" name="CMP0"/>
+            <interrupt index="11" module-instance="TCA0" name="LCMP0"/>
+            <interrupt index="12" module-instance="TCA0" name="CMP1"/>
+            <interrupt index="12" module-instance="TCA0" name="LCMP1"/>
+            <interrupt index="13" module-instance="TCA0" name="CMP2"/>
+            <interrupt index="13" module-instance="TCA0" name="LCMP2"/>
+            <interrupt index="14" module-instance="TCB0" name="INT"/>
+            <interrupt index="15" module-instance="TCB1" name="INT"/>
+            <interrupt index="16" module-instance="TCD0" name="OVF"/>
+            <interrupt index="17" module-instance="TCD0" name="TRIG"/>
+            <interrupt index="18" module-instance="TWI0" name="TWIS"/>
+            <interrupt index="19" module-instance="TWI0" name="TWIM"/>
+            <interrupt index="20" module-instance="SPI0" name="INT"/>
+            <interrupt index="21" module-instance="USART0" name="RXC"/>
+            <interrupt index="22" module-instance="USART0" name="DRE"/>
+            <interrupt index="23" module-instance="USART0" name="TXC"/>
+            <interrupt index="24" module-instance="PORTD" name="PORT"/>
+            <interrupt index="25" module-instance="AC0" name="AC"/>
+            <interrupt index="26" module-instance="ADC0" name="RESRDY"/>
+            <interrupt index="27" module-instance="ADC0" name="WCMP"/>
+            <interrupt index="28" module-instance="ZCD0" name="ZCD"/>
+            <interrupt index="29" module-instance="AC1" name="AC"/>
+            <interrupt index="30" module-instance="PORTC" name="PORT"/>
+            <interrupt index="31" module-instance="TCB2" name="INT"/>
+            <interrupt index="32" module-instance="USART1" name="RXC"/>
+            <interrupt index="33" module-instance="USART1" name="DRE"/>
+            <interrupt index="34" module-instance="USART1" name="TXC"/>
+            <interrupt index="35" module-instance="PORTF" name="PORT"/>
+            <interrupt index="36" module-instance="NVMCTRL" name="EE"/>
+            <interrupt index="37" module-instance="SPI1" name="INT"/>
+            <interrupt index="38" module-instance="USART2" name="RXC"/>
+            <interrupt index="39" module-instance="USART2" name="DRE"/>
+            <interrupt index="40" module-instance="USART2" name="TXC"/>
+            <interrupt index="41" module-instance="AC2" name="AC"/>
+            <interrupt index="42" module-instance="TWI1" name="TWIS"/>
+            <interrupt index="43" module-instance="TWI1" name="TWIM"/>
+         </interrupts>
+         <interfaces>
+            <interface name="UPDI" type="updi"/>
+         </interfaces>
+         <property-groups>
+            <property-group name="OCD_FEATURES">
+               <property name="BREAK_PIN" value="PF6"/>
+               <property name="BREAK_PIN_ALT" value="PF2"/>
+            </property-group>
+            <property-group name="PROGRAMMING_INFO">
+               <property name="FUSE_ENABLED_VALUE" value="1"/>
+            </property-group>
+            <property-group name="UPDI_INTERFACE">
+               <property name="HV_IMPLEMENTATION" value="1"/>
+               <property name="PROGMEM_OFFSET" value="0x00800000"/>
+            </property-group>
+            <property-group name="SIGNATURES">
+               <property name="SIGNATURE0" value="0x1E"/>
+               <property name="SIGNATURE1" value="0x97"/>
+               <property name="SIGNATURE2" value="0x0D"/>
+            </property-group>
+         </property-groups>
+      </device>
+   </devices>
+   <modules>
+      <module caption="Analog Comparator" id="cmp_control_v8" name="AC">
+         <register-group caption="Analog Comparator" name="AC" size="0x8">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Hysteresis Mode"
+                         mask="0x06"
+                         name="HYSMODE"
+                         rw="RW"
+                         values="AC_HYSMODE"/>
+               <bitfield caption="Power profile"
+                         mask="0x18"
+                         name="POWER"
+                         rw="RW"
+                         values="AC_POWER"/>
+               <bitfield caption="Output Pad Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTDBY"
+                         rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Window selection mode"
+                         mask="0x03"
+                         name="WINSEL"
+                         rw="RW"
+                         values="AC_WINSEL"/>
+            </register>
+            <register caption="Mux Control A"
+                      initval="0x00"
+                      name="MUXCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Negative Input MUX Selection"
+                         mask="0x07"
+                         name="MUXNEG"
+                         rw="RW"
+                         values="AC_MUXNEG"/>
+               <bitfield caption="Positive Input MUX Selection"
+                         mask="0x38"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="AC_MUXPOS"/>
+               <bitfield caption="AC Output Initial Value"
+                         mask="0x40"
+                         name="INITVAL"
+                         rw="RW"
+                         values="AC_INITVAL"/>
+               <bitfield caption="Invert AC Output" mask="0x80" name="INVERT" rw="RW"/>
+            </register>
+            <register caption="DAC Voltage Reference"
+                      initval="0xFF"
+                      name="DACREF"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="DACREF" mask="0xFF" name="DACREF" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <mode name="NORMAL" qualifier="AC.CTRLB.WINSEL" value="0x0"/>
+               <mode name="WINDOW" qualifier="AC.CTRLB.WINSEL" value="0x1 0x2"/>
+               <bitfield caption="Interrupt Enable" mask="0x01" name="CMP" rw="RW"/>
+               <bitfield caption="Interrupt Mode"
+                         mask="0x30"
+                         modes="NORMAL"
+                         name="INTMODE"
+                         rw="RW"
+                         values="AC_NORMAL_INTMODE"/>
+               <bitfield caption="Interrupt Mode"
+                         mask="0x30"
+                         modes="WINDOW"
+                         name="INTMODE"
+                         rw="RW"
+                         values="AC_WINDOW_INTMODE"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Comparator Interrupt Flag"
+                         mask="0x01"
+                         name="CMPIF"
+                         rw="RW"/>
+               <bitfield caption="Analog Comparator State"
+                         mask="0x10"
+                         name="CMPSTATE"
+                         rw="R"/>
+               <bitfield caption="Analog Comparator Window State"
+                         mask="0xC0"
+                         name="WINSTATE"
+                         rw="R"
+                         values="AC_WINSTATE"/>
+            </register>
+         </register-group>
+         <value-group caption="Hysteresis Mode select" name="AC_HYSMODE">
+            <value caption="No hysteresis" name="NONE" value="0x00"/>
+            <value caption="Small hysteresis" name="SMALL" value="0x01"/>
+            <value caption="Medium hysteresis" name="MEDIUM" value="0x02"/>
+            <value caption="Large hysteresis" name="LARGE" value="0x03"/>
+         </value-group>
+         <value-group caption="Power profile select" name="AC_POWER">
+            <value caption="Power profile 0, Shortest response time, highest consumption"
+                   name="PROFILE0"
+                   value="0x0"/>
+            <value caption="Power profile 1" name="PROFILE1" value="0x1"/>
+            <value caption="Power profile 2" name="PROFILE2" value="0x2"/>
+         </value-group>
+         <value-group caption="Window selection mode" name="AC_WINSEL">
+            <value caption="Window function disabled" name="DISABLED" value="0x0"/>
+            <value caption="Select ACn+1 as upper limit in window compare"
+                   name="UPSEL1"
+                   value="0x1"/>
+            <value caption="Select ACn+2 as upper limit in window compare"
+                   name="UPSEL2"
+                   value="0x2"/>
+         </value-group>
+         <value-group caption="Interrupt Mode select" name="AC_NORMAL_INTMODE">
+            <value caption="Positive and negative inputs crosses"
+                   name="BOTHEDGE"
+                   value="0x0"/>
+            <value caption="Positive input goes below negative input"
+                   name="NEGEDGE"
+                   value="0x2"/>
+            <value caption="Positive input goes above negative input"
+                   name="POSEDGE"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode select" name="AC_WINDOW_INTMODE">
+            <value caption="Window interrupt when input above both references"
+                   name="ABOVE"
+                   value="0x0"/>
+            <value caption="Window interrupt when input betweeen references"
+                   name="INSIDE"
+                   value="0x1"/>
+            <value caption="Window interrupt when input below both references"
+                   name="BELOW"
+                   value="0x2"/>
+            <value caption="Window interrupt when input outside reference"
+                   name="OUTSIDE"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="AC Output Initial Value select" name="AC_INITVAL">
+            <value caption="Output initialized to 0" name="LOW" value="0x0"/>
+            <value caption="Output initialized to 1" name="HIGH" value="0x1"/>
+         </value-group>
+         <value-group caption="Negative Input MUX Selection" name="AC_MUXNEG">
+            <value caption="Negative Pin 0" name="AINN0" value="0x00"/>
+            <value caption="Negative Pin 1" name="AINN1" value="0x01"/>
+            <value caption="Negative Pin 2" name="AINN2" value="0x02"/>
+            <value caption="DAC Reference" name="DACREF" value="0x03"/>
+         </value-group>
+         <value-group caption="Positive Input MUX Selection" name="AC_MUXPOS">
+            <value caption="Positive Pin 0" name="AINP0" value="0x00"/>
+            <value caption="Positive Pin 1" name="AINP1" value="0x01"/>
+            <value caption="Positive Pin 2" name="AINP2" value="0x02"/>
+            <value caption="Positive Pin 3" name="AINP3" value="0x03"/>
+         </value-group>
+         <value-group caption="Analog Comparator Window State select" name="AC_WINSTATE">
+            <value caption="Above window" name="ABOVE" value="0x0"/>
+            <value caption="Inside window" name="INSIDE" value="0x1"/>
+            <value caption="Below window" name="BELOW" value="0x2"/>
+         </value-group>
+      </module>
+      <module caption="Analog to Digital Converter"
+              id="adc_12b_diff_ctrl_v1"
+              name="ADC">
+         <register-group caption="Analog to Digital Converter" name="ADC" size="0x18">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="ADC Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Free running mode" mask="0x02" name="FREERUN" rw="RW"/>
+               <bitfield caption="Resolution selection"
+                         mask="0x0C"
+                         name="RESSEL"
+                         rw="RW"
+                         values="ADC_RESSEL"/>
+               <bitfield caption="Left adjust result" mask="0x10" name="LEFTADJ" rw="RW"/>
+               <bitfield caption="Conversion mode"
+                         mask="0x20"
+                         name="CONVMODE"
+                         rw="RW"
+                         values="ADC_CONVMODE"/>
+               <bitfield caption="Run standby mode" mask="0x80" name="RUNSTBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Accumulation Samples"
+                         mask="0x07"
+                         name="SAMPNUM"
+                         rw="RW"
+                         values="ADC_SAMPNUM"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Pre-scaler"
+                         mask="0x0F"
+                         name="PRESC"
+                         rw="RW"
+                         values="ADC_PRESC"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sampling Delay Selection"
+                         mask="0x0F"
+                         name="SAMPDLY"
+                         rw="RW"
+                         values="ADC_SAMPDLY"/>
+               <bitfield caption="Initial Delay Selection"
+                         mask="0xE0"
+                         name="INITDLY"
+                         rw="RW"
+                         values="ADC_INITDLY"/>
+            </register>
+            <register caption="Control E"
+                      initval="0x00"
+                      name="CTRLE"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Window Comparator Mode"
+                         mask="0x07"
+                         name="WINCM"
+                         rw="RW"
+                         values="ADC_WINCM"/>
+            </register>
+            <register caption="Sample Control"
+                      initval="0x00"
+                      name="SAMPCTRL"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sample lenght" mask="0xFF" name="SAMPLEN" rw="RW"/>
+            </register>
+            <register caption="Positive mux input"
+                      initval="0x00"
+                      name="MUXPOS"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Channel Selection Bits"
+                         mask="0x7F"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="ADC_MUXPOS"/>
+            </register>
+            <register caption="Negative mux input"
+                      initval="0x00"
+                      name="MUXNEG"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Channel Selection Bits"
+                         mask="0x7F"
+                         name="MUXNEG"
+                         rw="RW"
+                         values="ADC_MUXNEG"/>
+            </register>
+            <register caption="Command"
+                      initval="0x00"
+                      name="COMMAND"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Start Conversion" mask="0x01" name="STCONV" rw="RW"/>
+               <bitfield caption="Stop Conversion" mask="0x02" name="SPCONV" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Start Event Input Enable"
+                         mask="0x01"
+                         name="STARTEI"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Result Ready Interrupt Enable"
+                         mask="0x01"
+                         name="RESRDY"
+                         rw="RW"/>
+               <bitfield caption="Window Comparator Interrupt Enable"
+                         mask="0x02"
+                         name="WCMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Result Ready Flag" mask="0x01" name="RESRDY" rw="RW"/>
+               <bitfield caption="Window Comparator Flag"
+                         mask="0x02"
+                         name="WCMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary Data"
+                      initval="0x00"
+                      name="TEMP"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Temporary" mask="0xFF" name="TEMP" rw="RW"/>
+            </register>
+            <register caption="ADC Accumulator Result"
+                      name="RES"
+                      offset="0x10"
+                      rw="R"
+                      size="2"/>
+            <register caption="Window comparator low threshold"
+                      name="WINLT"
+                      offset="0x12"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Window comparator high threshold"
+                      name="WINHT"
+                      offset="0x14"
+                      rw="RW"
+                      size="2"/>
+         </register-group>
+         <value-group caption="Conversion mode select" name="ADC_CONVMODE">
+            <value caption="Single-Ended mode" name="SINGLEENDED" value="0x0"/>
+            <value caption="Differential mode" name="DIFF" value="0x1"/>
+         </value-group>
+         <value-group caption="Resolution selection" name="ADC_RESSEL">
+            <value caption="12-bit mode" name="12BIT" value="0x0"/>
+            <value caption="10-bit mode" name="10BIT" value="0x1"/>
+         </value-group>
+         <value-group caption="Accumulation Samples select" name="ADC_SAMPNUM">
+            <value caption="No accumulation" name="NONE" value="0x00"/>
+            <value caption="2 results accumulated" name="ACC2" value="0x01"/>
+            <value caption="4 results accumulated" name="ACC4" value="0x02"/>
+            <value caption="8 results accumulated" name="ACC8" value="0x03"/>
+            <value caption="16 results accumulated" name="ACC16" value="0x04"/>
+            <value caption="32 results accumulated" name="ACC32" value="0x05"/>
+            <value caption="64 results accumulated" name="ACC64" value="0x06"/>
+            <value caption="128 results accumulated" name="ACC128" value="0x7"/>
+         </value-group>
+         <value-group caption="Clock Pre-scaler select" name="ADC_PRESC">
+            <value caption="CLK_PER divided by 2" name="DIV2" value="0x00"/>
+            <value caption="CLK_PER divided by 4" name="DIV4" value="0x01"/>
+            <value caption="CLK_PER divided by 8" name="DIV8" value="0x02"/>
+            <value caption="CLK_PER divided by 12" name="DIV12" value="0x03"/>
+            <value caption="CLK_PER divided by 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER divided by 20" name="DIV20" value="0x05"/>
+            <value caption="CLK_PER divided by 24" name="DIV24" value="0x06"/>
+            <value caption="CLK_PER divided by 28" name="DIV28" value="0x07"/>
+            <value caption="CLK_PER divided by 32" name="DIV32" value="0x08"/>
+            <value caption="CLK_PER divided by 48" name="DIV48" value="0x09"/>
+            <value caption="CLK_PER divided by 64" name="DIV64" value="0x0A"/>
+            <value caption="CLK_PER divided by 96" name="DIV96" value="0x0B"/>
+            <value caption="CLK_PER divided by 128" name="DIV128" value="0x0C"/>
+            <value caption="CLK_PER divided by 256" name="DIV256" value="0x0D"/>
+         </value-group>
+         <value-group caption="Initial Delay Selection" name="ADC_INITDLY">
+            <value caption="Delay 0 CLK_ADC cycles" name="DLY0" value="0x00"/>
+            <value caption="Delay 16 CLK_ADC cycles" name="DLY16" value="0x01"/>
+            <value caption="Delay 32 CLK_ADC cycles" name="DLY32" value="0x02"/>
+            <value caption="Delay 64 CLK_ADC cycles" name="DLY64" value="0x03"/>
+            <value caption="Delay 128 CLK_ADC cycles" name="DLY128" value="0x04"/>
+            <value caption="Delay 256 CLK_ADC cycles" name="DLY256" value="0x05"/>
+         </value-group>
+         <value-group caption="Sampling Delay Selection" name="ADC_SAMPDLY">
+            <value caption="Delay 0 CLK_ADC cycles" name="DLY0" value="0x0"/>
+            <value caption="Delay 1 CLK_ADC cycles" name="DLY1" value="0x1"/>
+            <value caption="Delay 2 CLK_ADC cycles" name="DLY2" value="0x2"/>
+            <value caption="Delay 3 CLK_ADC cycles" name="DLY3" value="0x3"/>
+            <value caption="Delay 4 CLK_ADC cycles" name="DLY4" value="0x4"/>
+            <value caption="Delay 5 CLK_ADC cycles" name="DLY5" value="0x5"/>
+            <value caption="Delay 6 CLK_ADC cycles" name="DLY6" value="0x6"/>
+            <value caption="Delay 7 CLK_ADC cycles" name="DLY7" value="0x7"/>
+            <value caption="Delay 8 CLK_ADC cycles" name="DLY8" value="0x8"/>
+            <value caption="Delay 9 CLK_ADC cycles" name="DLY9" value="0x9"/>
+            <value caption="Delay 10 CLK_ADC cycles" name="DLY10" value="0xA"/>
+            <value caption="Delay 11 CLK_ADC cycles" name="DLY11" value="0xB"/>
+            <value caption="Delay 12 CLK_ADC cycles" name="DLY12" value="0xC"/>
+            <value caption="Delay 13 CLK_ADC cycles" name="DLY13" value="0xD"/>
+            <value caption="Delay 14 CLK_ADC cycles" name="DLY14" value="0xE"/>
+            <value caption="Delay 15 CLK_ADC cycles" name="DLY15" value="0xF"/>
+         </value-group>
+         <value-group caption="Window Comparator Mode select" name="ADC_WINCM">
+            <value caption="No Window Comparison" name="NONE" value="0x00"/>
+            <value caption="Below Window" name="BELOW" value="0x01"/>
+            <value caption="Above Window" name="ABOVE" value="0x02"/>
+            <value caption="Inside Window" name="INSIDE" value="0x03"/>
+            <value caption="Outside Window" name="OUTSIDE" value="0x04"/>
+         </value-group>
+         <value-group caption="Analog Channel Selection Bits" name="ADC_MUXNEG">
+            <value caption="ADC input pin 0" name="AIN0" value="0x00"/>
+            <value caption="ADC input pin 1" name="AIN1" value="0x01"/>
+            <value caption="ADC input pin 2" name="AIN2" value="0x02"/>
+            <value caption="ADC input pin 3" name="AIN3" value="0x03"/>
+            <value caption="ADC input pin 4" name="AIN4" value="0x04"/>
+            <value caption="ADC input pin 5" name="AIN5" value="0x05"/>
+            <value caption="ADC input pin 6" name="AIN6" value="0x06"/>
+            <value caption="ADC input pin 7" name="AIN7" value="0x07"/>
+            <value caption="ADC input pin 8" name="AIN8" value="0x08"/>
+            <value caption="ADC input pin 9" name="AIN9" value="0x09"/>
+            <value caption="ADC input pin 10" name="AIN10" value="0x0A"/>
+            <value caption="ADC input pin 11" name="AIN11" value="0x0B"/>
+            <value caption="ADC input pin 12" name="AIN12" value="0x0C"/>
+            <value caption="ADC input pin 13" name="AIN13" value="0x0D"/>
+            <value caption="ADC input pin 14" name="AIN14" value="0x0E"/>
+            <value caption="ADC input pin 15" name="AIN15" value="0x0F"/>
+            <value caption="Ground" name="GND" value="0x40"/>
+            <value caption="DAC0" name="DAC0" value="0x48"/>
+         </value-group>
+         <value-group caption="Analog Channel Selection Bits" name="ADC_MUXPOS">
+            <value caption="ADC input pin 0" name="AIN0" value="0x00"/>
+            <value caption="ADC input pin 1" name="AIN1" value="0x01"/>
+            <value caption="ADC input pin 2" name="AIN2" value="0x02"/>
+            <value caption="ADC input pin 3" name="AIN3" value="0x03"/>
+            <value caption="ADC input pin 4" name="AIN4" value="0x04"/>
+            <value caption="ADC input pin 5" name="AIN5" value="0x05"/>
+            <value caption="ADC input pin 6" name="AIN6" value="0x06"/>
+            <value caption="ADC input pin 7" name="AIN7" value="0x07"/>
+            <value caption="ADC input pin 8" name="AIN8" value="0x08"/>
+            <value caption="ADC input pin 9" name="AIN9" value="0x09"/>
+            <value caption="ADC input pin 10" name="AIN10" value="0x0A"/>
+            <value caption="ADC input pin 11" name="AIN11" value="0x0B"/>
+            <value caption="ADC input pin 12" name="AIN12" value="0x0C"/>
+            <value caption="ADC input pin 13" name="AIN13" value="0x0D"/>
+            <value caption="ADC input pin 14" name="AIN14" value="0x0E"/>
+            <value caption="ADC input pin 15" name="AIN15" value="0x0F"/>
+            <value caption="ADC input pin 16" name="AIN16" value="0x10"/>
+            <value caption="ADC input pin 17" name="AIN17" value="0x11"/>
+            <value caption="ADC input pin 18" name="AIN18" value="0x12"/>
+            <value caption="ADC input pin 19" name="AIN19" value="0x13"/>
+            <value caption="ADC input pin 20" name="AIN20" value="0x14"/>
+            <value caption="ADC input pin 21" name="AIN21" value="0x15"/>
+            <value caption="Ground" name="GND" value="0x40"/>
+            <value caption="Temperature sensor" name="TEMPSENSE" value="0x42"/>
+            <value caption="VDD/10" name="VDDDIV10" value="0x44"/>
+            <value caption="VDDIO2/10" name="VDDIO2DIV10" value="0x45"/>
+            <value caption="DAC0" name="DAC0" value="0x48"/>
+            <value caption="AC0 DAC Voltage Reference" name="DACREF0" value="0x49"/>
+            <value caption="AC1 DAC Voltage Reference" name="DACREF1" value="0x4A"/>
+            <value caption="AC2 DAC Voltage Reference" name="DACREF2" value="0x4B"/>
+         </value-group>
+      </module>
+      <module caption="Bod interface" id="bor_lvd_ctrl_v1" name="BOD">
+         <register-group caption="Bod interface" name="BOD" size="0x10">
+            <register caption="Control A"
+                      initval="0x01"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Operation in sleep mode"
+                         mask="0x03"
+                         name="SLEEP"
+                         rw="RW"
+                         values="BOD_SLEEP"/>
+               <bitfield caption="Operation in active mode"
+                         mask="0x0C"
+                         name="ACTIVE"
+                         rw="R"
+                         values="BOD_ACTIVE"/>
+               <bitfield caption="Sample frequency"
+                         mask="0x10"
+                         name="SAMPFREQ"
+                         rw="R"
+                         values="BOD_SAMPFREQ"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Bod level"
+                         mask="0x07"
+                         name="LVL"
+                         rw="R"
+                         values="BOD_LVL"/>
+            </register>
+            <register caption="Voltage level monitor Control"
+                      initval="0x00"
+                      name="VLMCTRLA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="voltage level monitor level"
+                         mask="0x03"
+                         name="VLMLVL"
+                         rw="RW"
+                         values="BOD_VLMLVL"/>
+            </register>
+            <register caption="Voltage level monitor interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="voltage level monitor interrrupt enable"
+                         mask="0x01"
+                         name="VLMIE"
+                         rw="RW"/>
+               <bitfield caption="Configuration"
+                         mask="0x06"
+                         name="VLMCFG"
+                         rw="RW"
+                         values="BOD_VLMCFG"/>
+            </register>
+            <register caption="Voltage level monitor interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Voltage level monitor interrupt flag"
+                         mask="0x01"
+                         name="VLMIF"
+                         rw="RW"/>
+            </register>
+            <register caption="Voltage level monitor status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Voltage level monitor status"
+                         mask="0x01"
+                         name="VLMS"
+                         rw="R"
+                         values="BOD_VLMS"/>
+            </register>
+         </register-group>
+         <value-group caption="Operation in active mode select" name="BOD_ACTIVE">
+            <value caption="Disabled" name="DIS" value="0x00"/>
+            <value caption="Enabled" name="ENABLED" value="0x01"/>
+            <value caption="Sampled" name="SAMPLED" value="0x02"/>
+            <value caption="Enabled with wake-up halted until BOD is ready"
+                   name="ENWAKE"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Sample frequency select" name="BOD_SAMPFREQ">
+            <value caption="128Hz sampling frequency" name="128HZ" value="0x0"/>
+            <value caption="32Hz sampling frequency" name="32HZ" value="0x1"/>
+         </value-group>
+         <value-group caption="Operation in sleep mode select" name="BOD_SLEEP">
+            <value caption="Disabled" name="DIS" value="0x00"/>
+            <value caption="Enabled" name="ENABLED" value="0x01"/>
+            <value caption="Sampled" name="SAMPLED" value="0x02"/>
+         </value-group>
+         <value-group caption="Bod level select" name="BOD_LVL">
+            <value caption="1.9 V" name="BODLEVEL0" value="0x00"/>
+            <value caption="2.45 V" name="BODLEVEL1" value="0x01"/>
+            <value caption="2.7 V" name="BODLEVEL2" value="0x02"/>
+            <value caption="2.85 V" name="BODLEVEL3" value="0x03"/>
+         </value-group>
+         <value-group caption="Configuration select" name="BOD_VLMCFG">
+            <value caption="VDD falls below VLM threshold" name="FALLING" value="0x00"/>
+            <value caption="VDD rises above VLM threshold" name="RISING" value="0x01"/>
+            <value caption="VDD crosses VLM threshold" name="BOTH" value="0x02"/>
+         </value-group>
+         <value-group caption="Voltage level monitor status select" name="BOD_VLMS">
+            <value caption="The voltage is above the VLM threshold level"
+                   name="ABOVE"
+                   value="0x0"/>
+            <value caption="The voltage is below the VLM threshold level"
+                   name="BELOW"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="voltage level monitor level select" name="BOD_VLMLVL">
+            <value caption="VLM Disabled" name="OFF" value="0x0"/>
+            <value caption="VLM threshold 5% above BOD level"
+                   name="5ABOVE"
+                   value="0x1"/>
+            <value caption="VLM threshold 15% above BOD level"
+                   name="15ABOVE"
+                   value="0x2"/>
+            <value caption="VLM threshold 25% above BOD level"
+                   name="25ABOVE"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="Configurable Custom Logic" id="cla_ccl_v1" name="CCL">
+         <register-group caption="Configurable Custom Logic" name="CCL" size="0x40">
+            <register caption="Control Register A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Run in Standby" mask="0x40" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Sequential Control 0"
+                      initval="0x00"
+                      name="SEQCTRL0"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sequential Selection"
+                         mask="0x0F"
+                         name="SEQSEL"
+                         rw="RW"
+                         values="CCL_SEQSEL"/>
+            </register>
+            <register caption="Sequential Control 1"
+                      initval="0x00"
+                      name="SEQCTRL1"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sequential Selection"
+                         mask="0x0F"
+                         name="SEQSEL"
+                         rw="RW"
+                         values="CCL_SEQSEL"/>
+            </register>
+            <register caption="Interrupt Control 0"
+                      initval="0x00"
+                      name="INTCTRL0"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Mode for LUT0"
+                         mask="0x03"
+                         name="INTMODE0"
+                         rw="RW"
+                         values="CCL_INTMODE0"/>
+               <bitfield caption="Interrupt Mode for LUT1"
+                         mask="0x0C"
+                         name="INTMODE1"
+                         rw="RW"
+                         values="CCL_INTMODE1"/>
+               <bitfield caption="Interrupt Mode for LUT2"
+                         mask="0x30"
+                         name="INTMODE2"
+                         rw="RW"
+                         values="CCL_INTMODE2"/>
+               <bitfield caption="Interrupt Mode for LUT3"
+                         mask="0xC0"
+                         name="INTMODE3"
+                         rw="RW"
+                         values="CCL_INTMODE3"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Flag" mask="0x0F" name="INT" rw="RW"/>
+            </register>
+            <register caption="LUT 0 Control A"
+                      initval="0x00"
+                      name="LUT0CTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 0 Control B"
+                      initval="0x00"
+                      name="LUT0CTRLB"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 0 Control C"
+                      initval="0x00"
+                      name="LUT0CTRLC"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 0"
+                      initval="0x00"
+                      name="TRUTH0"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 1 Control A"
+                      initval="0x00"
+                      name="LUT1CTRLA"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 1 Control B"
+                      initval="0x00"
+                      name="LUT1CTRLB"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 1 Control C"
+                      initval="0x00"
+                      name="LUT1CTRLC"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 1"
+                      initval="0x00"
+                      name="TRUTH1"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 2 Control A"
+                      initval="0x00"
+                      name="LUT2CTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 2 Control B"
+                      initval="0x00"
+                      name="LUT2CTRLB"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 2 Control C"
+                      initval="0x00"
+                      name="LUT2CTRLC"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 2"
+                      initval="0x00"
+                      name="TRUTH2"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+            <register caption="LUT 3 Control A"
+                      initval="0x00"
+                      name="LUT3CTRLA"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Source Selection"
+                         mask="0x0E"
+                         name="CLKSRC"
+                         rw="RW"
+                         values="CCL_CLKSRC"/>
+               <bitfield caption="Filter Selection"
+                         mask="0x30"
+                         name="FILTSEL"
+                         rw="RW"
+                         values="CCL_FILTSEL"/>
+               <bitfield caption="Output Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Edge Detection Enable"
+                         mask="0x80"
+                         name="EDGEDET"
+                         rw="RW"
+                         values="CCL_EDGEDET"/>
+            </register>
+            <register caption="LUT 3 Control B"
+                      initval="0x00"
+                      name="LUT3CTRLB"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 0 Source Selection"
+                         mask="0x0F"
+                         name="INSEL0"
+                         rw="RW"
+                         values="CCL_INSEL0"/>
+               <bitfield caption="LUT Input 1 Source Selection"
+                         mask="0xF0"
+                         name="INSEL1"
+                         rw="RW"
+                         values="CCL_INSEL1"/>
+            </register>
+            <register caption="LUT 3 Control C"
+                      initval="0x00"
+                      name="LUT3CTRLC"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="LUT Input 2 Source Selection"
+                         mask="0x0F"
+                         name="INSEL2"
+                         rw="RW"
+                         values="CCL_INSEL2"/>
+            </register>
+            <register caption="Truth 3"
+                      initval="0x00"
+                      name="TRUTH3"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Truth Table" mask="0xFF" name="TRUTH" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Interrupt Mode for LUT0 select" name="CCL_INTMODE0">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT1 select" name="CCL_INTMODE1">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT2 select" name="CCL_INTMODE2">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Interrupt Mode for LUT3 select" name="CCL_INTMODE3">
+            <value caption="Interrupt disabled" name="INTDISABLE" value="0x0"/>
+            <value caption="Sense rising edge" name="RISING" value="0x1"/>
+            <value caption="Sense falling edge" name="FALLING" value="0x2"/>
+            <value caption="Sense both edges" name="BOTH" value="0x3"/>
+         </value-group>
+         <value-group caption="Clock Source Selection" name="CCL_CLKSRC">
+            <value caption="Peripheral Clock" name="CLKPER" value="0x0"/>
+            <value caption="Selection by INSEL2" name="IN2" value="0x1"/>
+            <value caption="Internal High-Frequency Oscillator"
+                   name="OSCHF"
+                   value="0x4"/>
+            <value caption="32.768 kHz oscillator" name="OSC32K" value="0x5"/>
+            <value caption="32.768 kHz oscillator divided by 32"
+                   name="OSC1K"
+                   value="0x6"/>
+         </value-group>
+         <value-group caption="Edge Detection Enable select" name="CCL_EDGEDET">
+            <value caption="Edge detector is disabled" name="DIS" value="0x0"/>
+            <value caption="Edge detector is enabled" name="EN" value="0x1"/>
+         </value-group>
+         <value-group caption="Filter Selection" name="CCL_FILTSEL">
+            <value caption="Filter disabled" name="DISABLE" value="0x0"/>
+            <value caption="Synchronizer enabled" name="SYNCH" value="0x1"/>
+            <value caption="Filter enabled" name="FILTER" value="0x2"/>
+         </value-group>
+         <value-group caption="LUT Input 0 Source Selection" name="CCL_INSEL0">
+            <value caption="Masked input" name="MASK" value="0x00"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x01"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x02"/>
+            <value caption="Event input source A" name="EVENTA" value="0x03"/>
+            <value caption="Event input source B" name="EVENTB" value="0x04"/>
+            <value caption="IO pin LUTn-IN0 input source" name="IN0" value="0x05"/>
+            <value caption="AC0 OUT input source" name="AC0" value="0x06"/>
+            <value caption="ZCD0 OUT input source" name="ZCD0" value="0x07"/>
+            <value caption="USART0 TXD input source" name="USART0" value="0x08"/>
+            <value caption="SPI0 MOSI input source" name="SPI0" value="0x09"/>
+            <value caption="TCA0 WO0 input source" name="TCA0" value="0x0A"/>
+            <value caption="TCB0 WO input source" name="TCB0" value="0x0C"/>
+            <value caption="TCD0 WOA input source" name="TCD0" value="0x0D"/>
+         </value-group>
+         <value-group caption="LUT Input 1 Source Selection" name="CCL_INSEL1">
+            <value caption="Masked input" name="MASK" value="0x00"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x01"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x02"/>
+            <value caption="Event input source A" name="EVENTA" value="0x03"/>
+            <value caption="Event input source B" name="EVENTB" value="0x04"/>
+            <value caption="IO pin LUTn-IN1 input source" name="IN1" value="0x05"/>
+            <value caption="AC1 OUT input source" name="AC1" value="0x06"/>
+            <value caption="USART1 TXD input source" name="USART1" value="0x08"/>
+            <value caption="SPI0 MOSI input source" name="SPI0" value="0x09"/>
+            <value caption="TCA0 WO1 input source" name="TCA0" value="0x0A"/>
+            <value caption="TCB1 WO input source" name="TCB1" value="0x0C"/>
+            <value caption="TCD0 WOB input source" name="TCD0" value="0x0D"/>
+         </value-group>
+         <value-group caption="LUT Input 2 Source Selection" name="CCL_INSEL2">
+            <value caption="Masked input" name="MASK" value="0x00"/>
+            <value caption="Feedback input source" name="FEEDBACK" value="0x01"/>
+            <value caption="Linked LUT input source" name="LINK" value="0x02"/>
+            <value caption="Event input source A" name="EVENTA" value="0x03"/>
+            <value caption="Event input source B" name="EVENTB" value="0x04"/>
+            <value caption="IO pin LUTn-IN2 input source" name="IN2" value="0x05"/>
+            <value caption="AC2 OUT input source" name="AC2" value="0x06"/>
+            <value caption="USART2 TXD input source" name="USART2" value="0x08"/>
+            <value caption="SPI0 SCK input source" name="SPI0" value="0x09"/>
+            <value caption="TCA0 WO2 input source" name="TCA0" value="0x0A"/>
+            <value caption="TCB2 WO input source" name="TCB2" value="0x0C"/>
+            <value caption="TCD0 WOC input source" name="TCD0" value="0x0D"/>
+         </value-group>
+         <value-group caption="Sequential Selection" name="CCL_SEQSEL">
+            <value caption="Sequential logic disabled" name="DISABLE" value="0x00"/>
+            <value caption="D FlipFlop" name="DFF" value="0x01"/>
+            <value caption="JK FlipFlop" name="JK" value="0x02"/>
+            <value caption="D Latch" name="LATCH" value="0x03"/>
+            <value caption="RS Latch" name="RS" value="0x04"/>
+         </value-group>
+      </module>
+      <module caption="Clock controller" id="avrdb" name="CLKCTRL">
+         <register-group caption="Clock controller" name="CLKCTRL" size="0x40">
+            <register caption="MCLK Control A"
+                      initval="0x00"
+                      name="MCLKCTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock select"
+                         mask="0x07"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="CLKCTRL_CLKSEL"/>
+               <bitfield caption="System clock out" mask="0x80" name="CLKOUT" rw="RW"/>
+            </register>
+            <register caption="MCLK Control B"
+                      initval="0x00"
+                      name="MCLKCTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Prescaler enable" mask="0x01" name="PEN" rw="RW"/>
+               <bitfield caption="Prescaler division"
+                         mask="0x1E"
+                         name="PDIV"
+                         rw="RW"
+                         values="CLKCTRL_PDIV"/>
+            </register>
+            <register caption="MCLK Control C"
+                      initval="0x00"
+                      name="MCLKCTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Enable"
+                         mask="0x01"
+                         name="CFDEN"
+                         rw="RW"/>
+               <bitfield caption="Clock Failure Detect Test"
+                         mask="0x02"
+                         name="CFDTST"
+                         rw="W"/>
+               <bitfield caption="Clock Failure Detect Source"
+                         mask="0x0C"
+                         name="CFDSRC"
+                         rw="RW"
+                         values="CLKCTRL_CFDSRC"/>
+            </register>
+            <register caption="MCLK Interrupt Control"
+                      initval="0x00"
+                      name="MCLKINTCTRL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Interrupt Enable"
+                         mask="0x01"
+                         name="CFD"
+                         rw="RW"/>
+               <bitfield caption="Interrupt type"
+                         mask="0x80"
+                         name="INTTYPE"
+                         rw="RW"
+                         values="CLKCTRL_INTTYPE"/>
+            </register>
+            <register caption="MCLK Interrupt Flags"
+                      initval="0x00"
+                      name="MCLKINTFLAGS"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Failure Detect Interrupt Flag"
+                         mask="0x01"
+                         name="CFD"
+                         rw="RW"/>
+            </register>
+            <register caption="MCLK Status"
+                      initval="0x00"
+                      name="MCLKSTATUS"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="System Oscillator changing"
+                         mask="0x01"
+                         name="SOSC"
+                         rw="RW"/>
+               <bitfield caption="High frequency oscillator status"
+                         mask="0x02"
+                         name="OSCHFS"
+                         rw="RW"/>
+               <bitfield caption="32KHz oscillator status"
+                         mask="0x04"
+                         name="OSC32KS"
+                         rw="RW"/>
+               <bitfield caption="32.768 kHz Crystal Oscillator status"
+                         mask="0x08"
+                         name="XOSC32KS"
+                         rw="RW"/>
+               <bitfield caption="External Clock status" mask="0x10" name="EXTS" rw="RW"/>
+               <bitfield caption="PLL oscillator status" mask="0x20" name="PLLS" rw="RW"/>
+            </register>
+            <register caption="OSCHF Control A"
+                      initval="0x0C"
+                      name="OSCHFCTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Autotune" mask="0x01" name="AUTOTUNE" rw="RW"/>
+               <bitfield caption="Frequency select"
+                         mask="0x3C"
+                         name="FRQSEL"
+                         rw="RW"
+                         values="CLKCTRL_FRQSEL"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="OSCHF Tune"
+                      name="OSCHFTUNE"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Tune" mask="0xFF" name="TUNE" rw="RW"/>
+            </register>
+            <register caption="PLL Control A"
+                      name="PLLCTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Multiplication factor"
+                         mask="0x03"
+                         name="MULFAC"
+                         rw="RW"
+                         values="CLKCTRL_MULFAC"/>
+               <bitfield caption="Source"
+                         mask="0x40"
+                         name="SOURCE"
+                         rw="RW"
+                         values="CLKCTRL_SOURCE"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="OSC32K Control A"
+                      initval="0x00"
+                      name="OSC32KCTRLA"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="XOSC32K Control A"
+                      initval="0x00"
+                      name="XOSC32KCTRLA"
+                      offset="0x1C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Low power mode" mask="0x02" name="LPMODE" rw="RW"/>
+               <bitfield caption="Select" mask="0x04" name="SEL" rw="RW"/>
+               <bitfield caption="Crystal startup time"
+                         mask="0x30"
+                         name="CSUT"
+                         rw="RW"
+                         values="CLKCTRL_CSUT"/>
+               <bitfield caption="Run standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="XOSC High-Frequency Control A"
+                      initval="0x00"
+                      name="XOSCHFCTRLA"
+                      offset="0x20"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="External Source Select"
+                         mask="0x02"
+                         name="SELHF"
+                         rw="RW"
+                         values="CLKCTRL_SELHF"/>
+               <bitfield caption="Frequency Range"
+                         mask="0x0C"
+                         name="FRQRANGE"
+                         rw="RW"
+                         values="CLKCTRL_FRQRANGE"/>
+               <bitfield caption="Start-up Time Select"
+                         mask="0x30"
+                         name="CSUTHF"
+                         rw="RW"
+                         values="CLKCTRL_CSUTHF"/>
+               <bitfield caption="Run Standby" mask="0x80" name="RUNSTBY" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock select" name="CLKCTRL_CLKSEL">
+            <value caption="Internal high-frequency oscillator"
+                   name="OSCHF"
+                   value="0x0"/>
+            <value caption="Internal 32.768 kHz oscillator" name="OSC32K" value="0x1"/>
+            <value caption="32.768 kHz crystal oscillator" name="XOSC32K" value="0x2"/>
+            <value caption="External clock" name="EXTCLK" value="0x3"/>
+         </value-group>
+         <value-group caption="Prescaler division select" name="CLKCTRL_PDIV">
+            <value caption="2X" name="2X" value="0x00"/>
+            <value caption="4X" name="4X" value="0x01"/>
+            <value caption="8X" name="8X" value="0x02"/>
+            <value caption="16X" name="16X" value="0x03"/>
+            <value caption="32X" name="32X" value="0x04"/>
+            <value caption="64X" name="64X" value="0x05"/>
+            <value caption="6X" name="6X" value="0x08"/>
+            <value caption="10X" name="10X" value="0x09"/>
+            <value caption="12X" name="12X" value="0x0A"/>
+            <value caption="24X" name="24X" value="0x0B"/>
+            <value caption="48X" name="48X" value="0x0C"/>
+         </value-group>
+         <value-group caption="Clock Failure Detect Source select" name="CLKCTRL_CFDSRC">
+            <value caption="Main Clock" name="CLKMAIN" value="0x0"/>
+            <value caption="XOSCHF" name="XOSCHF" value="0x1"/>
+            <value caption="XOSC32K" name="XOSC32K" value="0x2"/>
+         </value-group>
+         <value-group caption="Interrupt type select" name="CLKCTRL_INTTYPE">
+            <value caption="Regular Interrupt" name="INT" value="0x0"/>
+            <value caption="NMI" name="NMI" value="0x1"/>
+         </value-group>
+         <value-group caption="Frequency select" name="CLKCTRL_FRQSEL">
+            <value caption="1 MHz system clock" name="1M" value="0x0"/>
+            <value caption="2 MHz system clock" name="2M" value="0x1"/>
+            <value caption="3 MHz system clock" name="3M" value="0x2"/>
+            <value caption="4 MHz system clock (default)" name="4M" value="0x3"/>
+            <value caption="8 MHz system clock" name="8M" value="0x5"/>
+            <value caption="12 MHz system clock" name="12M" value="0x6"/>
+            <value caption="16 MHz system clock" name="16M" value="0x7"/>
+            <value caption="20 MHz system clock" name="20M" value="0x8"/>
+            <value caption="24 MHz system clock" name="24M" value="0x9"/>
+         </value-group>
+         <value-group caption="Multiplication factor select" name="CLKCTRL_MULFAC">
+            <value caption="PLL is disabled" name="DISABLE" value="0x0"/>
+            <value caption="2 x multiplication factor" name="2x" value="0x1"/>
+            <value caption="3 x multiplication factor" name="3x" value="0x2"/>
+         </value-group>
+         <value-group caption="Source select" name="CLKCTRL_SOURCE">
+            <value caption="High frequency internal oscillator as PLL source"
+                   name="OSCHF"
+                   value="0x0"/>
+            <value caption="High frequency external clock or external high frequency oscillator as PLL source"
+                   name="XOSCHF"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="Start-up Time Select" name="CLKCTRL_CSUTHF">
+            <value caption="256 XOSCHF cycles" name="256" value="0x0"/>
+            <value caption="1K XOSCHF cycles" name="1K" value="0x1"/>
+            <value caption="4K XOSCHF cycles" name="4K" value="0x2"/>
+         </value-group>
+         <value-group caption="Frequency Range select" name="CLKCTRL_FRQRANGE">
+            <value caption="Max 8 MHz XTAL Frequency" name="8M" value="0x0"/>
+            <value caption="Max 16 MHz XTAL Frequency" name="16M" value="0x1"/>
+            <value caption="Max 24 MHz XTAL Frequency" name="24M" value="0x2"/>
+            <value caption="Max 32 MHz XTAL Frequency" name="32M" value="0x3"/>
+         </value-group>
+         <value-group caption="External Source Select" name="CLKCTRL_SELHF">
+            <value caption="External Crystal" name="XTAL" value="0x0"/>
+            <value caption="External clock on XTALHF1 pin" name="EXTCLOCK" value="0x1"/>
+         </value-group>
+         <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+            <value caption="1k cycles" name="1K" value="0x00"/>
+            <value caption="16k cycles" name="16K" value="0x01"/>
+            <value caption="32k cycles" name="32K" value="0x02"/>
+            <value caption="64k cycles" name="64K" value="0x03"/>
+         </value-group>
+      </module>
+      <module caption="CPU" id="cpu_avr_xt_v1" name="CPU">
+         <register-group caption="CPU" name="CPU" size="0x10">
+            <register caption="Configuration Change Protection"
+                      initval="0x00"
+                      name="CCP"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CCP signature"
+                         mask="0xFF"
+                         name="CCP"
+                         rw="RW"
+                         values="CPU_CCP"/>
+            </register>
+            <register caption="Extended Z-pointer Register"
+                      initval="0x00"
+                      name="RAMPZ"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Extended Z-Pointer Address bits"
+                         mask="0x01"
+                         name="RAMPZ"
+                         rw="RW"/>
+            </register>
+            <register caption="Stack Pointer"
+                      initval="0x7FFF"
+                      name="SP"
+                      offset="0xD"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Status Register"
+                      initval="0x00"
+                      name="SREG"
+                      offset="0xF"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Carry Flag" mask="0x01" name="C" rw="RW"/>
+               <bitfield caption="Zero Flag" mask="0x02" name="Z" rw="RW"/>
+               <bitfield caption="Negative Flag" mask="0x04" name="N" rw="RW"/>
+               <bitfield caption="Two's Complement Overflow Flag"
+                         mask="0x08"
+                         name="V"
+                         rw="RW"/>
+               <bitfield caption="N Exclusive Or V Flag" mask="0x10" name="S" rw="RW"/>
+               <bitfield caption="Half Carry Flag" mask="0x20" name="H" rw="RW"/>
+               <bitfield caption="Transfer Bit" mask="0x40" name="T" rw="RW"/>
+               <bitfield caption="Global Interrupt Enable Flag"
+                         mask="0x80"
+                         name="I"
+                         rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="CCP signature select" name="CPU_CCP">
+            <value caption="SPM Instruction Protection" name="SPM" value="0x9D"/>
+            <value caption="IO Register Protection" name="IOREG" value="0xD8"/>
+         </value-group>
+      </module>
+      <module caption="Interrupt Controller" id="int_8bit_v3" name="CPUINT">
+         <register-group caption="Interrupt Controller" name="CPUINT" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Round-robin Scheduling Enable"
+                         mask="0x01"
+                         name="LVL0RR"
+                         rw="RW"/>
+               <bitfield caption="Compact Vector Table" mask="0x20" name="CVT" rw="RW"/>
+               <bitfield caption="Interrupt Vector Select"
+                         mask="0x40"
+                         name="IVSEL"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x1"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Level 0 Interrupt Executing"
+                         mask="0x01"
+                         name="LVL0EX"
+                         rw="R"/>
+               <bitfield caption="Level 1 Interrupt Executing"
+                         mask="0x02"
+                         name="LVL1EX"
+                         rw="R"/>
+               <bitfield caption="Non-maskable Interrupt Executing"
+                         mask="0x80"
+                         name="NMIEX"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Level 0 Priority"
+                      initval="0x00"
+                      name="LVL0PRI"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Level Priority"
+                         mask="0xFF"
+                         name="LVL0PRI"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Level 1 Priority Vector"
+                      initval="0x00"
+                      name="LVL1VEC"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Vector with High Priority"
+                         mask="0xFF"
+                         name="LVL1VEC"
+                         rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="CRCSCAN" id="math_pdi_crc_v1" name="CRCSCAN">
+         <register-group caption="CRCSCAN" name="CRCSCAN" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable CRC scan" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Enable NMI Trigger" mask="0x02" name="NMIEN" rw="RW"/>
+               <bitfield caption="Reset CRC scan" mask="0x80" name="RESET" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CRC Source"
+                         mask="0x03"
+                         name="SRC"
+                         rw="RW"
+                         values="CRCSCAN_SRC"/>
+            </register>
+            <register caption="Status"
+                      initval="0x02"
+                      name="STATUS"
+                      offset="0x2"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CRC Busy" mask="0x01" name="BUSY" rw="R"/>
+               <bitfield caption="CRC Ok" mask="0x02" name="OK" rw="R"/>
+            </register>
+         </register-group>
+         <value-group caption="CRC Source select" name="CRCSCAN_SRC">
+            <value caption="CRC on entire flash" name="FLASH" value="0x0"/>
+            <value caption="CRC on boot and appl section of flash"
+                   name="BOOTAPP"
+                   value="0x1"/>
+            <value caption="CRC on boot section of flash" name="BOOT" value="0x2"/>
+         </value-group>
+      </module>
+      <module caption="Digital to Analog Converter"
+              id="dac_nbit_ctrl_v5"
+              name="DAC">
+         <register-group caption="Digital to Analog Converter" name="DAC" size="0x4">
+            <register caption="Control Register A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="DAC Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Output Buffer Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTDBY"
+                         rw="RW"/>
+            </register>
+            <register caption="DATA Register"
+                      name="DATA"
+                      offset="0x2"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Data" mask="0xFFC0" name="DATA" rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Event System" id="avrdb" name="EVSYS">
+         <register-group caption="Event System" name="EVSYS" size="0x40">
+            <register caption="Software Event A"
+                      initval="0x00"
+                      name="SWEVENTA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Software event on channel select"
+                         mask="0xFF"
+                         name="SWEVENTA"
+                         rw="W"
+                         values="EVSYS_SWEVENTA"/>
+            </register>
+            <register caption="Multiplexer Channel 0"
+                      initval="0x00"
+                      name="CHANNEL0"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 0 generator select"
+                         mask="0xFF"
+                         name="CHANNEL0"
+                         rw="RW"
+                         values="EVSYS_CHANNEL0"/>
+            </register>
+            <register caption="Multiplexer Channel 1"
+                      initval="0x00"
+                      name="CHANNEL1"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 1 generator select"
+                         mask="0xFF"
+                         name="CHANNEL1"
+                         rw="RW"
+                         values="EVSYS_CHANNEL1"/>
+            </register>
+            <register caption="Multiplexer Channel 2"
+                      initval="0x00"
+                      name="CHANNEL2"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 2 generator select"
+                         mask="0xFF"
+                         name="CHANNEL2"
+                         rw="RW"
+                         values="EVSYS_CHANNEL2"/>
+            </register>
+            <register caption="Multiplexer Channel 3"
+                      initval="0x00"
+                      name="CHANNEL3"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 3 generator select"
+                         mask="0xFF"
+                         name="CHANNEL3"
+                         rw="RW"
+                         values="EVSYS_CHANNEL3"/>
+            </register>
+            <register caption="Multiplexer Channel 4"
+                      initval="0x00"
+                      name="CHANNEL4"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 4 generator select"
+                         mask="0xFF"
+                         name="CHANNEL4"
+                         rw="RW"
+                         values="EVSYS_CHANNEL4"/>
+            </register>
+            <register caption="Multiplexer Channel 5"
+                      initval="0x00"
+                      name="CHANNEL5"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 5 generator select"
+                         mask="0xFF"
+                         name="CHANNEL5"
+                         rw="RW"
+                         values="EVSYS_CHANNEL5"/>
+            </register>
+            <register caption="Multiplexer Channel 6"
+                      initval="0x00"
+                      name="CHANNEL6"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 6 generator select"
+                         mask="0xFF"
+                         name="CHANNEL6"
+                         rw="RW"
+                         values="EVSYS_CHANNEL6"/>
+            </register>
+            <register caption="Multiplexer Channel 7"
+                      initval="0x00"
+                      name="CHANNEL7"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Channel 7 generator select"
+                         mask="0xFF"
+                         name="CHANNEL7"
+                         rw="RW"
+                         values="EVSYS_CHANNEL7"/>
+            </register>
+            <register caption="User 0 - CCL0 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT0A"
+                      offset="0x20"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 1 - CCL0 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT0B"
+                      offset="0x21"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 2 - CCL1 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT1A"
+                      offset="0x22"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 3 - CCL1 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT1B"
+                      offset="0x23"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 4 - CCL2 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT2A"
+                      offset="0x24"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 5 - CCL2 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT2B"
+                      offset="0x25"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 6 - CCL3 Event A"
+                      initval="0x00"
+                      name="USERCCLLUT3A"
+                      offset="0x26"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 7 - CCL3 Event B"
+                      initval="0x00"
+                      name="USERCCLLUT3B"
+                      offset="0x27"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 12 - ADC0"
+                      initval="0x00"
+                      name="USERADC0START"
+                      offset="0x2C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 13 - EVOUTA"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTA"
+                      offset="0x2D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 15 - EVOUTC"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTC"
+                      offset="0x2F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 16 - EVOUTD"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTD"
+                      offset="0x30"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 18 - EVOUTF"
+                      initval="0x00"
+                      name="USEREVSYSEVOUTF"
+                      offset="0x32"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 20 - USART0"
+                      initval="0x00"
+                      name="USERUSART0IRDA"
+                      offset="0x34"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 21 - USART1"
+                      initval="0x00"
+                      name="USERUSART1IRDA"
+                      offset="0x35"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 22 - USART2"
+                      initval="0x00"
+                      name="USERUSART2IRDA"
+                      offset="0x36"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 26 - TCA0 Event A"
+                      initval="0x00"
+                      name="USERTCA0CNTA"
+                      offset="0x3A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 27 - TCA0 Event B"
+                      initval="0x00"
+                      name="USERTCA0CNTB"
+                      offset="0x3B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 30 - TCB0 Event A"
+                      initval="0x00"
+                      name="USERTCB0CAPT"
+                      offset="0x3E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 31 - TCB0 Event B"
+                      initval="0x00"
+                      name="USERTCB0COUNT"
+                      offset="0x3F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 32 - TCB1 Event A"
+                      initval="0x00"
+                      name="USERTCB1CAPT"
+                      offset="0x40"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 33 - TCB1 Event B"
+                      initval="0x00"
+                      name="USERTCB1COUNT"
+                      offset="0x41"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 34 - TCB2 Event A"
+                      initval="0x00"
+                      name="USERTCB2CAPT"
+                      offset="0x42"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 35 - TCB2 Event B"
+                      initval="0x00"
+                      name="USERTCB2COUNT"
+                      offset="0x43"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 40 - TCD0 Event A"
+                      initval="0x00"
+                      name="USERTCD0INPUTA"
+                      offset="0x48"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 41 - TCD0 Event B"
+                      initval="0x00"
+                      name="USERTCD0INPUTB"
+                      offset="0x49"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 42 - OPAMP0 Enable"
+                      initval="0x00"
+                      name="USEROPAMP0ENABLE"
+                      offset="0x4A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 43 - OPAMP0 Disable"
+                      initval="0x00"
+                      name="USEROPAMP0DISABLE"
+                      offset="0x4B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 44 - OPAMP0 Dump"
+                      initval="0x00"
+                      name="USEROPAMP0DUMP"
+                      offset="0x4C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 45 - OPAMP0 Drive"
+                      initval="0x00"
+                      name="USEROPAMP0DRIVE"
+                      offset="0x4D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 46 - OPAMP1 Enable"
+                      initval="0x00"
+                      name="USEROPAMP1ENABLE"
+                      offset="0x4E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 47 - OPAMP1 Disable"
+                      initval="0x00"
+                      name="USEROPAMP1DISABLE"
+                      offset="0x4F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 48 - OPAMP1 Dump"
+                      initval="0x00"
+                      name="USEROPAMP1DUMP"
+                      offset="0x50"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+            <register caption="User 49 - OPAMP1 Drive"
+                      initval="0x00"
+                      name="USEROPAMP1DRIVE"
+                      offset="0x51"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="User channel select"
+                         mask="0xFF"
+                         name="USER"
+                         rw="RW"
+                         values="EVSYS_USER"/>
+            </register>
+         </register-group>
+         <value-group caption="Channel 0 generator select" name="EVSYS_CHANNEL0">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV8192"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV4096"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV2048"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV1024"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="Port A Pin 0" name="PORTA_PIN0" value="0x40"/>
+            <value caption="Port A Pin 1" name="PORTA_PIN1" value="0x41"/>
+            <value caption="Port A Pin 2" name="PORTA_PIN2" value="0x42"/>
+            <value caption="Port A Pin 3" name="PORTA_PIN3" value="0x43"/>
+            <value caption="Port A Pin 4" name="PORTA_PIN4" value="0x44"/>
+            <value caption="Port A Pin 5" name="PORTA_PIN5" value="0x45"/>
+            <value caption="Port A Pin 6" name="PORTA_PIN6" value="0x46"/>
+            <value caption="Port A Pin 7" name="PORTA_PIN7" value="0x47"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 1 generator select" name="EVSYS_CHANNEL1">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV512"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV256"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV128"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV64"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="Port A Pin 0" name="PORTA_PIN0" value="0x40"/>
+            <value caption="Port A Pin 1" name="PORTA_PIN1" value="0x41"/>
+            <value caption="Port A Pin 2" name="PORTA_PIN2" value="0x42"/>
+            <value caption="Port A Pin 3" name="PORTA_PIN3" value="0x43"/>
+            <value caption="Port A Pin 4" name="PORTA_PIN4" value="0x44"/>
+            <value caption="Port A Pin 5" name="PORTA_PIN5" value="0x45"/>
+            <value caption="Port A Pin 6" name="PORTA_PIN6" value="0x46"/>
+            <value caption="Port A Pin 7" name="PORTA_PIN7" value="0x47"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 2 generator select" name="EVSYS_CHANNEL2">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV8192"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV4096"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV2048"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV1024"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="Port C Pin 0" name="PORTC_PIN0" value="0x40"/>
+            <value caption="Port C Pin 1" name="PORTC_PIN1" value="0x41"/>
+            <value caption="Port C Pin 2" name="PORTC_PIN2" value="0x42"/>
+            <value caption="Port C Pin 3" name="PORTC_PIN3" value="0x43"/>
+            <value caption="Port D Pin 1" name="PORTD_PIN1" value="0x49"/>
+            <value caption="Port D Pin 2" name="PORTD_PIN2" value="0x4A"/>
+            <value caption="Port D Pin 3" name="PORTD_PIN3" value="0x4B"/>
+            <value caption="Port D Pin 4" name="PORTD_PIN4" value="0x4C"/>
+            <value caption="Port D Pin 5" name="PORTD_PIN5" value="0x4D"/>
+            <value caption="Port D Pin 6" name="PORTD_PIN6" value="0x4E"/>
+            <value caption="Port D Pin 7" name="PORTD_PIN7" value="0x4F"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 3 generator select" name="EVSYS_CHANNEL3">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV512"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV256"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV128"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV64"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="Port C Pin 0" name="PORTC_PIN0" value="0x40"/>
+            <value caption="Port C Pin 1" name="PORTC_PIN1" value="0x41"/>
+            <value caption="Port C Pin 2" name="PORTC_PIN2" value="0x42"/>
+            <value caption="Port C Pin 3" name="PORTC_PIN3" value="0x43"/>
+            <value caption="Port D Pin 1" name="PORTD_PIN1" value="0x49"/>
+            <value caption="Port D Pin 2" name="PORTD_PIN2" value="0x4A"/>
+            <value caption="Port D Pin 3" name="PORTD_PIN3" value="0x4B"/>
+            <value caption="Port D Pin 4" name="PORTD_PIN4" value="0x4C"/>
+            <value caption="Port D Pin 5" name="PORTD_PIN5" value="0x4D"/>
+            <value caption="Port D Pin 6" name="PORTD_PIN6" value="0x4E"/>
+            <value caption="Port D Pin 7" name="PORTD_PIN7" value="0x4F"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 4 generator select" name="EVSYS_CHANNEL4">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV8192"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV4096"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV2048"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV1024"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="Port F Pin 0" name="PORTF_PIN0" value="0x48"/>
+            <value caption="Port F Pin 1" name="PORTF_PIN1" value="0x49"/>
+            <value caption="Port F Pin 2" name="PORTF_PIN2" value="0x4A"/>
+            <value caption="Port F Pin 3" name="PORTF_PIN3" value="0x4B"/>
+            <value caption="Port F Pin 4" name="PORTF_PIN4" value="0x4C"/>
+            <value caption="Port F Pin 5" name="PORTF_PIN5" value="0x4D"/>
+            <value caption="Port F Pin 6" name="PORTF_PIN6" value="0x4E"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 5 generator select" name="EVSYS_CHANNEL5">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV512"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV256"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV128"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV64"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="Port F Pin 0" name="PORTF_PIN0" value="0x48"/>
+            <value caption="Port F Pin 1" name="PORTF_PIN1" value="0x49"/>
+            <value caption="Port F Pin 2" name="PORTF_PIN2" value="0x4A"/>
+            <value caption="Port F Pin 3" name="PORTF_PIN3" value="0x4B"/>
+            <value caption="Port F Pin 4" name="PORTF_PIN4" value="0x4C"/>
+            <value caption="Port F Pin 5" name="PORTF_PIN5" value="0x4D"/>
+            <value caption="Port F Pin 6" name="PORTF_PIN6" value="0x4E"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 6 generator select" name="EVSYS_CHANNEL6">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV8192"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV4096"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV2048"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV1024"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Channel 7 generator select" name="EVSYS_CHANNEL7">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="UPDI SYNCH character" name="UPDI_SYNCH" value="0x1"/>
+            <value caption="MVIO VDDIO2 OK" name="MVIO" value="0x5"/>
+            <value caption="Real Time Counter overflow" name="RTC_OVF" value="0x6"/>
+            <value caption="Real Time Counter compare" name="RTC_CMP" value="0x7"/>
+            <value caption="Periodic Interrupt Timer output 0"
+                   name="RTC_PIT_DIV512"
+                   value="0x8"/>
+            <value caption="Periodic Interrupt Timer output 1"
+                   name="RTC_PIT_DIV256"
+                   value="0x9"/>
+            <value caption="Periodic Interrupt Timer output 2"
+                   name="RTC_PIT_DIV128"
+                   value="0xA"/>
+            <value caption="Periodic Interrupt Timer output 3"
+                   name="RTC_PIT_DIV64"
+                   value="0xB"/>
+            <value caption="Configurable Custom Logic LUT0"
+                   name="CCL_LUT0"
+                   value="0x10"/>
+            <value caption="Configurable Custom Logic LUT1"
+                   name="CCL_LUT1"
+                   value="0x11"/>
+            <value caption="Configurable Custom Logic LUT2"
+                   name="CCL_LUT2"
+                   value="0x12"/>
+            <value caption="Configurable Custom Logic LUT3"
+                   name="CCL_LUT3"
+                   value="0x13"/>
+            <value caption="Analog Comparator 0 out" name="AC0_OUT" value="0x20"/>
+            <value caption="Analog Comparator 1 out" name="AC1_OUT" value="0x21"/>
+            <value caption="Analog Comparator 2 out" name="AC2_OUT" value="0x22"/>
+            <value caption="ADC 0 Result Ready" name="ADC0_RESRDY" value="0x24"/>
+            <value caption="Zero Cross Detect 0 out" name="ZCD0" value="0x30"/>
+            <value caption="OPAMP0 Ready" name="OPAMP0_READY" value="0x34"/>
+            <value caption="OPAMP1 Ready" name="OPAMP1_READY" value="0x35"/>
+            <value caption="USART 0 XCK" name="USART0_XCK" value="0x60"/>
+            <value caption="USART 1 XCK" name="USART1_XCK" value="0x61"/>
+            <value caption="USART 2 XCK" name="USART2_XCK" value="0x62"/>
+            <value caption="SPI 0 SCK" name="SPI0_SCK" value="0x68"/>
+            <value caption="SPI 1 SCK" name="SPI1_SCK" value="0x69"/>
+            <value caption="Timer/Counter A0 overflow / low byte timer underflow"
+                   name="TCA0_OVF_LUNF"
+                   value="0x80"/>
+            <value caption="Timer/Counter A0 high byte timer underflow"
+                   name="TCA0_HUNF"
+                   value="0x81"/>
+            <value caption="Timer/Counter A0 compare 0 / low byte timer compare 0"
+                   name="TCA0_CMP0_LCMP0"
+                   value="0x84"/>
+            <value caption="Timer/Counter A0 compare 1 / low byte timer compare 1"
+                   name="TCA0_CMP1_LCMP1"
+                   value="0x85"/>
+            <value caption="Timer/Counter A0 compare 2 / low byte timer compare 2"
+                   name="TCA0_CMP2_LCMP2"
+                   value="0x86"/>
+            <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+            <value caption="Timer/Counter B0 overflow" name="TCB0_OVF" value="0xA1"/>
+            <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+            <value caption="Timer/Counter B1 overflow" name="TCB1_OVF" value="0xA3"/>
+            <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+            <value caption="Timer/Counter B2 overflow" name="TCB2_OVF" value="0xA5"/>
+            <value caption="Timer/Counter D0 event 0" name="TCD0_CMPBCLR" value="0xB0"/>
+            <value caption="Timer/Counter D0 event 1" name="TCD0_CMPASET" value="0xB1"/>
+            <value caption="Timer/Counter D0 event 2" name="TCD0_CMPBSET" value="0xB2"/>
+            <value caption="Timer/Counter D0 event 3" name="TCD0_PROGEV" value="0xB3"/>
+         </value-group>
+         <value-group caption="Software event on channel select" name="EVSYS_SWEVENTA">
+            <value caption="Software event on channel 0" name="CH0" value="0x01"/>
+            <value caption="Software event on channel 1" name="CH1" value="0x02"/>
+            <value caption="Software event on channel 2" name="CH2" value="0x04"/>
+            <value caption="Software event on channel 3" name="CH3" value="0x08"/>
+            <value caption="Software event on channel 4" name="CH4" value="0x10"/>
+            <value caption="Software event on channel 5" name="CH5" value="0x20"/>
+            <value caption="Software event on channel 6" name="CH6" value="0x40"/>
+            <value caption="Software event on channel 7" name="CH7" value="0x80"/>
+         </value-group>
+         <value-group caption="User channel select" name="EVSYS_USER">
+            <value caption="Off" name="OFF" value="0x0"/>
+            <value caption="Connect user to event channel 0"
+                   name="CHANNEL0"
+                   value="0x1"/>
+            <value caption="Connect user to event channel 1"
+                   name="CHANNEL1"
+                   value="0x2"/>
+            <value caption="Connect user to event channel 2"
+                   name="CHANNEL2"
+                   value="0x3"/>
+            <value caption="Connect user to event channel 3"
+                   name="CHANNEL3"
+                   value="0x4"/>
+            <value caption="Connect user to event channel 4"
+                   name="CHANNEL4"
+                   value="0x5"/>
+            <value caption="Connect user to event channel 5"
+                   name="CHANNEL5"
+                   value="0x6"/>
+            <value caption="Connect user to event channel 6"
+                   name="CHANNEL6"
+                   value="0x7"/>
+            <value caption="Connect user to event channel 7"
+                   name="CHANNEL7"
+                   value="0x8"/>
+         </value-group>
+      </module>
+      <module caption="Fuses" id="avrdb" name="FUSE">
+         <register-group caption="Fuses" name="FUSE" size="0x09">
+            <register caption="Watchdog Configuration"
+                      initval="0x00"
+                      name="WDTCFG"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Watchdog Timeout Period"
+                         mask="0x0F"
+                         name="PERIOD"
+                         rw="RW"
+                         values="FUSE_PERIOD"/>
+               <bitfield caption="Watchdog Window Timeout Period"
+                         mask="0xF0"
+                         name="WINDOW"
+                         rw="RW"
+                         values="FUSE_WINDOW"/>
+            </register>
+            <register caption="BOD Configuration"
+                      initval="0x00"
+                      name="BODCFG"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="BOD Operation in Sleep Mode"
+                         mask="0x03"
+                         name="SLEEP"
+                         rw="RW"
+                         values="FUSE_SLEEP"/>
+               <bitfield caption="BOD Operation in Active Mode"
+                         mask="0x0C"
+                         name="ACTIVE"
+                         rw="RW"
+                         values="FUSE_ACTIVE"/>
+               <bitfield caption="BOD Sample Frequency"
+                         mask="0x10"
+                         name="SAMPFREQ"
+                         rw="RW"
+                         values="FUSE_SAMPFREQ"/>
+               <bitfield caption="BOD Level"
+                         mask="0xE0"
+                         name="LVL"
+                         rw="RW"
+                         values="FUSE_LVL"/>
+            </register>
+            <register caption="Oscillator Configuration"
+                      initval="0x00"
+                      name="OSCCFG"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Frequency Select"
+                         mask="0x07"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="FUSE_CLKSEL"/>
+            </register>
+            <register caption="System Configuration 0"
+                      initval="0xC0"
+                      name="SYSCFG0"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Save" mask="0x01" name="EESAVE" rw="RW"/>
+               <bitfield caption="Reset Pin Configuration"
+                         mask="0x0C"
+                         name="RSTPINCFG"
+                         rw="RW"
+                         values="FUSE_RSTPINCFG"/>
+               <bitfield caption="CRC Select"
+                         mask="0x20"
+                         name="CRCSEL"
+                         rw="RW"
+                         values="FUSE_CRCSEL"/>
+               <bitfield caption="CRC Source"
+                         mask="0xC0"
+                         name="CRCSRC"
+                         rw="RW"
+                         values="FUSE_CRCSRC"/>
+            </register>
+            <register caption="System Configuration 1"
+                      initval="0x08"
+                      name="SYSCFG1"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Startup Time"
+                         mask="0x07"
+                         name="SUT"
+                         rw="RW"
+                         values="FUSE_SUT"/>
+               <bitfield caption="MVIO System Configuration"
+                         mask="0x18"
+                         name="MVSYSCFG"
+                         rw="RW"
+                         values="FUSE_MVSYSCFG"/>
+            </register>
+            <register caption="Code Section Size"
+                      initval="0x00"
+                      name="CODESIZE"
+                      offset="0x7"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Boot Section Size"
+                      initval="0x00"
+                      name="BOOTSIZE"
+                      offset="0x8"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+         <value-group caption="BOD Operation in Active Mode select" name="FUSE_ACTIVE">
+            <value caption="BOD disabled" name="DISABLE" value="0x00"/>
+            <value caption="BOD enabled in continuous mode" name="ENABLE" value="0x01"/>
+            <value caption="BOD enabled in sampled mode" name="SAMPLE" value="0x02"/>
+            <value caption="BOD enabled in continuous mode. Execution is halted at wake-up until BOD is running."
+                   name="ENABLEWAIT"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="BOD Level select" name="FUSE_LVL">
+            <value caption="1.9V" name="BODLEVEL0" value="0x00"/>
+            <value caption="2.45V" name="BODLEVEL1" value="0x01"/>
+            <value caption="2.7V" name="BODLEVEL2" value="0x02"/>
+            <value caption="2.85V" name="BODLEVEL3" value="0x03"/>
+         </value-group>
+         <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
+            <value caption="Sample frequency is 128 Hz" name="128Hz" value="0x0"/>
+            <value caption="Sample frequency is 32 Hz" name="32Hz" value="0x1"/>
+         </value-group>
+         <value-group caption="BOD Operation in Sleep Mode select" name="FUSE_SLEEP">
+            <value caption="BOD disabled" name="DISABLE" value="0x00"/>
+            <value caption="BOD enabled in continuous mode" name="ENABLE" value="0x01"/>
+            <value caption="BOD enabled in sampled mode" name="SAMPLE" value="0x02"/>
+         </value-group>
+         <value-group caption="Frequency Select" name="FUSE_CLKSEL">
+            <value caption="1-32MHz internal oscillator" name="OSCHF" value="0x0"/>
+            <value caption="32.768kHz internal oscillator" name="OSC32K" value="0x1"/>
+         </value-group>
+         <value-group caption="CRC Select" name="FUSE_CRCSEL">
+            <value caption="Enable CRC16" name="CRC16" value="0x0"/>
+            <value caption="Enable CRC32" name="CRC32" value="0x1"/>
+         </value-group>
+         <value-group caption="CRC Source select" name="FUSE_CRCSRC">
+            <value caption="CRC of full Flash (boot, application code and application data)"
+                   name="FLASH"
+                   value="0x0"/>
+            <value caption="CRC of boot section" name="BOOT" value="0x1"/>
+            <value caption="CRC of application code and boot sections"
+                   name="BOOTAPP"
+                   value="0x2"/>
+            <value caption="No CRC" name="NOCRC" value="0x3"/>
+         </value-group>
+         <value-group caption="Reset Pin Configuration select" name="FUSE_RSTPINCFG">
+            <value caption="GPIO mode" name="GPIO" value="0x0"/>
+            <value caption="Reset mode" name="RST" value="0x2"/>
+         </value-group>
+         <value-group caption="MVIO System Configuration select" name="FUSE_MVSYSCFG">
+            <value caption="Device used in a dual supply configuration"
+                   name="DUAL"
+                   value="0x1"/>
+            <value caption="Device used in a single supply configuration"
+                   name="SINGLE"
+                   value="0x2"/>
+         </value-group>
+         <value-group caption="Startup Time select" name="FUSE_SUT">
+            <value caption="0 ms" name="0MS" value="0x00"/>
+            <value caption="1 ms" name="1MS" value="0x01"/>
+            <value caption="2 ms" name="2MS" value="0x02"/>
+            <value caption="4 ms" name="4MS" value="0x03"/>
+            <value caption="8 ms" name="8MS" value="0x04"/>
+            <value caption="16 ms" name="16MS" value="0x05"/>
+            <value caption="32 ms" name="32MS" value="0x06"/>
+            <value caption="64 ms" name="64MS" value="0x07"/>
+         </value-group>
+         <value-group caption="Watchdog Timeout Period select" name="FUSE_PERIOD">
+            <value caption="Watch-Dog timer Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.0s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.0s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+         <value-group caption="Watchdog Window Timeout Period select" name="FUSE_WINDOW">
+            <value caption="Window mode off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.0s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.0s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+      </module>
+      <module caption="General Purpose Registers" id="avrdb" name="GPR">
+         <register-group caption="General Purpose Registers" name="GPR" size="0x4">
+            <register caption="General Purpose Register 0"
+                      name="GPR0"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 1"
+                      name="GPR1"
+                      offset="0x1"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 2"
+                      name="GPR2"
+                      offset="0x2"
+                      rw="RW"
+                      size="1"/>
+            <register caption="General Purpose Register 3"
+                      name="GPR3"
+                      offset="0x3"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Lockbits" id="avrdb" name="LOCK">
+         <register-group caption="Lockbits" name="LOCK" size="0x4">
+            <register caption="Lock Key Bits"
+                      initval="0x5CC5C55C"
+                      name="KEY"
+                      offset="0x0"
+                      rw="RW"
+                      size="4">
+               <bitfield caption="Lock Key"
+                         mask="0xFFFFFFFF"
+                         name="KEY"
+                         rw="RW"
+                         values="LOCK_KEY"/>
+            </register>
+         </register-group>
+         <value-group caption="Lock Key select" name="LOCK_KEY">
+            <value caption="No locks" name="NOLOCK" value="0x5CC5C55C"/>
+            <value caption="Read and write lock" name="RWLOCK" value="0xA33A3AA3"/>
+         </value-group>
+      </module>
+      <module caption="Multi-Voltage I/O" id="io_multiv_ctrl_avr_v1" name="MVIO">
+         <register-group caption="Multi-Voltage I/O" name="MVIO" size="0x4">
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="VDDIO2 Interrupt Enable"
+                         mask="0x01"
+                         name="VDDIO2IE"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="VDDIO2 Interrupt Flag"
+                         mask="0x01"
+                         name="VDDIO2IF"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x2"
+                      rw="R"
+                      size="1">
+               <bitfield caption="VDDIO2 Status" mask="0x01" name="VDDIO2S" rw="R"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Non-volatile Memory Controller"
+              id="nvm_ctrl_avr_v1"
+              name="NVMCTRL">
+         <register-group caption="Non-volatile Memory Controller" name="NVMCTRL" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x7F"
+                         name="CMD"
+                         rw="RW"
+                         values="NVMCTRL_CMD"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x30"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Application Code Write Protect"
+                         mask="0x01"
+                         name="APPCODEWP"
+                         rw="RW"/>
+               <bitfield caption="Boot Read Protect" mask="0x02" name="BOOTRP" rw="RW"/>
+               <bitfield caption="Application Data Write Protect"
+                         mask="0x04"
+                         name="APPDATAWP"
+                         rw="RW"/>
+               <bitfield caption="Flash Mapping in Data space"
+                         mask="0x30"
+                         name="FLMAP"
+                         rw="RW"
+                         values="NVMCTRL_FLMAP"/>
+               <bitfield caption="Flash Mapping Lock"
+                         mask="0x80"
+                         name="FLMAPLOCK"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x02"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Flash busy" mask="0x01" name="FBUSY" rw="R"/>
+               <bitfield caption="EEPROM busy" mask="0x02" name="EEBUSY" rw="R"/>
+               <bitfield caption="Write error"
+                         mask="0x70"
+                         name="ERROR"
+                         rw="R"
+                         values="NVMCTRL_ERROR"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Ready" mask="0x01" name="EEREADY" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="EEPROM Ready" mask="0x01" name="EEREADY" rw="RW"/>
+            </register>
+            <register caption="Data" name="DATA" offset="0x06" rw="RW" size="2"/>
+            <register caption="Address"
+                      name="ADDR"
+                      offset="0x08"
+                      rw="RW"
+                      size="4"/>
+         </register-group>
+         <value-group caption="Command select" name="NVMCTRL_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="No Operation" name="NOOP" value="0x01"/>
+            <value caption="Flash Write" name="FLWR" value="0x02"/>
+            <value caption="Flash Page Erase" name="FLPER" value="0x08"/>
+            <value caption="Flash Multi-Page Erase 2 pages"
+                   name="FLMPER2"
+                   value="0x09"/>
+            <value caption="Flash Multi-Page Erase 4 pages"
+                   name="FLMPER4"
+                   value="0x0A"/>
+            <value caption="Flash Multi-Page Erase 8 pages"
+                   name="FLMPER8"
+                   value="0x0B"/>
+            <value caption="Flash Multi-Page Erase 16 pages"
+                   name="FLMPER16"
+                   value="0x0C"/>
+            <value caption="Flash Multi-Page Erase 32 pages"
+                   name="FLMPER32"
+                   value="0x0D"/>
+            <value caption="EEPROM Write" name="EEWR" value="0x12"/>
+            <value caption="EEPROM Erase and Write" name="EEERWR" value="0x13"/>
+            <value caption="EEPROM Byte Erase" name="EEBER" value="0x18"/>
+            <value caption="EEPROM Multi-Byte Erase 2 bytes"
+                   name="EEMBER2"
+                   value="0x19"/>
+            <value caption="EEPROM Multi-Byte Erase 4 bytes"
+                   name="EEMBER4"
+                   value="0x1A"/>
+            <value caption="EEPROM Multi-Byte Erase 8 bytes"
+                   name="EEMBER8"
+                   value="0x1B"/>
+            <value caption="EEPROM Multi-Byte Erase 16 bytes"
+                   name="EEMBER16"
+                   value="0x1C"/>
+            <value caption="EEPROM Multi-Byte Erase 32 bytes"
+                   name="EEMBER32"
+                   value="0x1D"/>
+            <value caption="Chip Erase Command" name="CHER" value="0x20"/>
+            <value caption="EEPROM Erase Command" name="EECHER" value="0x30"/>
+         </value-group>
+         <value-group caption="Flash Mapping in Data space select" name="NVMCTRL_FLMAP">
+            <value caption="Flash section 0" name="SECTION0" value="0x0"/>
+            <value caption="Flash section 1" name="SECTION1" value="0x1"/>
+            <value caption="Flash section 2" name="SECTION2" value="0x2"/>
+            <value caption="Flash section 3" name="SECTION3" value="0x3"/>
+         </value-group>
+         <value-group caption="Write error select" name="NVMCTRL_ERROR">
+            <value caption="No Error" name="NOERROR" value="0x0"/>
+            <value caption="Write command not selected" name="ILLEGALCMD" value="0x1"/>
+            <value caption="Write to section not allowed"
+                   name="ILLEGALSADDR"
+                   value="0x2"/>
+            <value caption="Selecting new write command while write command already seleted"
+                   name="DOUBLESELECT"
+                   value="0x3"/>
+            <value caption="Starting a new programming operation before previous is completed"
+                   name="ONGOINGPROG"
+                   value="0x4"/>
+         </value-group>
+      </module>
+      <module caption="Operational Amplifier System"
+              id="amp_opamp_ctrl_avr_v1"
+              name="OPAMP">
+         <register-group caption="Operational Amplifier System" name="OPAMP" size="0x40">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Op Amp System Enable"
+                         mask="0x01"
+                         name="ENABLE"
+                         rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in Debug Mode" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Timebase Value"
+                      initval="0x01"
+                      name="TIMEBASE"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Timebase Value" mask="0x7F" name="TIMEBASE" rw="RW"/>
+            </register>
+            <register caption="Power Control"
+                      initval="0x00"
+                      name="PWRCTRL"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input Range Select"
+                         mask="0x01"
+                         name="IRSEL"
+                         rw="RW"
+                         values="OPAMP_IRSEL"/>
+            </register>
+            <register caption="Op Amp 0 Control A"
+                      initval="0x00"
+                      name="OP0CTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Always On" mask="0x01" name="ALWAYSON" rw="RW"/>
+               <bitfield caption="Enable Events" mask="0x02" name="EVENTEN" rw="RW"/>
+               <bitfield caption="Output Mode"
+                         mask="0x0C"
+                         name="OUTMODE"
+                         rw="RW"
+                         values="OPAMP_OUTMODE"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTBY"
+                         rw="RW"/>
+            </register>
+            <register caption="Op Amp 0 Status"
+                      initval="0x00"
+                      name="OP0STATUS"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Settled" mask="0x01" name="SETTLED" rw="R"/>
+            </register>
+            <register caption="Op Amp 0 Resistor Ladder Multiplexer"
+                      initval="0x00"
+                      name="OP0RESMUX"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Multiplexer Top"
+                         mask="0x03"
+                         name="MUXTOP"
+                         rw="RW"
+                         values="OPAMP_MUXTOP"/>
+               <bitfield caption="Multiplexer Bottom"
+                         mask="0x1C"
+                         name="MUXBOT"
+                         rw="RW"
+                         values="OPAMP_MUXBOT"/>
+               <bitfield caption="Multiplexer Wiper selector"
+                         mask="0xE0"
+                         name="MUXWIP"
+                         rw="RW"
+                         values="OPAMP_MUXWIP"/>
+            </register>
+            <register caption="Op Amp 0 Input Multiplexer"
+                      initval="0x00"
+                      name="OP0INMUX"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Positive Input Multiplexer"
+                         mask="0x07"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="OPAMP_OP0_MUXPOS"/>
+               <bitfield caption="Negative Input Multiplexer"
+                         mask="0x70"
+                         name="MUXNEG"
+                         rw="RW"
+                         values="OPAMP_MUXNEG"/>
+            </register>
+            <register caption="Op Amp 0 Settle"
+                      initval="0x00"
+                      name="OP0SETTLE"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Settle Time" mask="0x7F" name="SETTLE" rw="RW"/>
+            </register>
+            <register caption="Op Amp 0 Calibration"
+                      name="OP0CAL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Calibration (for input offset voltage)"
+                         mask="0xFF"
+                         name="CAL"
+                         rw="RW"/>
+            </register>
+            <register caption="Op Amp 1 Control A"
+                      initval="0x00"
+                      name="OP1CTRLA"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Always On" mask="0x01" name="ALWAYSON" rw="RW"/>
+               <bitfield caption="Enable Events" mask="0x02" name="EVENTEN" rw="RW"/>
+               <bitfield caption="Output Mode"
+                         mask="0x0C"
+                         name="OUTMODE"
+                         rw="RW"
+                         values="OPAMP_OUTMODE"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTBY"
+                         rw="RW"/>
+            </register>
+            <register caption="Op Amp 1 Status"
+                      initval="0x00"
+                      name="OP1STATUS"
+                      offset="0x19"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Settled" mask="0x01" name="SETTLED" rw="R"/>
+            </register>
+            <register caption="Op Amp 1 Resistor Ladder Multiplexer"
+                      initval="0x00"
+                      name="OP1RESMUX"
+                      offset="0x1A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Multiplexer Top"
+                         mask="0x03"
+                         name="MUXTOP"
+                         rw="RW"
+                         values="OPAMP_MUXTOP"/>
+               <bitfield caption="Multiplexer Bottom"
+                         mask="0x1C"
+                         name="MUXBOT"
+                         rw="RW"
+                         values="OPAMP_MUXBOT"/>
+               <bitfield caption="Multiplexer Wiper selector"
+                         mask="0xE0"
+                         name="MUXWIP"
+                         rw="RW"
+                         values="OPAMP_MUXWIP"/>
+            </register>
+            <register caption="Op Amp 1 Input Multiplexer"
+                      initval="0x00"
+                      name="OP1INMUX"
+                      offset="0x1B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Positive Input Multiplexer"
+                         mask="0x07"
+                         name="MUXPOS"
+                         rw="RW"
+                         values="OPAMP_OP1_MUXPOS"/>
+               <bitfield caption="Negative Input Multiplexer"
+                         mask="0x70"
+                         name="MUXNEG"
+                         rw="RW"
+                         values="OPAMP_MUXNEG"/>
+            </register>
+            <register caption="Op Amp 1 Settle"
+                      initval="0x00"
+                      name="OP1SETTLE"
+                      offset="0x1C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Settle Time" mask="0x7F" name="SETTLE" rw="RW"/>
+            </register>
+            <register caption="Op Amp 1 Calibration"
+                      name="OP1CAL"
+                      offset="0x1D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Calibration (for input offset voltage)"
+                         mask="0xFF"
+                         name="CAL"
+                         rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Output Mode select" name="OPAMP_OUTMODE">
+            <value caption="Output Driver Off" name="OFF" value="0x0"/>
+            <value caption="Output Driver in Normal Mode" name="NORMAL" value="0x1"/>
+         </value-group>
+         <value-group caption="Negative Input Multiplexer select" name="OPAMP_MUXNEG">
+            <value caption="Negative input pin for OPn" name="INN" value="0x0"/>
+            <value caption="Wiper from OPn's resistor ladder" name="WIP" value="0x1"/>
+            <value caption="OPn output (unity gain)" name="OUT" value="0x2"/>
+            <value caption="DAC output" name="DAC" value="0x3"/>
+         </value-group>
+         <value-group caption="Positive Input Multiplexer select" name="OPAMP_OP0_MUXPOS">
+            <value caption="Positive input pin for OPn" name="INP" value="0x0"/>
+            <value caption="Wiper from OPn's resistor ladder" name="WIP" value="0x1"/>
+            <value caption="DAC output" name="DAC" value="0x2"/>
+            <value caption="Ground" name="GND" value="0x3"/>
+            <value caption="VDD/2" name="VDDDIV2" value="0x4"/>
+         </value-group>
+         <value-group caption="Positive Input Multiplexer select" name="OPAMP_OP1_MUXPOS">
+            <value caption="Positive input pin for OPn" name="INP" value="0x0"/>
+            <value caption="Wiper from OPn's resistor ladder" name="WIP" value="0x1"/>
+            <value caption="DAC output" name="DAC" value="0x2"/>
+            <value caption="Ground" name="GND" value="0x3"/>
+            <value caption="VDD/2" name="VDDDIV2" value="0x4"/>
+            <value caption="Output from OP0" name="LINKOUT" value="0x5"/>
+         </value-group>
+         <value-group caption="Multiplexer Bottom select" name="OPAMP_MUXBOT">
+            <value caption="Multiplexer off" name="OFF" value="0x0"/>
+            <value caption="Positive input pin for OPn" name="INP" value="0x1"/>
+            <value caption="Negative input pin for OPn" name="INN" value="0x2"/>
+            <value caption="DAC output" name="DAC" value="0x3"/>
+            <value caption="Link OP[n-1] output" name="LINKOUT" value="0x4"/>
+            <value caption="Ground" name="GND" value="0x5"/>
+         </value-group>
+         <value-group caption="Multiplexer Top select" name="OPAMP_MUXTOP">
+            <value caption="Multiplexer off" name="OFF" value="0x0"/>
+            <value caption="OPn output" name="OUT" value="0x1"/>
+            <value caption="VDD" name="VDD" value="0x2"/>
+         </value-group>
+         <value-group caption="Multiplexer Wiper selector" name="OPAMP_MUXWIP">
+            <value caption="R1 = 15R, R2 = 1R, R2/R1 = 0.07" name="WIP0" value="0x0"/>
+            <value caption="R1 = 14R, R2 = 2R, R2/R1 = 0.14" name="WIP1" value="0x1"/>
+            <value caption="R1 = 12R, R2 = 4R, R2/R1 = 0.33" name="WIP2" value="0x2"/>
+            <value caption="R1 = 8R, R2 = 8R, R2/R1 = 1" name="WIP3" value="0x3"/>
+            <value caption="R1 = 6R, R2 = 10R, R2/R1 = 1.67" name="WIP4" value="0x4"/>
+            <value caption="R1 = 4R, R2 = 12R, R2/R1 = 3" name="WIP5" value="0x5"/>
+            <value caption="R1 = 2R, R2 = 14R, R2/R1 = 7" name="WIP6" value="0x6"/>
+            <value caption="R1 = 1R, R2 = 15R, R2/R1 = 15" name="WIP7" value="0x7"/>
+         </value-group>
+         <value-group caption="Input Range Select" name="OPAMP_IRSEL">
+            <value caption="Full Input Range" name="FULL" value="0x0"/>
+            <value caption="Reduced Input Range" name="REDUCED" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="I/O Ports" id="gpio_ports_avr_v2_port" name="PORT">
+         <register-group caption="I/O Ports" name="PORT" size="0x20">
+            <register caption="Data Direction"
+                      name="DIR"
+                      offset="0x00"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Set"
+                      name="DIRSET"
+                      offset="0x01"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Clear"
+                      name="DIRCLR"
+                      offset="0x02"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Data Direction Toggle"
+                      name="DIRTGL"
+                      offset="0x03"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value"
+                      name="OUT"
+                      offset="0x04"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Set"
+                      name="OUTSET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Clear"
+                      name="OUTCLR"
+                      offset="0x06"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value Toggle"
+                      name="OUTTGL"
+                      offset="0x07"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Input Value"
+                      name="IN"
+                      offset="0x08"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin Interrupt Flag" mask="0xFF" name="INT" rw="RW"/>
+            </register>
+            <register caption="Port Control"
+                      initval="0x00"
+                      name="PORTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Slew Rate Limit Enable" mask="0x01" name="SRL" rw="RW"/>
+            </register>
+            <register caption="Pin Control Config"
+                      initval="0x00"
+                      name="PINCONFIG"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin Control Update"
+                      initval="0x00"
+                      name="PINCTRLUPD"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin control update mask"
+                         mask="0xFF"
+                         name="PINCTRLUPD"
+                         rw="RW"/>
+            </register>
+            <register caption="Pin Control Set"
+                      initval="0x00"
+                      name="PINCTRLSET"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin control set mask"
+                         mask="0xFF"
+                         name="PINCTRLSET"
+                         rw="RW"/>
+            </register>
+            <register caption="Pin Control Clear"
+                      initval="0x00"
+                      name="PINCTRLCLR"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin control clear mask"
+                         mask="0xFF"
+                         name="PINCTRLCLR"
+                         rw="RW"/>
+            </register>
+            <register caption="Pin 0 Control"
+                      initval="0x00"
+                      name="PIN0CTRL"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 1 Control"
+                      initval="0x00"
+                      name="PIN1CTRL"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 2 Control"
+                      initval="0x00"
+                      name="PIN2CTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 3 Control"
+                      initval="0x00"
+                      name="PIN3CTRL"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 4 Control"
+                      initval="0x00"
+                      name="PIN4CTRL"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 5 Control"
+                      initval="0x00"
+                      name="PIN5CTRL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 6 Control"
+                      initval="0x00"
+                      name="PIN6CTRL"
+                      offset="0x16"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+            <register caption="Pin 7 Control"
+                      initval="0x00"
+                      name="PIN7CTRL"
+                      offset="0x17"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input/Sense Configuration"
+                         mask="0x07"
+                         name="ISC"
+                         rw="RW"
+                         values="PORT_ISC"/>
+               <bitfield caption="Pullup enable" mask="0x08" name="PULLUPEN" rw="RW"/>
+               <bitfield caption="Input level select" mask="0x40" name="INLVL" rw="RW"/>
+               <bitfield caption="Inverted I/O Enable" mask="0x80" name="INVEN" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Input/Sense Configuration select" name="PORT_ISC">
+            <value caption="Interrupt disabled but input buffer enabled"
+                   name="INTDISABLE"
+                   value="0x0"/>
+            <value caption="Sense Both Edges" name="BOTHEDGES" value="0x1"/>
+            <value caption="Sense Rising Edge" name="RISING" value="0x2"/>
+            <value caption="Sense Falling Edge" name="FALLING" value="0x3"/>
+            <value caption="Digital Input Buffer disabled"
+                   name="INPUT_DISABLE"
+                   value="0x4"/>
+            <value caption="Sense low Level" name="LEVEL" value="0x5"/>
+         </value-group>
+      </module>
+      <module caption="Port Multiplexer" id="avrdb" name="PORTMUX">
+         <register-group caption="Port Multiplexer" name="PORTMUX" size="0x10">
+            <register caption="EVSYS route A"
+                      initval="0x00"
+                      name="EVSYSROUTEA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Output A"
+                         mask="0x01"
+                         name="EVOUTA"
+                         rw="RW"
+                         values="PORTMUX_EVOUTA"/>
+               <bitfield caption="Event Output C"
+                         mask="0x04"
+                         name="EVOUTC"
+                         rw="RW"
+                         values="PORTMUX_EVOUTC"/>
+               <bitfield caption="Event Output D"
+                         mask="0x08"
+                         name="EVOUTD"
+                         rw="RW"
+                         values="PORTMUX_EVOUTD"/>
+               <bitfield caption="Event Output F"
+                         mask="0x20"
+                         name="EVOUTF"
+                         rw="RW"
+                         values="PORTMUX_EVOUTF"/>
+            </register>
+            <register caption="CCL route A"
+                      initval="0x00"
+                      name="CCLROUTEA"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="CCL Look-Up Table 0 Signals"
+                         mask="0x01"
+                         name="LUT0"
+                         rw="RW"
+                         values="PORTMUX_LUT0"/>
+               <bitfield caption="CCL Look-Up Table 1 Signals"
+                         mask="0x02"
+                         name="LUT1"
+                         rw="RW"
+                         values="PORTMUX_LUT1"/>
+               <bitfield caption="CCL Look-Up Table 2 Signals"
+                         mask="0x04"
+                         name="LUT2"
+                         rw="RW"
+                         values="PORTMUX_LUT2"/>
+               <bitfield caption="CCL Look-Up Table 3 Signals"
+                         mask="0x08"
+                         name="LUT3"
+                         rw="RW"
+                         values="PORTMUX_LUT3"/>
+            </register>
+            <register caption="USART route A"
+                      initval="0x00"
+                      name="USARTROUTEA"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="USART0 Signals"
+                         mask="0x03"
+                         name="USART0"
+                         rw="RW"
+                         values="PORTMUX_USART0"/>
+               <bitfield caption="USART1 Signals"
+                         mask="0x0C"
+                         name="USART1"
+                         rw="RW"
+                         values="PORTMUX_USART1"/>
+               <bitfield caption="USART2 Signals"
+                         mask="0x30"
+                         name="USART2"
+                         rw="RW"
+                         values="PORTMUX_USART2"/>
+            </register>
+            <register caption="SPI route A"
+                      initval="0x00"
+                      name="SPIROUTEA"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SPI0 Signals"
+                         mask="0x03"
+                         name="SPI0"
+                         rw="RW"
+                         values="PORTMUX_SPI0"/>
+               <bitfield caption="SPI1 Signals"
+                         mask="0x0C"
+                         name="SPI1"
+                         rw="RW"
+                         values="PORTMUX_SPI1"/>
+            </register>
+            <register caption="TWI route A"
+                      initval="0x00"
+                      name="TWIROUTEA"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TWI0 Signals"
+                         mask="0x03"
+                         name="TWI0"
+                         rw="RW"
+                         values="PORTMUX_TWI0"/>
+               <bitfield caption="TWI1 Signals"
+                         mask="0x0C"
+                         name="TWI1"
+                         rw="RW"
+                         values="PORTMUX_TWI1"/>
+            </register>
+            <register caption="TCA route A"
+                      initval="0x00"
+                      name="TCAROUTEA"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCA0 Signals"
+                         mask="0x07"
+                         name="TCA0"
+                         rw="RW"
+                         values="PORTMUX_TCA0"/>
+            </register>
+            <register caption="TCB route A"
+                      initval="0x00"
+                      name="TCBROUTEA"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCB0 Output"
+                         mask="0x01"
+                         name="TCB0"
+                         rw="RW"
+                         values="PORTMUX_TCB0"/>
+               <bitfield caption="TCB1 Output"
+                         mask="0x02"
+                         name="TCB1"
+                         rw="RW"
+                         values="PORTMUX_TCB1"/>
+               <bitfield caption="TCB2 Output"
+                         mask="0x04"
+                         name="TCB2"
+                         rw="RW"
+                         values="PORTMUX_TCB2"/>
+            </register>
+            <register caption="TCD route A"
+                      initval="0x00"
+                      name="TCDROUTEA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="TCD0 Signals"
+                         mask="0x07"
+                         name="TCD0"
+                         rw="RW"
+                         values="PORTMUX_TCD0"/>
+            </register>
+            <register caption="AC route A"
+                      initval="0x00"
+                      name="ACROUTEA"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Analog Comparator 0 Output"
+                         mask="0x01"
+                         name="AC0"
+                         rw="RW"
+                         values="PORTMUX_AC0"/>
+               <bitfield caption="Analog Comparator 1 Output"
+                         mask="0x02"
+                         name="AC1"
+                         rw="RW"
+                         values="PORTMUX_AC1"/>
+               <bitfield caption="Analog Comparator 2 Output"
+                         mask="0x04"
+                         name="AC2"
+                         rw="RW"
+                         values="PORTMUX_AC2"/>
+            </register>
+            <register caption="ZCD route A"
+                      initval="0x00"
+                      name="ZCDROUTEA"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Zero Cross Detector 0 Output"
+                         mask="0x01"
+                         name="ZCD0"
+                         rw="RW"
+                         values="PORTMUX_ZCD0"/>
+            </register>
+         </register-group>
+         <value-group caption="Analog Comparator 0 Output select" name="PORTMUX_AC0">
+            <value caption="OUT: PA7" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="Analog Comparator 1 Output select" name="PORTMUX_AC1">
+            <value caption="OUT: PA7" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="Analog Comparator 2 Output select" name="PORTMUX_AC2">
+            <value caption="OUT: PA7" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 0 Signals select" name="PORTMUX_LUT0">
+            <value caption="In: PA0, PA1, PA2 Out: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="In: PA0, PA1, PA2 Out: PA6" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 1 Signals select" name="PORTMUX_LUT1">
+            <value caption="In: PC0, PC1, PC2 Out: PC3" name="DEFAULT" value="0x0"/>
+            <value caption="In: PC0, PC1, PC2 Out: -" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 2 Signals select" name="PORTMUX_LUT2">
+            <value caption="In: -, PD1, PD2 Out: PD3" name="DEFAULT" value="0x0"/>
+            <value caption="In: -, PD1, PD2 Out: PD6" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="CCL Look-Up Table 3 Signals select" name="PORTMUX_LUT3">
+            <value caption="In: PF0, PF1, PF2 Out: PF3" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="Event Output A select" name="PORTMUX_EVOUTA">
+            <value caption="EVOUTA: PA2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTA: PA7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Output C select" name="PORTMUX_EVOUTC">
+            <value caption="EVOUTC: PC2" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="Event Output D select" name="PORTMUX_EVOUTD">
+            <value caption="EVOUTD: PD2" name="DEFAULT" value="0x0"/>
+            <value caption="EVOUTD: PD7" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Output F select" name="PORTMUX_EVOUTF">
+            <value caption="EVOUTF: PF2" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="SPI0 Signals select" name="PORTMUX_SPI0">
+            <value caption="MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x3"/>
+         </value-group>
+         <value-group caption="SPI1 Signals select" name="PORTMUX_SPI1">
+            <value caption="MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x3"/>
+         </value-group>
+         <value-group caption="TCA0 Signals select" name="PORTMUX_TCA0">
+            <value caption="WOn: PA0, PA1, PA2, PA3, PA4, PA5"
+                   name="PORTA"
+                   value="0x0"/>
+            <value caption="WOn: PC0, PC1, PC2, PC3, -, -" name="PORTC" value="0x2"/>
+            <value caption="WOn: -, PD1, PD2, PD3, PD4, PD5" name="PORTD" value="0x3"/>
+            <value caption="WOn: PF0, PF1, PF2, PF3, PF4, PF5"
+                   name="PORTF"
+                   value="0x5"/>
+         </value-group>
+         <value-group caption="TCB0 Output select" name="PORTMUX_TCB0">
+            <value caption="WO: PA2" name="DEFAULT" value="0x0"/>
+            <value caption="WO: PF4" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="TCB1 Output select" name="PORTMUX_TCB1">
+            <value caption="WO: PA3" name="DEFAULT" value="0x0"/>
+            <value caption="WO: PF5" name="ALT1" value="0x1"/>
+         </value-group>
+         <value-group caption="TCB2 Output select" name="PORTMUX_TCB2">
+            <value caption="WO: PC0" name="DEFAULT" value="0x0"/>
+         </value-group>
+         <value-group caption="TCD0 Signals select" name="PORTMUX_TCD0">
+            <value caption="WOx: PA4, PA5, PA6, PA7" name="DEFAULT" value="0x0"/>
+            <value caption="WOx: PF0, PF1, PF2, PF3" name="ALT2" value="0x2"/>
+         </value-group>
+         <value-group caption="TWI0 Signals select" name="PORTMUX_TWI0">
+            <value caption="SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3."
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: -."
+                   name="ALT1"
+                   value="0x1"/>
+            <value caption="SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: -."
+                   name="ALT2"
+                   value="0x2"/>
+         </value-group>
+         <value-group caption="TWI1 Signals select" name="PORTMUX_TWI1">
+            <value caption="SDA: PF2, SCL: PF3. Dual mode: SDA: -, SCL: -."
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="SDA: PF2, SCL: PF3. Dual mode: SDA: -, SCL: -."
+                   name="ALT1"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="USART0 Signals select" name="PORTMUX_USART0">
+            <value caption="TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7"
+                   name="ALT1"
+                   value="0x1"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x3"/>
+         </value-group>
+         <value-group caption="USART1 Signals select" name="PORTMUX_USART1">
+            <value caption="TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x3"/>
+         </value-group>
+         <value-group caption="USART2 Signals select" name="PORTMUX_USART2">
+            <value caption="TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3"
+                   name="DEFAULT"
+                   value="0x0"/>
+            <value caption="TxD: PF4, RxD: PF5, XDIR: PF3" name="ALT1" value="0x1"/>
+            <value caption="Not connected to any pins" name="NONE" value="0x3"/>
+         </value-group>
+         <value-group caption="Zero Cross Detector 0 Output select" name="PORTMUX_ZCD0">
+            <value caption="OUT: PA7" name="DEFAULT" value="0x0"/>
+         </value-group>
+      </module>
+      <module caption="Reset controller" id="rst_integration_v8" name="RSTCTRL">
+         <register-group caption="Reset controller" name="RSTCTRL" size="0x4">
+            <register caption="Reset Flags"
+                      initval="0x00"
+                      name="RSTFR"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Power on Reset flag" mask="0x01" name="PORF" rw="RW"/>
+               <bitfield caption="Brown out detector Reset flag"
+                         mask="0x02"
+                         name="BORF"
+                         rw="RW"/>
+               <bitfield caption="External Reset flag" mask="0x04" name="EXTRF" rw="RW"/>
+               <bitfield caption="Watch dog Reset flag" mask="0x08" name="WDRF" rw="RW"/>
+               <bitfield caption="Software Reset flag" mask="0x10" name="SWRF" rw="RW"/>
+               <bitfield caption="UPDI Reset flag" mask="0x20" name="UPDIRF" rw="RW"/>
+            </register>
+            <register caption="Software Reset"
+                      initval="0x00"
+                      name="SWRR"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Software reset enable"
+                         mask="0x01"
+                         name="SWRST"
+                         rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Real-Time Counter" id="tmr_16b_rtc_v1" name="RTC">
+         <register-group caption="Real-Time Counter" name="RTC" size="0x20">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="RTCEN" rw="RW"/>
+               <bitfield caption="Correction enable" mask="0x04" name="CORREN" rw="RW"/>
+               <bitfield caption="Prescaling Factor"
+                         mask="0x78"
+                         name="PRESCALER"
+                         rw="RW"
+                         values="RTC_PRESCALER"/>
+               <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x01"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CTRLA Synchronization Busy Flag"
+                         mask="0x01"
+                         name="CTRLABUSY"
+                         rw="R"/>
+               <bitfield caption="Count Synchronization Busy Flag"
+                         mask="0x02"
+                         name="CNTBUSY"
+                         rw="R"/>
+               <bitfield caption="Period Synchronization Busy Flag"
+                         mask="0x04"
+                         name="PERBUSY"
+                         rw="R"/>
+               <bitfield caption="Comparator Synchronization Busy Flag"
+                         mask="0x08"
+                         name="CMPBUSY"
+                         rw="R"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt enable"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Compare Match Interrupt enable"
+                         mask="0x02"
+                         name="CMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt Flag"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Compare Match Interrupt"
+                         mask="0x02"
+                         name="CMP"
+                         rw="RW"/>
+            </register>
+            <register caption="Temporary"
+                      name="TEMP"
+                      offset="0x04"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Debug control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in debug" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Calibration"
+                      initval="0x00"
+                      name="CALIB"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Error Correction Value"
+                         mask="0x7F"
+                         name="ERROR"
+                         rw="RW"/>
+               <bitfield caption="Error Correction Sign Bit"
+                         mask="0x80"
+                         name="SIGN"
+                         rw="RW"/>
+            </register>
+            <register caption="Clock Select"
+                      initval="0x00"
+                      name="CLKSEL"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Clock Select"
+                         mask="0x03"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="RTC_CLKSEL"/>
+            </register>
+            <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
+            <register caption="Period"
+                      initval="0xFFFF"
+                      name="PER"
+                      offset="0x0A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
+            <register caption="PIT Control A"
+                      initval="0x00"
+                      name="PITCTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="PITEN" rw="RW"/>
+               <bitfield caption="Period"
+                         mask="0x78"
+                         name="PERIOD"
+                         rw="RW"
+                         values="RTC_PERIOD"/>
+            </register>
+            <register caption="PIT Status"
+                      initval="0x00"
+                      name="PITSTATUS"
+                      offset="0x11"
+                      rw="R"
+                      size="1">
+               <bitfield caption="CTRLA Synchronization Busy Flag"
+                         mask="0x01"
+                         name="CTRLBUSY"
+                         rw="R"/>
+            </register>
+            <register caption="PIT Interrupt Control"
+                      initval="0x00"
+                      name="PITINTCTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Periodic Interrupt" mask="0x01" name="PI" rw="RW"/>
+            </register>
+            <register caption="PIT Interrupt Flags"
+                      initval="0x00"
+                      name="PITINTFLAGS"
+                      offset="0x13"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Periodic Interrupt" mask="0x01" name="PI" rw="RW"/>
+            </register>
+            <register caption="PIT Debug control"
+                      initval="0x00"
+                      name="PITDBGCTRL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Run in debug" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock Select" name="RTC_CLKSEL">
+            <value caption="32.768 kHz from OSC32K" name="OSC32K" value="0x0"/>
+            <value caption="1.024 kHz from OSC32K" name="OSC1K" value="0x1"/>
+            <value caption="32.768 kHz from XOSC32K" name="XOSC32K" value="0x2"/>
+            <value caption="External Clock" name="EXTCLK" value="0x3"/>
+         </value-group>
+         <value-group caption="Prescaling Factor select" name="RTC_PRESCALER">
+            <value caption="RTC Clock / 1" name="DIV1" value="0x00"/>
+            <value caption="RTC Clock / 2" name="DIV2" value="0x01"/>
+            <value caption="RTC Clock / 4" name="DIV4" value="0x02"/>
+            <value caption="RTC Clock / 8" name="DIV8" value="0x03"/>
+            <value caption="RTC Clock / 16" name="DIV16" value="0x04"/>
+            <value caption="RTC Clock / 32" name="DIV32" value="0x05"/>
+            <value caption="RTC Clock / 64" name="DIV64" value="0x06"/>
+            <value caption="RTC Clock / 128" name="DIV128" value="0x07"/>
+            <value caption="RTC Clock / 256" name="DIV256" value="0x08"/>
+            <value caption="RTC Clock / 512" name="DIV512" value="0x09"/>
+            <value caption="RTC Clock / 1024" name="DIV1024" value="0x0A"/>
+            <value caption="RTC Clock / 2048" name="DIV2048" value="0x0B"/>
+            <value caption="RTC Clock / 4096" name="DIV4096" value="0x0C"/>
+            <value caption="RTC Clock / 8192" name="DIV8192" value="0x0D"/>
+            <value caption="RTC Clock / 16384" name="DIV16384" value="0x0E"/>
+            <value caption="RTC Clock / 32768" name="DIV32768" value="0x0F"/>
+         </value-group>
+         <value-group caption="Period select" name="RTC_PERIOD">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="RTC Clock Cycles 4" name="CYC4" value="0x01"/>
+            <value caption="RTC Clock Cycles 8" name="CYC8" value="0x02"/>
+            <value caption="RTC Clock Cycles 16" name="CYC16" value="0x03"/>
+            <value caption="RTC Clock Cycles 32" name="CYC32" value="0x04"/>
+            <value caption="RTC Clock Cycles 64" name="CYC64" value="0x05"/>
+            <value caption="RTC Clock Cycles 128" name="CYC128" value="0x06"/>
+            <value caption="RTC Clock Cycles 256" name="CYC256" value="0x07"/>
+            <value caption="RTC Clock Cycles 512" name="CYC512" value="0x08"/>
+            <value caption="RTC Clock Cycles 1024" name="CYC1024" value="0x09"/>
+            <value caption="RTC Clock Cycles 2048" name="CYC2048" value="0x0A"/>
+            <value caption="RTC Clock Cycles 4096" name="CYC4096" value="0x0B"/>
+            <value caption="RTC Clock Cycles 8192" name="CYC8192" value="0x0C"/>
+            <value caption="RTC Clock Cycles 16384" name="CYC16384" value="0x0D"/>
+            <value caption="RTC Clock Cycles 32768" name="CYC32768" value="0x0E"/>
+         </value-group>
+      </module>
+      <module caption="Signature row" id="avrdb" name="SIGROW">
+         <register-group caption="Signature row" name="SIGROW" size="0x40">
+            <register caption="Device ID Byte 0"
+                      name="DEVICEID0"
+                      offset="0x00"
+                      rw="R"
+                      size="1"/>
+            <register caption="Device ID Byte 1"
+                      name="DEVICEID1"
+                      offset="0x01"
+                      rw="R"
+                      size="1"/>
+            <register caption="Device ID Byte 2"
+                      name="DEVICEID2"
+                      offset="0x02"
+                      rw="R"
+                      size="1"/>
+            <register caption="Temperature Calibration 0"
+                      name="TEMPSENSE0"
+                      offset="0x04"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Temperature Calibration 0"
+                         mask="0xFFFF"
+                         name="TEMPSENSE0"
+                         rw="R"/>
+            </register>
+            <register caption="Temperature Calibration 1"
+                      name="TEMPSENSE1"
+                      offset="0x06"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Temperature Calibration 1"
+                         mask="0xFFFF"
+                         name="TEMPSENSE1"
+                         rw="R"/>
+            </register>
+            <register caption="LOTNUM0"
+                      name="SERNUM0"
+                      offset="0x10"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM1"
+                      name="SERNUM1"
+                      offset="0x11"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM2"
+                      name="SERNUM2"
+                      offset="0x12"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM3"
+                      name="SERNUM3"
+                      offset="0x13"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM4"
+                      name="SERNUM4"
+                      offset="0x14"
+                      rw="R"
+                      size="1"/>
+            <register caption="LOTNUM5"
+                      name="SERNUM5"
+                      offset="0x15"
+                      rw="R"
+                      size="1"/>
+            <register caption="RANDOM"
+                      name="SERNUM6"
+                      offset="0x16"
+                      rw="R"
+                      size="1"/>
+            <register caption="SCRIBE"
+                      name="SERNUM7"
+                      offset="0x17"
+                      rw="R"
+                      size="1"/>
+            <register caption="XPOS0"
+                      name="SERNUM8"
+                      offset="0x18"
+                      rw="R"
+                      size="1"/>
+            <register caption="XPOS1"
+                      name="SERNUM9"
+                      offset="0x19"
+                      rw="R"
+                      size="1"/>
+            <register caption="YPOS0"
+                      name="SERNUM10"
+                      offset="0x1A"
+                      rw="R"
+                      size="1"/>
+            <register caption="YPOS1"
+                      name="SERNUM11"
+                      offset="0x1B"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES0"
+                      name="SERNUM12"
+                      offset="0x1C"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES1"
+                      name="SERNUM13"
+                      offset="0x1D"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES2"
+                      name="SERNUM14"
+                      offset="0x1E"
+                      rw="R"
+                      size="1"/>
+            <register caption="RES3"
+                      name="SERNUM15"
+                      offset="0x1F"
+                      rw="R"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Sleep Controller"
+              id="clk_sleep_ctrl_avr_v2"
+              name="SLPCTRL">
+         <register-group caption="Sleep Controller" name="SLPCTRL" size="0x2">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Sleep enable" mask="0x01" name="SEN" rw="RW"/>
+               <bitfield caption="Sleep mode"
+                         mask="0x06"
+                         name="SMODE"
+                         rw="RW"
+                         values="SLPCTRL_SMODE"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="VREGCTRL"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Performance Mode"
+                         mask="0x07"
+                         name="PMODE"
+                         rw="RW"
+                         values="SLPCTRL_PMODE"/>
+               <bitfield caption="High Temperature Low Leakage Enable"
+                         mask="0x10"
+                         name="HTLLEN"
+                         rw="RW"
+                         values="SLPCTRL_HTLLEN"/>
+            </register>
+         </register-group>
+         <value-group caption="Sleep mode select" name="SLPCTRL_SMODE">
+            <value caption="Idle mode" name="IDLE" value="0x00"/>
+            <value caption="Standby Mode" name="STDBY" value="0x01"/>
+            <value caption="Power-down Mode" name="PDOWN" value="0x02"/>
+         </value-group>
+         <value-group caption="High Temperature Low Leakage Enable select"
+                      name="SLPCTRL_HTLLEN">
+            <value caption="Disabled" name="OFF" value="0x0"/>
+            <value caption="Enabled" name="ON" value="0x1"/>
+         </value-group>
+         <value-group caption="Performance Mode select" name="SLPCTRL_PMODE">
+            <value caption="" name="AUTO" value="0x0"/>
+            <value caption="" name="FULL" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="Serial Peripheral Interface" id="spi_8bit_v2" name="SPI">
+         <register-group caption="Serial Peripheral Interface" name="SPI" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable Module" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Prescaler"
+                         mask="0x06"
+                         name="PRESC"
+                         rw="RW"
+                         values="SPI_PRESC"/>
+               <bitfield caption="Enable Double Speed" mask="0x10" name="CLK2X" rw="RW"/>
+               <bitfield caption="Host Operation Enable"
+                         mask="0x20"
+                         name="MASTER"
+                         rw="RW"/>
+               <bitfield caption="Data Order Setting" mask="0x40" name="DORD" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="SPI Mode"
+                         mask="0x03"
+                         name="MODE"
+                         rw="RW"
+                         values="SPI_MODE"/>
+               <bitfield caption="SPI Select Disable" mask="0x04" name="SSD" rw="RW"/>
+               <bitfield caption="Buffer Mode Wait for Receive"
+                         mask="0x40"
+                         name="BUFWR"
+                         rw="RW"/>
+               <bitfield caption="Buffer Mode Enable" mask="0x80" name="BUFEN" rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Enable" mask="0x01" name="IE" rw="RW"/>
+               <bitfield caption="SPI Select Trigger Interrupt Enable"
+                         mask="0x10"
+                         name="SSIE"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Enable"
+                         mask="0x20"
+                         name="DREIE"
+                         rw="RW"/>
+               <bitfield caption="Transfer Complete Interrupt Enable"
+                         mask="0x40"
+                         name="TXCIE"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Enable"
+                         mask="0x80"
+                         name="RXCIE"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <mode name="DEFAULT" qualifier="SPI.CTRLB.BUFEN" value="0"/>
+               <mode name="BUFFERED" qualifier="SPI.CTRLB.BUFEN" value="1"/>
+               <bitfield caption="Buffer Overflow"
+                         mask="0x01"
+                         modes="BUFFERED"
+                         name="BUFOVF"
+                         rw="RW"/>
+               <bitfield caption="SPI Select Trigger Interrupt Flag"
+                         mask="0x10"
+                         modes="BUFFERED"
+                         name="SSIF"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Flag"
+                         mask="0x20"
+                         modes="BUFFERED"
+                         name="DREIF"
+                         rw="RW"/>
+               <bitfield caption="Transfer Complete Interrupt Flag"
+                         mask="0x40"
+                         modes="BUFFERED"
+                         name="TXCIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         modes="BUFFERED"
+                         name="RXCIF"
+                         rw="RW"/>
+               <bitfield caption="Write Collision"
+                         mask="0x40"
+                         modes="DEFAULT"
+                         name="WRCOL"
+                         rw="RW"/>
+               <bitfield caption="Interrupt Flag"
+                         mask="0x80"
+                         modes="DEFAULT"
+                         name="IF"
+                         rw="RW"/>
+            </register>
+            <register caption="Data" name="DATA" offset="0x4" rw="RW" size="1"/>
+         </register-group>
+         <value-group caption="Prescaler select" name="SPI_PRESC">
+            <value caption="CLK_PER / 4" name="DIV4" value="0x00"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x01"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x02"/>
+            <value caption="CLK_PER / 128" name="DIV128" value="0x03"/>
+         </value-group>
+         <value-group caption="SPI Mode select" name="SPI_MODE">
+            <value caption="SPI Mode 0" name="0" value="0x00"/>
+            <value caption="SPI Mode 1" name="1" value="0x01"/>
+            <value caption="SPI Mode 2" name="2" value="0x02"/>
+            <value caption="SPI Mode 3" name="3" value="0x03"/>
+         </value-group>
+      </module>
+      <module caption="System Configuration Registers" id="avrdb" name="SYSCFG">
+         <register-group caption="System Configuration Registers" name="SYSCFG" size="0x20">
+            <register caption="Revision ID"
+                      name="REVID"
+                      offset="0x01"
+                      rw="R"
+                      size="1"/>
+            <register caption="OCD Message Control"
+                      name="OCDMCTRL"
+                      offset="0x18"
+                      rw="RW"
+                      size="1"/>
+            <register caption="OCD Message Status"
+                      initval="0x00"
+                      name="OCDMSTATUS"
+                      offset="0x19"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="OCD Message Read" mask="0x01" name="OCDMR" rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="16-bit Timer/Counter Type A"
+              id="tmr_16b_pwm_v1"
+              name="TCA">
+         <register-group caption="16-bit Timer/Counter Type A" name="TCA" size="0x40">
+            <mode caption="Single Mode"
+                  name="SINGLE"
+                  qualifier="TCA.SINGLE.CTRLD.SPLITM"
+                  value="0"/>
+            <mode caption="Split Mode"
+                  name="SPLIT"
+                  qualifier="TCA.SPLIT.CTRLD.SPLITM"
+                  value="1"/>
+            <register caption="Control A"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Module Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Selection"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCA_SINGLE_CLKSEL"/>
+               <bitfield caption="Run in Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Waveform generation mode"
+                         mask="0x07"
+                         name="WGMODE"
+                         rw="RW"
+                         values="TCA_SINGLE_WGMODE"/>
+               <bitfield caption="Auto Lock Update" mask="0x08" name="ALUPD" rw="RW"/>
+               <bitfield caption="Compare 0 Enable" mask="0x10" name="CMP0EN" rw="RW"/>
+               <bitfield caption="Compare 1 Enable" mask="0x20" name="CMP1EN" rw="RW"/>
+               <bitfield caption="Compare 2 Enable" mask="0x40" name="CMP2EN" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Compare 0 Waveform Output Value"
+                         mask="0x01"
+                         name="CMP0OV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Waveform Output Value"
+                         mask="0x02"
+                         name="CMP1OV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Waveform Output Value"
+                         mask="0x04"
+                         name="CMP2OV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Split Mode Enable" mask="0x01" name="SPLITM" rw="RW"/>
+            </register>
+            <register caption="Control E Clear"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLECLR"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Direction" mask="0x01" name="DIR" rw="RW"/>
+               <bitfield caption="Lock Update" mask="0x02" name="LUPD" rw="RW"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SINGLE_CMD"/>
+            </register>
+            <register caption="Control E Set"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLESET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Direction"
+                         mask="0x01"
+                         name="DIR"
+                         rw="RW"
+                         values="TCA_SINGLE_DIR"/>
+               <bitfield caption="Lock Update" mask="0x02" name="LUPD" rw="RW"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SINGLE_CMD"/>
+            </register>
+            <register caption="Control F Clear"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLFCLR"
+                      offset="0x06"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period Buffer Valid" mask="0x01" name="PERBV" rw="RW"/>
+               <bitfield caption="Compare 0 Buffer Valid"
+                         mask="0x02"
+                         name="CMP0BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Buffer Valid"
+                         mask="0x04"
+                         name="CMP1BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Buffer Valid"
+                         mask="0x08"
+                         name="CMP2BV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control F Set"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="CTRLFSET"
+                      offset="0x07"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period Buffer Valid" mask="0x01" name="PERBV" rw="RW"/>
+               <bitfield caption="Compare 0 Buffer Valid"
+                         mask="0x02"
+                         name="CMP0BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 1 Buffer Valid"
+                         mask="0x04"
+                         name="CMP1BV"
+                         rw="RW"/>
+               <bitfield caption="Compare 2 Buffer Valid"
+                         mask="0x08"
+                         name="CMP2BV"
+                         rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="EVCTRL"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Count on Event Input A"
+                         mask="0x01"
+                         name="CNTAEI"
+                         rw="RW"/>
+               <bitfield caption="Event Action A"
+                         mask="0x0E"
+                         name="EVACTA"
+                         rw="RW"
+                         values="TCA_SINGLE_EVACTA"/>
+               <bitfield caption="Count on Event Input B"
+                         mask="0x10"
+                         name="CNTBEI"
+                         rw="RW"/>
+               <bitfield caption="Event Action B"
+                         mask="0xE0"
+                         name="EVACTB"
+                         rw="RW"
+                         values="TCA_SINGLE_EVACTB"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="INTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt" mask="0x01" name="OVF" rw="RW"/>
+               <bitfield caption="Compare 0 Interrupt" mask="0x10" name="CMP0" rw="RW"/>
+               <bitfield caption="Compare 1 Interrupt" mask="0x20" name="CMP1" rw="RW"/>
+               <bitfield caption="Compare 2 Interrupt" mask="0x40" name="CMP2" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="INTFLAGS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow Interrupt" mask="0x01" name="OVF" rw="RW"/>
+               <bitfield caption="Compare 0 Interrupt" mask="0x10" name="CMP0" rw="RW"/>
+               <bitfield caption="Compare 1 Interrupt" mask="0x20" name="CMP1" rw="RW"/>
+               <bitfield caption="Compare 2 Interrupt" mask="0x40" name="CMP2" rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      modes="SINGLE"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary data for 16-bit Access"
+                      modes="SINGLE"
+                      name="TEMP"
+                      offset="0x0F"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Count"
+                      modes="SINGLE"
+                      name="CNT"
+                      offset="0x20"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Period"
+                      initval="0xFFFF"
+                      modes="SINGLE"
+                      name="PER"
+                      offset="0x26"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 0"
+                      modes="SINGLE"
+                      name="CMP0"
+                      offset="0x28"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 1"
+                      modes="SINGLE"
+                      name="CMP1"
+                      offset="0x2A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 2"
+                      modes="SINGLE"
+                      name="CMP2"
+                      offset="0x2C"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Period Buffer"
+                      initval="0xFFFF"
+                      modes="SINGLE"
+                      name="PERBUF"
+                      offset="0x36"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 0 Buffer"
+                      modes="SINGLE"
+                      name="CMP0BUF"
+                      offset="0x38"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 1 Buffer"
+                      modes="SINGLE"
+                      name="CMP1BUF"
+                      offset="0x3A"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare 2 Buffer"
+                      modes="SINGLE"
+                      name="CMP2BUF"
+                      offset="0x3C"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Control A"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Module Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Selection"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCA_SPLIT_CLKSEL"/>
+               <bitfield caption="Run in Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Compare 0 Enable"
+                         mask="0x01"
+                         name="LCMP0EN"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Enable"
+                         mask="0x02"
+                         name="LCMP1EN"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Enable"
+                         mask="0x04"
+                         name="LCMP2EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 0 Enable"
+                         mask="0x10"
+                         name="HCMP0EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 1 Enable"
+                         mask="0x20"
+                         name="HCMP1EN"
+                         rw="RW"/>
+               <bitfield caption="High Compare 2 Enable"
+                         mask="0x40"
+                         name="HCMP2EN"
+                         rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Compare 0 Output Value"
+                         mask="0x01"
+                         name="LCMP0OV"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Output Value"
+                         mask="0x02"
+                         name="LCMP1OV"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Output Value"
+                         mask="0x04"
+                         name="LCMP2OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 0 Output Value"
+                         mask="0x10"
+                         name="HCMP0OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 1 Output Value"
+                         mask="0x20"
+                         name="HCMP1OV"
+                         rw="RW"/>
+               <bitfield caption="High Compare 2 Output Value"
+                         mask="0x40"
+                         name="HCMP2OV"
+                         rw="RW"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Split Mode Enable" mask="0x01" name="SPLITM" rw="RW"/>
+            </register>
+            <register caption="Control E Clear"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLECLR"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command Enable"
+                         mask="0x03"
+                         name="CMDEN"
+                         rw="RW"
+                         values="TCA_SPLIT_CMDEN"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SPLIT_CMD"/>
+            </register>
+            <register caption="Control E Set"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="CTRLESET"
+                      offset="0x05"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command Enable"
+                         mask="0x03"
+                         name="CMDEN"
+                         rw="RW"
+                         values="TCA_SPLIT_CMDEN"/>
+               <bitfield caption="Command"
+                         mask="0x0C"
+                         name="CMD"
+                         rw="RW"
+                         values="TCA_SPLIT_CMD"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="INTCTRL"
+                      offset="0x0A"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Underflow Interrupt Enable"
+                         mask="0x01"
+                         name="LUNF"
+                         rw="RW"/>
+               <bitfield caption="High Underflow Interrupt Enable"
+                         mask="0x02"
+                         name="HUNF"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 0 Interrupt Enable"
+                         mask="0x10"
+                         name="LCMP0"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Interrupt Enable"
+                         mask="0x20"
+                         name="LCMP1"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Interrupt Enable"
+                         mask="0x40"
+                         name="LCMP2"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="INTFLAGS"
+                      offset="0x0B"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Low Underflow Interrupt Flag"
+                         mask="0x01"
+                         name="LUNF"
+                         rw="RW"/>
+               <bitfield caption="High Underflow Interrupt Flag"
+                         mask="0x02"
+                         name="HUNF"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 2 Interrupt Flag"
+                         mask="0x10"
+                         name="LCMP0"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 1 Interrupt Flag"
+                         mask="0x20"
+                         name="LCMP1"
+                         rw="RW"/>
+               <bitfield caption="Low Compare 0 Interrupt Flag"
+                         mask="0x40"
+                         name="LCMP2"
+                         rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      modes="SPLIT"
+                      name="DBGCTRL"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Low Count"
+                      modes="SPLIT"
+                      name="LCNT"
+                      offset="0x20"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Count"
+                      modes="SPLIT"
+                      name="HCNT"
+                      offset="0x21"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Period"
+                      initval="0xFF"
+                      modes="SPLIT"
+                      name="LPER"
+                      offset="0x26"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Period"
+                      initval="0xFF"
+                      modes="SPLIT"
+                      name="HPER"
+                      offset="0x27"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP0"
+                      offset="0x28"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP0"
+                      offset="0x29"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP1"
+                      offset="0x2A"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP1"
+                      offset="0x2B"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Low Compare"
+                      modes="SPLIT"
+                      name="LCMP2"
+                      offset="0x2C"
+                      rw="RW"
+                      size="1"/>
+            <register caption="High Compare"
+                      modes="SPLIT"
+                      name="HCMP2"
+                      offset="0x2D"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+         <value-group caption="Clock Selection" name="TCA_SINGLE_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER / 2" name="DIV2" value="0x01"/>
+            <value caption="CLK_PER / 4" name="DIV4" value="0x02"/>
+            <value caption="CLK_PER / 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x05"/>
+            <value caption="CLK_PER / 256" name="DIV256" value="0x06"/>
+            <value caption="CLK_PER / 1024" name="DIV1024" value="0x07"/>
+         </value-group>
+         <value-group caption="Waveform generation mode select" name="TCA_SINGLE_WGMODE">
+            <value caption="Normal Mode" name="NORMAL" value="0x00"/>
+            <value caption="Frequency Generation Mode" name="FRQ" value="0x01"/>
+            <value caption="Single Slope PWM" name="SINGLESLOPE" value="0x03"/>
+            <value caption="Dual Slope PWM, overflow on TOP" name="DSTOP" value="0x05"/>
+            <value caption="Dual Slope PWM, overflow on TOP and BOTTOM"
+                   name="DSBOTH"
+                   value="0x06"/>
+            <value caption="Dual Slope PWM, overflow on BOTTOM"
+                   name="DSBOTTOM"
+                   value="0x07"/>
+         </value-group>
+         <value-group caption="Command select" name="TCA_SINGLE_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="Force Update" name="UPDATE" value="0x01"/>
+            <value caption="Force Restart" name="RESTART" value="0x02"/>
+            <value caption="Force Hard Reset" name="RESET" value="0x03"/>
+         </value-group>
+         <value-group caption="Direction select" name="TCA_SINGLE_DIR">
+            <value caption="Count up" name="UP" value="0x0"/>
+            <value caption="Count down" name="DOWN" value="0x1"/>
+         </value-group>
+         <value-group caption="Event Action A select" name="TCA_SINGLE_EVACTA">
+            <value caption="Count on positive edge event"
+                   name="CNT_POSEDGE"
+                   value="0x00"/>
+            <value caption="Count on any edge event" name="CNT_ANYEDGE" value="0x01"/>
+            <value caption="Count on prescaled clock while event line is 1."
+                   name="CNT_HIGHLVL"
+                   value="0x02"/>
+            <value caption="Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1."
+                   name="UPDOWN"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Event Action B select" name="TCA_SINGLE_EVACTB">
+            <value caption="No Action" name="NONE" value="0x00"/>
+            <value caption="Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1."
+                   name="UPDOWN"
+                   value="0x03"/>
+            <value caption="Restart counter at positive edge event"
+                   name="RESTART_POSEDGE"
+                   value="0x04"/>
+            <value caption="Restart counter on any edge event"
+                   name="RESTART_ANYEDGE"
+                   value="0x05"/>
+            <value caption="Restart counter while event line is 1."
+                   name="RESTART_HIGHLVL"
+                   value="0x06"/>
+         </value-group>
+         <value-group caption="Clock Selection" name="TCA_SPLIT_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER / 2" name="DIV2" value="0x01"/>
+            <value caption="CLK_PER / 4" name="DIV4" value="0x02"/>
+            <value caption="CLK_PER / 8" name="DIV8" value="0x03"/>
+            <value caption="CLK_PER / 16" name="DIV16" value="0x04"/>
+            <value caption="CLK_PER / 64" name="DIV64" value="0x05"/>
+            <value caption="CLK_PER / 256" name="DIV256" value="0x06"/>
+            <value caption="CLK_PER / 1024" name="DIV1024" value="0x07"/>
+         </value-group>
+         <value-group caption="Command select" name="TCA_SPLIT_CMD">
+            <value caption="No Command" name="NONE" value="0x00"/>
+            <value caption="Force Restart" name="RESTART" value="0x02"/>
+            <value caption="Force Hard Reset" name="RESET" value="0x03"/>
+         </value-group>
+         <value-group caption="Command Enable select" name="TCA_SPLIT_CMDEN">
+            <value caption="None" name="NONE" value="0x0"/>
+            <value caption="Both low byte and high byte counter"
+                   name="BOTH"
+                   value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="16-bit Timer Type B" id="tmr_16b_capture_v1" name="TCB">
+         <register-group caption="16-bit Timer Type B" name="TCB" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Clock Select"
+                         mask="0x0E"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCB_CLKSEL"/>
+               <bitfield caption="Synchronize Update" mask="0x10" name="SYNCUPD" rw="RW"/>
+               <bitfield caption="Cascade two timers" mask="0x20" name="CASCADE" rw="RW"/>
+               <bitfield caption="Run Standby" mask="0x40" name="RUNSTDBY" rw="RW"/>
+            </register>
+            <register caption="Control Register B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Timer Mode"
+                         mask="0x07"
+                         name="CNTMODE"
+                         rw="RW"
+                         values="TCB_CNTMODE"/>
+               <bitfield caption="Pin Output Enable" mask="0x10" name="CCMPEN" rw="RW"/>
+               <bitfield caption="Pin Initial State" mask="0x20" name="CCMPINIT" rw="RW"/>
+               <bitfield caption="Asynchronous Enable" mask="0x40" name="ASYNC" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Event Input Enable" mask="0x01" name="CAPTEI" rw="RW"/>
+               <bitfield caption="Event Edge" mask="0x10" name="EDGE" rw="RW"/>
+               <bitfield caption="Input Capture Noise Cancellation Filter"
+                         mask="0x40"
+                         name="FILTER"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Capture or Timeout" mask="0x01" name="CAPT" rw="RW"/>
+               <bitfield caption="Overflow" mask="0x02" name="OVF" rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Capture or Timeout" mask="0x01" name="CAPT" rw="RW"/>
+               <bitfield caption="Overflow" mask="0x02" name="OVF" rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x7"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Run" mask="0x01" name="RUN" rw="R"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Temporary Value"
+                      name="TEMP"
+                      offset="0x9"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Count"
+                      initval="0x0000"
+                      name="CNT"
+                      offset="0xA"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Compare or Capture"
+                      name="CCMP"
+                      offset="0xC"
+                      rw="RW"
+                      size="2"/>
+         </register-group>
+         <value-group caption="Clock Select" name="TCB_CLKSEL">
+            <value caption="CLK_PER" name="DIV1" value="0x00"/>
+            <value caption="CLK_PER/2" name="DIV2" value="0x01"/>
+            <value caption="Use CLK_TCA from TCA0" name="TCA0" value="0x02"/>
+            <value caption="Count on event edge" name="EVENT" value="0x07"/>
+         </value-group>
+         <value-group caption="Timer Mode select" name="TCB_CNTMODE">
+            <value caption="Periodic Interrupt" name="INT" value="0x00"/>
+            <value caption="Periodic Timeout" name="TIMEOUT" value="0x01"/>
+            <value caption="Input Capture Event" name="CAPT" value="0x02"/>
+            <value caption="Input Capture Frequency measurement"
+                   name="FRQ"
+                   value="0x03"/>
+            <value caption="Input Capture Pulse-Width measurement"
+                   name="PW"
+                   value="0x04"/>
+            <value caption="Input Capture Frequency and Pulse-Width measurement"
+                   name="FRQPW"
+                   value="0x05"/>
+            <value caption="Single Shot" name="SINGLE" value="0x06"/>
+            <value caption="8-bit PWM" name="PWM8" value="0x07"/>
+         </value-group>
+      </module>
+      <module caption="Timer Counter D" id="tmr_12b_psc_v1" name="TCD">
+         <register-group caption="Timer Counter D" name="TCD" size="0x40">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x00"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Synchronization prescaler"
+                         mask="0x06"
+                         name="SYNCPRES"
+                         rw="RW"
+                         values="TCD_SYNCPRES"/>
+               <bitfield caption="Counter prescaler"
+                         mask="0x18"
+                         name="CNTPRES"
+                         rw="RW"
+                         values="TCD_CNTPRES"/>
+               <bitfield caption="Clock select"
+                         mask="0x60"
+                         name="CLKSEL"
+                         rw="RW"
+                         values="TCD_CLKSEL"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x01"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Waveform generation mode"
+                         mask="0x03"
+                         name="WGMODE"
+                         rw="RW"
+                         values="TCD_WGMODE"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x00"
+                      name="CTRLC"
+                      offset="0x02"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Compare output value override"
+                         mask="0x01"
+                         name="CMPOVR"
+                         rw="RW"/>
+               <bitfield caption="Auto update" mask="0x02" name="AUPDATE" rw="RW"/>
+               <bitfield caption="Fifty percent waveform"
+                         mask="0x08"
+                         name="FIFTY"
+                         rw="RW"/>
+               <bitfield caption="Compare C output select"
+                         mask="0x40"
+                         name="CMPCSEL"
+                         rw="RW"
+                         values="TCD_CMPCSEL"/>
+               <bitfield caption="Compare D output select"
+                         mask="0x80"
+                         name="CMPDSEL"
+                         rw="RW"
+                         values="TCD_CMPDSEL"/>
+            </register>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0x03"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Compare A value" mask="0x0F" name="CMPAVAL" rw="RW"/>
+               <bitfield caption="Compare B value" mask="0xF0" name="CMPBVAL" rw="RW"/>
+            </register>
+            <register caption="Control E"
+                      initval="0x00"
+                      name="CTRLE"
+                      offset="0x04"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Synchronize end of cycle strobe"
+                         mask="0x01"
+                         name="SYNCEOC"
+                         rw="RW"/>
+               <bitfield caption="synchronize strobe" mask="0x02" name="SYNC" rw="RW"/>
+               <bitfield caption="Restart strobe" mask="0x04" name="RESTART" rw="RW"/>
+               <bitfield caption="Software Capture A Strobe"
+                         mask="0x08"
+                         name="SCAPTUREA"
+                         rw="RW"/>
+               <bitfield caption="Software Capture B Strobe"
+                         mask="0x10"
+                         name="SCAPTUREB"
+                         rw="RW"/>
+               <bitfield caption="Disable at end of cycle"
+                         mask="0x80"
+                         name="DISEOC"
+                         rw="RW"/>
+            </register>
+            <register caption="EVCTRLA"
+                      initval="0x00"
+                      name="EVCTRLA"
+                      offset="0x08"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Trigger event enable"
+                         mask="0x01"
+                         name="TRIGEI"
+                         rw="RW"/>
+               <bitfield caption="Event action"
+                         mask="0x04"
+                         name="ACTION"
+                         rw="RW"
+                         values="TCD_ACTION"/>
+               <bitfield caption="Edge select"
+                         mask="0x10"
+                         name="EDGE"
+                         rw="RW"
+                         values="TCD_EDGE"/>
+               <bitfield caption="Event config"
+                         mask="0xC0"
+                         name="CFG"
+                         rw="RW"
+                         values="TCD_CFG"/>
+            </register>
+            <register caption="EVCTRLB"
+                      initval="0x00"
+                      name="EVCTRLB"
+                      offset="0x09"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Trigger event enable"
+                         mask="0x01"
+                         name="TRIGEI"
+                         rw="RW"/>
+               <bitfield caption="Event action"
+                         mask="0x04"
+                         name="ACTION"
+                         rw="RW"
+                         values="TCD_ACTION"/>
+               <bitfield caption="Edge select"
+                         mask="0x10"
+                         name="EDGE"
+                         rw="RW"
+                         values="TCD_EDGE"/>
+               <bitfield caption="Event config"
+                         mask="0xC0"
+                         name="CFG"
+                         rw="RW"
+                         values="TCD_CFG"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x0C"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow interrupt enable"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Trigger A interrupt enable"
+                         mask="0x04"
+                         name="TRIGA"
+                         rw="RW"/>
+               <bitfield caption="Trigger B interrupt enable"
+                         mask="0x08"
+                         name="TRIGB"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x0D"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Overflow interrupt enable"
+                         mask="0x01"
+                         name="OVF"
+                         rw="RW"/>
+               <bitfield caption="Trigger A interrupt enable"
+                         mask="0x04"
+                         name="TRIGA"
+                         rw="RW"/>
+               <bitfield caption="Trigger B interrupt enable"
+                         mask="0x08"
+                         name="TRIGB"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x0E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable ready" mask="0x01" name="ENRDY" rw="R"/>
+               <bitfield caption="Command ready" mask="0x02" name="CMDRDY" rw="R"/>
+               <bitfield caption="PWM activity on A" mask="0x40" name="PWMACTA" rw="RW"/>
+               <bitfield caption="PWM activity on B" mask="0x80" name="PWMACTB" rw="RW"/>
+            </register>
+            <register caption="Input Control A"
+                      initval="0x00"
+                      name="INPUTCTRLA"
+                      offset="0x10"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input mode"
+                         mask="0x0F"
+                         name="INPUTMODE"
+                         rw="RW"
+                         values="TCD_INPUTMODE"/>
+            </register>
+            <register caption="Input Control B"
+                      initval="0x00"
+                      name="INPUTCTRLB"
+                      offset="0x11"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Input mode"
+                         mask="0x0F"
+                         name="INPUTMODE"
+                         rw="RW"
+                         values="TCD_INPUTMODE"/>
+            </register>
+            <register caption="Fault Control"
+                      initval="0x00"
+                      name="FAULTCTRL"
+                      offset="0x12"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Compare A value" mask="0x01" name="CMPA" rw="RW"/>
+               <bitfield caption="Compare B value" mask="0x02" name="CMPB" rw="RW"/>
+               <bitfield caption="Compare C value" mask="0x04" name="CMPC" rw="RW"/>
+               <bitfield caption="Compare D vaule" mask="0x08" name="CMPD" rw="RW"/>
+               <bitfield caption="Compare A enable" mask="0x10" name="CMPAEN" rw="RW"/>
+               <bitfield caption="Compare B enable" mask="0x20" name="CMPBEN" rw="RW"/>
+               <bitfield caption="Compare C enable" mask="0x40" name="CMPCEN" rw="RW"/>
+               <bitfield caption="Compare D enable" mask="0x80" name="CMPDEN" rw="RW"/>
+            </register>
+            <register caption="Delay Control"
+                      initval="0x00"
+                      name="DLYCTRL"
+                      offset="0x14"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Delay select"
+                         mask="0x03"
+                         name="DLYSEL"
+                         rw="RW"
+                         values="TCD_DLYSEL"/>
+               <bitfield caption="Delay trigger"
+                         mask="0x0C"
+                         name="DLYTRIG"
+                         rw="RW"
+                         values="TCD_DLYTRIG"/>
+               <bitfield caption="Delay prescaler"
+                         mask="0x30"
+                         name="DLYPRESC"
+                         rw="RW"
+                         values="TCD_DLYPRESC"/>
+            </register>
+            <register caption="Delay value"
+                      initval="0x00"
+                      name="DLYVAL"
+                      offset="0x15"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Delay value" mask="0xFF" name="DLYVAL" rw="RW"/>
+            </register>
+            <register caption="Dither Control A"
+                      initval="0x00"
+                      name="DITCTRL"
+                      offset="0x18"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Dither select"
+                         mask="0x03"
+                         name="DITHERSEL"
+                         rw="RW"
+                         values="TCD_DITHERSEL"/>
+            </register>
+            <register caption="Dither value"
+                      initval="0x00"
+                      name="DITVAL"
+                      offset="0x19"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Dither value" mask="0x0F" name="DITHER" rw="RW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x1E"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug run" mask="0x01" name="DBGRUN" rw="RW"/>
+               <bitfield caption="Fault detection" mask="0x04" name="FAULTDET" rw="RW"/>
+            </register>
+            <register caption="Capture A"
+                      initval="0x0000"
+                      name="CAPTUREA"
+                      offset="0x22"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Capture A" mask="0xFFF" name="CAPTUREA" rw="R"/>
+            </register>
+            <register caption="Capture B"
+                      initval="0x0000"
+                      name="CAPTUREB"
+                      offset="0x24"
+                      rw="R"
+                      size="2">
+               <bitfield caption="Capture B" mask="0xFFF" name="CAPTUREB" rw="R"/>
+            </register>
+            <register caption="Compare A Set"
+                      initval="0x0000"
+                      name="CMPASET"
+                      offset="0x28"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Compare A Set" mask="0xFFF" name="CMPASET" rw="RW"/>
+            </register>
+            <register caption="Compare A Clear"
+                      initval="0x0000"
+                      name="CMPACLR"
+                      offset="0x2A"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Compare A Clear" mask="0xFFF" name="CMPACLR" rw="RW"/>
+            </register>
+            <register caption="Compare B Set"
+                      initval="0x0000"
+                      name="CMPBSET"
+                      offset="0x2C"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Compare B Set" mask="0xFFF" name="CMPBSET" rw="RW"/>
+            </register>
+            <register caption="Compare B Clear"
+                      initval="0x0000"
+                      name="CMPBCLR"
+                      offset="0x2E"
+                      rw="RW"
+                      size="2">
+               <bitfield caption="Compare B Clear" mask="0xFFF" name="COMPBCLR" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Clock select" name="TCD_CLKSEL">
+            <value caption="Internal High-Frequency oscillator"
+                   name="OSCHF"
+                   value="0x00"/>
+            <value caption="PLL" name="PLL" value="0x01"/>
+            <value caption="External Clock" name="EXTCLK" value="0x02"/>
+            <value caption="Peripheral clock" name="CLKPER" value="0x03"/>
+         </value-group>
+         <value-group caption="Counter prescaler select" name="TCD_CNTPRES">
+            <value caption="Sync clock divided by 1" name="DIV1" value="0x00"/>
+            <value caption="Sync clock divided by 4" name="DIV4" value="0x01"/>
+            <value caption="Sync clock divided by 32" name="DIV32" value="0x02"/>
+         </value-group>
+         <value-group caption="Synchronization prescaler select" name="TCD_SYNCPRES">
+            <value caption="Selected clock source divided by 1"
+                   name="DIV1"
+                   value="0x00"/>
+            <value caption="Selected clock source divided by 2"
+                   name="DIV2"
+                   value="0x01"/>
+            <value caption="Selected clock source divided by 4"
+                   name="DIV4"
+                   value="0x02"/>
+            <value caption="Selected clock source divided by 8"
+                   name="DIV8"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Waveform generation mode select" name="TCD_WGMODE">
+            <value caption="One ramp mode" name="ONERAMP" value="0x0"/>
+            <value caption="Two ramp mode" name="TWORAMP" value="0x1"/>
+            <value caption="Four ramp mode" name="FOURRAMP" value="0x2"/>
+            <value caption="Dual slope mode" name="DS" value="0x3"/>
+         </value-group>
+         <value-group caption="Compare C output select" name="TCD_CMPCSEL">
+            <value caption="PWM A output" name="PWMA" value="0x0"/>
+            <value caption="PWM B output" name="PWMB" value="0x1"/>
+         </value-group>
+         <value-group caption="Compare D output select" name="TCD_CMPDSEL">
+            <value caption="PWM A output" name="PWMA" value="0x0"/>
+            <value caption="PWM B output" name="PWMB" value="0x1"/>
+         </value-group>
+         <value-group caption="Dither select" name="TCD_DITHERSEL">
+            <value caption="On-time ramp B" name="ONTIMEB" value="0x0"/>
+            <value caption="On-time ramp A and B" name="ONTIMEAB" value="0x1"/>
+            <value caption="Dead-time rampB" name="DEADTIMEB" value="0x2"/>
+            <value caption="Dead-time ramp A and B" name="DEADTIMEAB" value="0x3"/>
+         </value-group>
+         <value-group caption="Delay prescaler select" name="TCD_DLYPRESC">
+            <value caption="No prescaling" name="DIV1" value="0x0"/>
+            <value caption="Prescale with 2" name="DIV2" value="0x1"/>
+            <value caption="Prescale with 4" name="DIV4" value="0x2"/>
+            <value caption="Prescale with 8" name="DIV8" value="0x3"/>
+         </value-group>
+         <value-group caption="Delay select" name="TCD_DLYSEL">
+            <value caption="No delay" name="OFF" value="0x0"/>
+            <value caption="Input blanking enabled" name="INBLANK" value="0x1"/>
+            <value caption="Event delay enabled" name="EVENT" value="0x2"/>
+         </value-group>
+         <value-group caption="Delay trigger select" name="TCD_DLYTRIG">
+            <value caption="Compare A set" name="CMPASET" value="0x0"/>
+            <value caption="Compare A clear" name="CMPACLR" value="0x1"/>
+            <value caption="Compare B set" name="CMPBSET" value="0x2"/>
+            <value caption="Compare B clear" name="CMPBCLR" value="0x3"/>
+         </value-group>
+         <value-group caption="Event action select" name="TCD_ACTION">
+            <value caption="Event trigger a fault" name="FAULT" value="0x0"/>
+            <value caption="Event trigger a fault and capture"
+                   name="CAPTURE"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="Event config select" name="TCD_CFG">
+            <value caption="Neither Filter nor Asynchronous Event is enabled"
+                   name="NEITHER"
+                   value="0x0"/>
+            <value caption="Input Capture Noise Cancellation Filter enabled"
+                   name="FILTER"
+                   value="0x1"/>
+            <value caption="Asynchronous Event output qualification enabled"
+                   name="ASYNC"
+                   value="0x2"/>
+         </value-group>
+         <value-group caption="Edge select" name="TCD_EDGE">
+            <value caption="The falling edge or low level of event generates retrigger or fault action"
+                   name="FALL_LOW"
+                   value="0x0"/>
+            <value caption="The rising edge or high level of event generates retrigger or fault action"
+                   name="RISE_HIGH"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="Input mode select" name="TCD_INPUTMODE">
+            <value caption="Input has no actions" name="NONE" value="0x00"/>
+            <value caption="Stop output, jump to opposite compare cycle and wait"
+                   name="JMPWAIT"
+                   value="0x01"/>
+            <value caption="Stop output, execute opposite compare cycle and wait"
+                   name="EXECWAIT"
+                   value="0x02"/>
+            <value caption="stop output, execute opposite compare cycle while fault active"
+                   name="EXECFAULT"
+                   value="0x03"/>
+            <value caption="Stop all outputs, maintain frequency"
+                   name="FREQ"
+                   value="0x04"/>
+            <value caption="Stop all outputs, execute dead time while fault active"
+                   name="EXECDT"
+                   value="0x05"/>
+            <value caption="Stop all outputs, jump to next compare cycle and wait"
+                   name="WAIT"
+                   value="0x06"/>
+            <value caption="Stop all outputs, wait for software action"
+                   name="WAITSW"
+                   value="0x07"/>
+            <value caption="Stop output on edge, jump to next compare cycle"
+                   name="EDGETRIG"
+                   value="0x08"/>
+            <value caption="Stop output on edge, maintain frequency"
+                   name="EDGETRIGFREQ"
+                   value="0x09"/>
+            <value caption="Stop output at level, maintain frequency"
+                   name="LVLTRIGFREQ"
+                   value="0x0A"/>
+         </value-group>
+      </module>
+      <module caption="Two-Wire Interface" id="i2c_8bit_v2" name="TWI">
+         <register-group caption="Two-Wire Interface" name="TWI" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="FM Plus Enable"
+                         mask="0x02"
+                         name="FMPEN"
+                         rw="RW"
+                         values="TWI_FMPEN"/>
+               <bitfield caption="SDA Hold Time"
+                         mask="0x0C"
+                         name="SDAHOLD"
+                         rw="RW"
+                         values="TWI_SDAHOLD"/>
+               <bitfield caption="SDA Setup Time"
+                         mask="0x10"
+                         name="SDASETUP"
+                         rw="RW"
+                         values="TWI_SDASETUP"/>
+               <bitfield caption="Input Voltage Transition Level"
+                         mask="0x40"
+                         name="INPUTLVL"
+                         rw="RW"
+                         values="TWI_INPUTLVL"/>
+            </register>
+            <register caption="Dual Control"
+                      initval="0x00"
+                      name="DUALCTRL"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Dual Control Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="FM Plus Enable" mask="0x02" name="FMPEN" rw="RW"/>
+               <bitfield caption="SDA Hold Time"
+                         mask="0x0C"
+                         name="SDAHOLD"
+                         rw="RW"
+                         values="TWI_SDAHOLD"/>
+               <bitfield caption="Input Voltage Transition Level"
+                         mask="0x40"
+                         name="INPUTLVL"
+                         rw="RW"
+                         values="TWI_INPUTLVL"/>
+            </register>
+            <register caption="Debug Control Register"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Host Control A"
+                      initval="0x00"
+                      name="MCTRLA"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable TWI Host" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Smart Mode Enable" mask="0x02" name="SMEN" rw="RW"/>
+               <bitfield caption="Inactive Bus Timeout"
+                         mask="0x0C"
+                         name="TIMEOUT"
+                         rw="RW"
+                         values="TWI_TIMEOUT"/>
+               <bitfield caption="Quick Command Enable" mask="0x10" name="QCEN" rw="RW"/>
+               <bitfield caption="Write Interrupt Enable"
+                         mask="0x40"
+                         name="WIEN"
+                         rw="RW"/>
+               <bitfield caption="Read Interrupt Enable" mask="0x80" name="RIEN" rw="RW"/>
+            </register>
+            <register caption="Host Control B"
+                      initval="0x00"
+                      name="MCTRLB"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x03"
+                         name="MCMD"
+                         rw="RW"
+                         values="TWI_MCMD"/>
+               <bitfield caption="Acknowledge Action"
+                         mask="0x04"
+                         name="ACKACT"
+                         rw="RW"
+                         values="TWI_ACKACT"/>
+               <bitfield caption="Flush" mask="0x08" name="FLUSH" rw="RW"/>
+            </register>
+            <register caption="Host Status"
+                      initval="0x00"
+                      name="MSTATUS"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Bus State"
+                         mask="0x03"
+                         name="BUSSTATE"
+                         rw="RW"
+                         values="TWI_BUSSTATE"/>
+               <bitfield caption="Bus Error" mask="0x04" name="BUSERR" rw="RW"/>
+               <bitfield caption="Arbitration Lost" mask="0x08" name="ARBLOST" rw="RW"/>
+               <bitfield caption="Received Acknowledge" mask="0x10" name="RXACK" rw="R"/>
+               <bitfield caption="Clock Hold" mask="0x20" name="CLKHOLD" rw="RW"/>
+               <bitfield caption="Write Interrupt Flag" mask="0x40" name="WIF" rw="RW"/>
+               <bitfield caption="Read Interrupt Flag" mask="0x80" name="RIF" rw="RW"/>
+            </register>
+            <register caption="Host Baud Rate Control"
+                      initval="0x00"
+                      name="MBAUD"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Baud" mask="0xFF" name="BAUD" rw="RW"/>
+            </register>
+            <register caption="Host Address"
+                      initval="0x00"
+                      name="MADDR"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address" mask="0xFF" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="Host Data"
+                      initval="0x00"
+                      name="MDATA"
+                      offset="0x8"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Data" mask="0xFF" name="DATA" rw="RW"/>
+            </register>
+            <register caption="Client Control A"
+                      initval="0x00"
+                      name="SCTRLA"
+                      offset="0x9"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable TWI Client" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Smart Mode Enable" mask="0x02" name="SMEN" rw="RW"/>
+               <bitfield caption="Promiscuous Mode Enable"
+                         mask="0x04"
+                         name="PMEN"
+                         rw="RW"/>
+               <bitfield caption="Stop Interrupt Enable" mask="0x20" name="PIEN" rw="RW"/>
+               <bitfield caption="Address/Stop Interrupt Enable"
+                         mask="0x40"
+                         name="APIEN"
+                         rw="RW"/>
+               <bitfield caption="Data Interrupt Enable" mask="0x80" name="DIEN" rw="RW"/>
+            </register>
+            <register caption="Client Control B"
+                      initval="0x00"
+                      name="SCTRLB"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Command"
+                         mask="0x03"
+                         name="SCMD"
+                         rw="RW"
+                         values="TWI_SCMD"/>
+               <bitfield caption="Acknowledge Action"
+                         mask="0x04"
+                         name="ACKACT"
+                         rw="RW"
+                         values="TWI_ACKACT"/>
+            </register>
+            <register caption="Client Status"
+                      initval="0x00"
+                      name="SSTATUS"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Client Address or Stop"
+                         mask="0x01"
+                         name="AP"
+                         rw="R"
+                         values="TWI_AP"/>
+               <bitfield caption="Read/Write Direction" mask="0x02" name="DIR" rw="R"/>
+               <bitfield caption="Bus Error" mask="0x04" name="BUSERR" rw="RW"/>
+               <bitfield caption="Collision" mask="0x08" name="COLL" rw="RW"/>
+               <bitfield caption="Received Acknowledge" mask="0x10" name="RXACK" rw="R"/>
+               <bitfield caption="Clock Hold" mask="0x20" name="CLKHOLD" rw="R"/>
+               <bitfield caption="Address/Stop Interrupt Flag"
+                         mask="0x40"
+                         name="APIF"
+                         rw="R"/>
+               <bitfield caption="Data Interrupt Flag" mask="0x80" name="DIF" rw="R"/>
+            </register>
+            <register caption="Client Address"
+                      initval="0x00"
+                      name="SADDR"
+                      offset="0xC"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address" mask="0xFF" name="ADDR" rw="RW"/>
+            </register>
+            <register caption="Client Data"
+                      initval="0x00"
+                      name="SDATA"
+                      offset="0xD"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Data" mask="0xFF" name="DATA" rw="RW"/>
+            </register>
+            <register caption="Client Address Mask"
+                      initval="0x00"
+                      name="SADDRMASK"
+                      offset="0xE"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Address Enable" mask="0x01" name="ADDREN" rw="RW"/>
+               <bitfield caption="Address Mask" mask="0xFE" name="ADDRMASK" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="FM Plus Enable select" name="TWI_FMPEN">
+            <value caption="Operating in Standard-mode or Fast-mode"
+                   name="OFF"
+                   value="0x0"/>
+            <value caption="Operating in Fast-mode Plus" name="ON" value="0x1"/>
+         </value-group>
+         <value-group caption="Input Voltage Transition Level select" name="TWI_INPUTLVL">
+            <value caption="I2C input voltage transition level" name="I2C" value="0x0"/>
+            <value caption="SMBus 3.0 input voltage transition level"
+                   name="SMBUS"
+                   value="0x1"/>
+         </value-group>
+         <value-group caption="SDA Hold Time select" name="TWI_SDAHOLD">
+            <value caption="SDA hold time off" name="OFF" value="0x00"/>
+            <value caption="Typical 50ns hold time" name="50NS" value="0x01"/>
+            <value caption="Typical 300ns hold time" name="300NS" value="0x02"/>
+            <value caption="Typical 500ns hold time" name="500NS" value="0x03"/>
+         </value-group>
+         <value-group caption="SDA Setup Time select" name="TWI_SDASETUP">
+            <value caption="SDA setup time is 4 clock cycles" name="4CYC" value="0x0"/>
+            <value caption="SDA setup time is 8 clock cycles" name="8CYC" value="0x1"/>
+         </value-group>
+         <value-group caption="Inactive Bus Timeout select" name="TWI_TIMEOUT">
+            <value caption="Bus Timeout Disabled" name="DISABLED" value="0x00"/>
+            <value caption="50 Microseconds" name="50US" value="0x01"/>
+            <value caption="100 Microseconds" name="100US" value="0x02"/>
+            <value caption="200 Microseconds" name="200US" value="0x03"/>
+         </value-group>
+         <value-group caption="Acknowledge Action select" name="TWI_ACKACT">
+            <value caption="Send ACK" name="ACK" value="0x0"/>
+            <value caption="Send NACK" name="NACK" value="0x1"/>
+         </value-group>
+         <value-group caption="Command select" name="TWI_MCMD">
+            <value caption="No Action" name="NOACT" value="0x00"/>
+            <value caption="Issue Repeated Start Condition"
+                   name="REPSTART"
+                   value="0x01"/>
+            <value caption="Receive or Transmit Data, depending on DIR"
+                   name="RECVTRANS"
+                   value="0x02"/>
+            <value caption="Issue Stop Condition" name="STOP" value="0x03"/>
+         </value-group>
+         <value-group caption="Bus State select" name="TWI_BUSSTATE">
+            <value caption="Unknown Bus State" name="UNKNOWN" value="0x00"/>
+            <value caption="Bus is Idle" name="IDLE" value="0x01"/>
+            <value caption="This Module Controls The Bus" name="OWNER" value="0x02"/>
+            <value caption="The Bus is Busy" name="BUSY" value="0x03"/>
+         </value-group>
+         <value-group caption="Command select" name="TWI_SCMD">
+            <value caption="No Action" name="NOACT" value="0x00"/>
+            <value caption="Used To Complete a Transaction"
+                   name="COMPTRANS"
+                   value="0x02"/>
+            <value caption="Used in Response to Address/Data Interrupt"
+                   name="RESPONSE"
+                   value="0x03"/>
+         </value-group>
+         <value-group caption="Client Address or Stop select" name="TWI_AP">
+            <value caption="Stop condition generated APIF" name="STOP" value="0x0"/>
+            <value caption="Address detection generated APIF" name="ADR" value="0x1"/>
+         </value-group>
+      </module>
+      <module caption="Universal Synchronous and Asynchronous Receiver and Transmitter"
+              id="uart_autobd_v4"
+              name="USART">
+         <register-group caption="Universal Synchronous and Asynchronous Receiver and Transmitter"
+                         name="USART"
+                         size="0x10">
+            <register caption="Receive Data Low Byte"
+                      initval="0x00"
+                      name="RXDATAL"
+                      offset="0x0"
+                      rw="R"
+                      size="1">
+               <bitfield caption="RX Data" mask="0xFF" name="DATA" rw="R"/>
+            </register>
+            <register caption="Receive Data High Byte"
+                      initval="0x00"
+                      name="RXDATAH"
+                      offset="0x1"
+                      rw="R"
+                      size="1">
+               <bitfield caption="Receiver Data Register"
+                         mask="0x01"
+                         name="DATA8"
+                         rw="R"/>
+               <bitfield caption="Parity Error" mask="0x02" name="PERR" rw="R"/>
+               <bitfield caption="Frame Error" mask="0x04" name="FERR" rw="R"/>
+               <bitfield caption="Buffer Overflow" mask="0x40" name="BUFOVF" rw="R"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         name="RXCIF"
+                         rw="R"/>
+            </register>
+            <register caption="Transmit Data Low Byte"
+                      initval="0x00"
+                      name="TXDATAL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit Data Register"
+                         mask="0xFF"
+                         name="DATA"
+                         rw="RW"/>
+            </register>
+            <register caption="Transmit Data High Byte"
+                      initval="0x00"
+                      name="TXDATAH"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit Data Register (CHSIZE=9bit)"
+                         mask="0x01"
+                         name="DATA8"
+                         rw="RW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x20"
+                      name="STATUS"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Wait For Break" mask="0x01" name="WFB" rw="W"/>
+               <bitfield caption="Break Detected Flag" mask="0x02" name="BDF" rw="RW"/>
+               <bitfield caption="Inconsistent Sync Field Interrupt Flag"
+                         mask="0x08"
+                         name="ISFIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Start Interrupt"
+                         mask="0x10"
+                         name="RXSIF"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Flag"
+                         mask="0x20"
+                         name="DREIF"
+                         rw="R"/>
+               <bitfield caption="Transmit Interrupt Flag"
+                         mask="0x40"
+                         name="TXCIF"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Flag"
+                         mask="0x80"
+                         name="RXCIF"
+                         rw="R"/>
+            </register>
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x5"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="RS485 Mode internal transmitter"
+                         mask="0x01"
+                         name="RS485"
+                         rw="RW"
+                         values="USART_RS485"/>
+               <bitfield caption="Auto-baud Error Interrupt Enable"
+                         mask="0x04"
+                         name="ABEIE"
+                         rw="RW"/>
+               <bitfield caption="Loop-back Mode Enable" mask="0x08" name="LBME" rw="RW"/>
+               <bitfield caption="Receiver Start Frame Interrupt Enable"
+                         mask="0x10"
+                         name="RXSIE"
+                         rw="RW"/>
+               <bitfield caption="Data Register Empty Interrupt Enable"
+                         mask="0x20"
+                         name="DREIE"
+                         rw="RW"/>
+               <bitfield caption="Transmit Complete Interrupt Enable"
+                         mask="0x40"
+                         name="TXCIE"
+                         rw="RW"/>
+               <bitfield caption="Receive Complete Interrupt Enable"
+                         mask="0x80"
+                         name="RXCIE"
+                         rw="RW"/>
+            </register>
+            <register caption="Control B"
+                      initval="0x00"
+                      name="CTRLB"
+                      offset="0x6"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Multi-processor Communication Mode"
+                         mask="0x01"
+                         name="MPCM"
+                         rw="RW"/>
+               <bitfield caption="Receiver Mode"
+                         mask="0x06"
+                         name="RXMODE"
+                         rw="RW"
+                         values="USART_RXMODE"/>
+               <bitfield caption="Open Drain Mode Enable"
+                         mask="0x08"
+                         name="ODME"
+                         rw="RW"/>
+               <bitfield caption="Start Frame Detection Enable"
+                         mask="0x10"
+                         name="SFDEN"
+                         rw="RW"/>
+               <bitfield caption="Transmitter Enable" mask="0x40" name="TXEN" rw="RW"/>
+               <bitfield caption="Reciever enable" mask="0x80" name="RXEN" rw="RW"/>
+            </register>
+            <register caption="Control C"
+                      initval="0x03"
+                      name="CTRLC"
+                      offset="0x7"
+                      rw="RW"
+                      size="1">
+               <mode name="NORMAL" qualifier="USART.CTRLC.CMODE" value="0x00 0x01 0x02"/>
+               <mode name="MSPI" qualifier="USART.CTRLC.CMODE" value="0x03"/>
+               <bitfield caption="Communication Mode"
+                         mask="0xC0"
+                         name="CMODE"
+                         rw="RW"
+                         values="USART_CMODE"/>
+               <bitfield caption="SPI Host Mode, Clock Phase"
+                         mask="0x02"
+                         modes="MSPI"
+                         name="UCPHA"
+                         rw="RW"/>
+               <bitfield caption="SPI Host Mode, Data Order"
+                         mask="0x04"
+                         modes="MSPI"
+                         name="UDORD"
+                         rw="RW"/>
+               <bitfield caption="Character Size"
+                         mask="0x07"
+                         modes="NORMAL"
+                         name="CHSIZE"
+                         rw="RW"
+                         values="USART_NORMAL_CHSIZE"/>
+               <bitfield caption="Stop Bit Mode"
+                         mask="0x08"
+                         modes="NORMAL"
+                         name="SBMODE"
+                         rw="RW"
+                         values="USART_NORMAL_SBMODE"/>
+               <bitfield caption="Parity Mode"
+                         mask="0x30"
+                         modes="NORMAL"
+                         name="PMODE"
+                         rw="RW"
+                         values="USART_NORMAL_PMODE"/>
+            </register>
+            <register caption="Baud Rate"
+                      initval="0x0000"
+                      name="BAUD"
+                      offset="0x8"
+                      rw="RW"
+                      size="2"/>
+            <register caption="Control D"
+                      initval="0x00"
+                      name="CTRLD"
+                      offset="0xA"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Auto Baud Window"
+                         mask="0xC0"
+                         name="ABW"
+                         rw="RW"
+                         values="USART_ABW"/>
+            </register>
+            <register caption="Debug Control"
+                      initval="0x00"
+                      name="DBGCTRL"
+                      offset="0xB"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Debug Run" mask="0x01" name="DBGRUN" rw="RW"/>
+            </register>
+            <register caption="Event Control"
+                      initval="0x00"
+                      name="EVCTRL"
+                      offset="0xC"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="IrDA Event Input Enable"
+                         mask="0x01"
+                         name="IREI"
+                         rw="RW"/>
+            </register>
+            <register caption="IRCOM Transmitter Pulse Length Control"
+                      initval="0x00"
+                      name="TXPLCTRL"
+                      offset="0xD"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Transmit pulse length" mask="0xFF" name="TXPL" rw="RW"/>
+            </register>
+            <register caption="IRCOM Receiver Pulse Length Control"
+                      initval="0x00"
+                      name="RXPLCTRL"
+                      offset="0xE"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Receiver Pulse Lenght" mask="0x7F" name="RXPL" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="RS485 Mode internal transmitter select" name="USART_RS485">
+            <value caption="RS485 Mode disabled" name="DISABLE" value="0x0"/>
+            <value caption="RS485 Mode enabled" name="ENABLE" value="0x1"/>
+         </value-group>
+         <value-group caption="Receiver Mode select" name="USART_RXMODE">
+            <value caption="Normal mode" name="NORMAL" value="0x0"/>
+            <value caption="CLK2x mode" name="CLK2X" value="0x1"/>
+            <value caption="Generic autobaud mode" name="GENAUTO" value="0x2"/>
+            <value caption="LIN constrained autobaud mode" name="LINAUTO" value="0x3"/>
+         </value-group>
+         <value-group caption="Communication Mode select" name="USART_CMODE">
+            <value caption="Asynchronous Mode" name="ASYNCHRONOUS" value="0x00"/>
+            <value caption="Synchronous Mode" name="SYNCHRONOUS" value="0x01"/>
+            <value caption="Infrared Communication" name="IRCOM" value="0x02"/>
+            <value caption="SPI Host Mode" name="MSPI" value="0x03"/>
+         </value-group>
+         <value-group caption="Character Size select" name="USART_NORMAL_CHSIZE">
+            <value caption="Character size: 5 bit" name="5BIT" value="0x00"/>
+            <value caption="Character size: 6 bit" name="6BIT" value="0x01"/>
+            <value caption="Character size: 7 bit" name="7BIT" value="0x02"/>
+            <value caption="Character size: 8 bit" name="8BIT" value="0x03"/>
+            <value caption="Character size: 9 bit read low byte first"
+                   name="9BITL"
+                   value="0x06"/>
+            <value caption="Character size: 9 bit read high byte first"
+                   name="9BITH"
+                   value="0x07"/>
+         </value-group>
+         <value-group caption="Parity Mode select" name="USART_NORMAL_PMODE">
+            <value caption="No Parity" name="DISABLED" value="0x00"/>
+            <value caption="Even Parity" name="EVEN" value="0x02"/>
+            <value caption="Odd Parity" name="ODD" value="0x03"/>
+         </value-group>
+         <value-group caption="Stop Bit Mode select" name="USART_NORMAL_SBMODE">
+            <value caption="1 stop bit" name="1BIT" value="0x0"/>
+            <value caption="2 stop bits" name="2BIT" value="0x1"/>
+         </value-group>
+         <value-group caption="Auto Baud Window select" name="USART_ABW">
+            <value caption="18% tolerance" name="WDW0" value="0x0"/>
+            <value caption="15% tolerance" name="WDW1" value="0x1"/>
+            <value caption="21% tolerance" name="WDW2" value="0x2"/>
+            <value caption="25% tolerance" name="WDW3" value="0x3"/>
+         </value-group>
+      </module>
+      <module caption="User Row" id="avrdb" name="USERROW">
+         <register-group caption="User Row" name="USERROW" size="0x20">
+            <register caption="User Row"
+                      count="0x20"
+                      name="USERROW"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+         </register-group>
+      </module>
+      <module caption="Virtual Ports" id="gpio_ports_avr_v2_vport" name="VPORT">
+         <register-group caption="Virtual Ports" name="VPORT" size="0x4">
+            <register caption="Data Direction"
+                      name="DIR"
+                      offset="0x0"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Output Value"
+                      name="OUT"
+                      offset="0x1"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Input Value"
+                      name="IN"
+                      offset="0x2"
+                      rw="RW"
+                      size="1"/>
+            <register caption="Interrupt Flags"
+                      initval="0x00"
+                      name="INTFLAGS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Pin Interrupt Flag" mask="0xFF" name="INT" rw="RW"/>
+            </register>
+         </register-group>
+      </module>
+      <module caption="Voltage reference" id="avrdb" name="VREF">
+         <register-group caption="Voltage reference" name="VREF" size="0x2">
+            <register caption="ADC0 Reference"
+                      initval="0x00"
+                      name="ADC0REF"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference select"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="VREF_REFSEL"/>
+               <bitfield caption="Always on" mask="0x80" name="ALWAYSON" rw="RW"/>
+            </register>
+            <register caption="DAC0 Reference"
+                      initval="0x00"
+                      name="DAC0REF"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference select"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="VREF_REFSEL"/>
+               <bitfield caption="Always on" mask="0x80" name="ALWAYSON" rw="RW"/>
+            </register>
+            <register caption="AC Reference"
+                      initval="0x00"
+                      name="ACREF"
+                      offset="0x4"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Reference select"
+                         mask="0x07"
+                         name="REFSEL"
+                         rw="RW"
+                         values="VREF_REFSEL"/>
+               <bitfield caption="Always on" mask="0x80" name="ALWAYSON" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Reference select" name="VREF_REFSEL">
+            <value caption="Internal 1.024V reference" name="1V024" value="0x00"/>
+            <value caption="Internal 2.048V reference" name="2V048" value="0x01"/>
+            <value caption="Internal 4.096V reference" name="4V096" value="0x02"/>
+            <value caption="Internal 2.500V reference" name="2V500" value="0x03"/>
+            <value caption="VDD as reference" name="VDD" value="0x05"/>
+            <value caption="External reference on VREFA pin" name="VREFA" value="0x06"/>
+         </value-group>
+      </module>
+      <module caption="Watch-Dog Timer" id="wdt_windowed_v2" name="WDT">
+         <register-group caption="Watch-Dog Timer" name="WDT" size="0x10">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Period"
+                         mask="0x0F"
+                         name="PERIOD"
+                         rw="RW"
+                         values="WDT_PERIOD"/>
+               <bitfield caption="Window"
+                         mask="0xF0"
+                         name="WINDOW"
+                         rw="RW"
+                         values="WDT_WINDOW"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x1"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Syncronization busy"
+                         mask="0x01"
+                         name="SYNCBUSY"
+                         rw="R"/>
+               <bitfield caption="Lock enable" mask="0x80" name="LOCK" rw="RW"/>
+            </register>
+         </register-group>
+         <value-group caption="Period select" name="WDT_PERIOD">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.1s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.2s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+         <value-group caption="Window select" name="WDT_WINDOW">
+            <value caption="Off" name="OFF" value="0x00"/>
+            <value caption="8 cycles (8ms)" name="8CLK" value="0x01"/>
+            <value caption="16 cycles (16ms)" name="16CLK" value="0x02"/>
+            <value caption="32 cycles (32ms)" name="32CLK" value="0x03"/>
+            <value caption="64 cycles (64ms)" name="64CLK" value="0x04"/>
+            <value caption="128 cycles (0.128s)" name="128CLK" value="0x05"/>
+            <value caption="256 cycles (0.256s)" name="256CLK" value="0x06"/>
+            <value caption="512 cycles (0.512s)" name="512CLK" value="0x07"/>
+            <value caption="1K cycles (1.0s)" name="1KCLK" value="0x08"/>
+            <value caption="2K cycles (2.0s)" name="2KCLK" value="0x09"/>
+            <value caption="4K cycles (4.1s)" name="4KCLK" value="0x0A"/>
+            <value caption="8K cycles (8.2s)" name="8KCLK" value="0x0B"/>
+         </value-group>
+      </module>
+      <module caption="Zero Cross Detect" id="cmp_zxover_ctrl_v3" name="ZCD">
+         <register-group caption="Zero Cross Detect" name="ZCD" size="0x8">
+            <register caption="Control A"
+                      initval="0x00"
+                      name="CTRLA"
+                      offset="0x0"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Enable" mask="0x01" name="ENABLE" rw="RW"/>
+               <bitfield caption="Invert signal from pin"
+                         mask="0x08"
+                         name="INVERT"
+                         rw="RW"/>
+               <bitfield caption="Output Pad Enable" mask="0x40" name="OUTEN" rw="RW"/>
+               <bitfield caption="Run in Standby Mode"
+                         mask="0x80"
+                         name="RUNSTDBY"
+                         rw="RW"/>
+            </register>
+            <register caption="Interrupt Control"
+                      initval="0x00"
+                      name="INTCTRL"
+                      offset="0x2"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="Interrupt Mode"
+                         mask="0x03"
+                         name="INTMODE"
+                         rw="RW"
+                         values="ZCD_INTMODE"/>
+            </register>
+            <register caption="Status"
+                      initval="0x00"
+                      name="STATUS"
+                      offset="0x3"
+                      rw="RW"
+                      size="1">
+               <bitfield caption="ZCD Interrupt Flag" mask="0x01" name="CROSSIF" rw="RW"/>
+               <bitfield caption="ZCD State"
+                         mask="0x10"
+                         name="STATE"
+                         rw="R"
+                         values="ZCD_STATE"/>
+            </register>
+         </register-group>
+         <value-group caption="Interrupt Mode select" name="ZCD_INTMODE">
+            <value caption="No interrupt" name="NONE" value="0x0"/>
+            <value caption="Interrupt on rising input signal"
+                   name="RISING"
+                   value="0x1"/>
+            <value caption="Interrupt on falling input signal"
+                   name="FALLING"
+                   value="0x2"/>
+            <value caption="Interrupt on both rising and falling input signal"
+                   name="BOTH"
+                   value="0x3"/>
+         </value-group>
+         <value-group caption="ZCD State select" name="ZCD_STATE">
+            <value caption="Output is 0" name="LOW" value="0x0"/>
+            <value caption="Output is 1" name="HIGH" value="0x1"/>
+         </value-group>
+      </module>
+   </modules>
+   <pinouts>
+      <pinout name="QFP32">
+         <pin pad="PA3" position="1"/>
+         <pin pad="PA4" position="2"/>
+         <pin pad="PA5" position="3"/>
+         <pin pad="PA6" position="4"/>
+         <pin pad="PA7" position="5"/>
+         <pin pad="PC0" position="6"/>
+         <pin pad="PC1" position="7"/>
+         <pin pad="PC2" position="8"/>
+         <pin pad="PC3" position="9"/>
+         <pin pad="VDDIO2" position="10"/>
+         <pin pad="PD1" position="11"/>
+         <pin pad="PD2" position="12"/>
+         <pin pad="PD3" position="13"/>
+         <pin pad="PD4" position="14"/>
+         <pin pad="PD5" position="15"/>
+         <pin pad="PD6" position="16"/>
+         <pin pad="PD7" position="17"/>
+         <pin pad="AVDD" position="18"/>
+         <pin pad="AGND" position="19"/>
+         <pin pad="PF0" position="20"/>
+         <pin pad="PF1" position="21"/>
+         <pin pad="PF2" position="22"/>
+         <pin pad="PF3" position="23"/>
+         <pin pad="PF4" position="24"/>
+         <pin pad="PF5" position="25"/>
+         <pin pad="PF6" position="26"/>
+         <pin pad="UPDI" position="27"/>
+         <pin pad="VDD0" position="28"/>
+         <pin pad="GND0" position="29"/>
+         <pin pad="PA0" position="30"/>
+         <pin pad="PA1" position="31"/>
+         <pin pad="PA2" position="32"/>
+      </pinout>
+   </pinouts>
+</avr-tools-device-file>


### PR DESCRIPTION
## summary
- add the `avr128db32` device feature
- include the AVR128DB32 ATDF vendor file
- expose the generated `avr128db32` PAC module
- add AVR128DB32 to the crate docs and public reexports

## why
- enables PAC generation for AVR128DB32 targets
- supports boards using the 32-pin AVR128DB variant