### PR TITLE
Unpin dev-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,11 +121,11 @@ version = "=0.8.1"
 optional = true
 
 [build-dependencies]
-svd2rust = { version = "=0.37.1", default-features = false }
-svdtools = { version = "=0.5.0", default-features = false }
-atdf2svd = { version = "=0.5.1", default-features = false }
-prettyplease = "=0.2.37"
-svd-rs = { version = "=0.14.12", default-features = false }
-yaml-rust2 = { version = "=0.10.4", default-features = false }
-syn = { version = "=2.0.110", default-features = false, features = ["full", "parsing"] }
+svd2rust = { version = "0.37.1", default-features = false }
+svdtools = { version = "0.5.0", default-features = false }
+atdf2svd = { version = "0.5.1", default-features = false }
+prettyplease = "0.2.37"
+svd-rs = { version = "0.14.12", default-features = false }
+yaml-rust2 = { version = "0.10.4", default-features = false }
+syn = { version = "2.0.110", default-features = false, features = ["full", "parsing"] }
 anyhow = "1.0"


### PR DESCRIPTION
Do not pin exact versions of dependencies. This creates version conflicts 
because it applies to the whole dependency tree, even if it's just build-deps. For example latest cortex-m 
requires a `syn` version higher than the pinned one, so Cargo bails out:

```
error: failed to select a version for `syn`.
    ... required by package `cortex-m-macros v0.7.8`
    ... which satisfies dependency `cortex-m-macros = "=0.7.8"` of package `cortex-m v0.7.8`
    ... which satisfies dependency `cortex-m = "^0.7.8"` of package `embassy-executor v0.10.0 (/home/dirbaio/embassy/embassy/embassy-executor)`
versions that meet the requirements `^2.0.117` are: 2.0.119, 2.0.118, 2.0.117

all possible versions conflict with previously selected packages

  previously selected package `syn v2.0.110`
    ... which satisfies dependency `syn = "=2.0.110"` of package `avr-device v0.8.1`
    ... which satisfies dependency `avr-device = "^0.8.1"` of package `embassy-executor v0.10.0 (/home/dirbaio/embassy/embassy/embassy-executor)`

failed to select a version for `syn` which could resolve this conflict
```

This means you can't make a crate that depends on both latest `avr-device` and `cortex-m`, which `embassy-executor` does.

