### PR TITLE
Unpin syn and yaml-rust2 versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "svd-rs",
  "svd2rust",
  "svdtools",
- "syn 2.0.110",
+ "syn 2.0.119",
  "ufmt",
  "vcell",
  "yaml-rust2",
@@ -116,7 +116,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -595,7 +595,7 @@ dependencies = [
  "regex",
  "svd-parser",
  "svd-rs",
- "syn 2.0.110",
+ "syn 2.0.119",
  "thiserror 2.0.17",
  "url",
 ]
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -655,7 +655,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -695,7 +695,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -847,7 +847,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -868,7 +868,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -902,5 +902,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,5 +127,5 @@ atdf2svd = { version = "=0.5.1", default-features = false }
 prettyplease = "=0.2.37"
 svd-rs = { version = "=0.14.12", default-features = false }
 yaml-rust2 = { version = "=0.10.4", default-features = false }
-syn = { version = "=2.0.110", default-features = false, features = ["full", "parsing"] }
+syn = { version = "2.0.119", default-features = false, features = ["full", "parsing"] }
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,6 @@ svdtools = { version = "=0.5.0", default-features = false }
 atdf2svd = { version = "=0.5.1", default-features = false }
 prettyplease = "=0.2.37"
 svd-rs = { version = "=0.14.12", default-features = false }
-yaml-rust2 = { version = "=0.10.4", default-features = false }
+yaml-rust2 = { version = "0.10.4", default-features = false }
 syn = { version = "2.0.119", default-features = false, features = ["full", "parsing"] }
 anyhow = "1.0"


### PR DESCRIPTION
Unpin the dependency version specification for `syn` and `yaml-rust2` so we don't run into cargo dependency resolver errors due to conflicts with other crates in the user's dependency tree.

See [pr #266][1] for more info.

[1]: https://github.com/Rahix/avr-device/pull/266